### PR TITLE
ci:重构为nuitka打包

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -99,7 +99,7 @@ jobs:
       is_release: ${{ steps.set_tag.outputs.is_release }}
       is_prerelease: ${{ steps.set_tag.outputs.is_prerelease }}
 
-  pyinstaller:
+  nuitka:
     needs: meta
     name: Build (${{ matrix.platform }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
@@ -173,7 +173,7 @@ jobs:
           python -m pip install setuptools wheel maturin  # maturin 用于 Rust-Python 混合编译
 
           # 安装其他依赖
-          python -m pip install pyinstaller
+          python -m pip install pyinstaller nuitka ordered-set zstandard
           python -m pip install -r ./requirements.txt
         shell: pwsh
 
@@ -182,16 +182,16 @@ jobs:
         run: |
           uname -m
           if [[ ${{ matrix.arch }} == "x86_64" ]]; then
-            arch -x86_64 python -m pip install --force-reinstall --no-cache-dir pyinstaller -r requirements.txt
+            arch -x86_64 python -m pip install --force-reinstall --no-cache-dir pyinstaller nuitka ordered-set zstandard -r requirements.txt
           elif [[ ${{ matrix.arch }} == "aarch64" ]]; then
-            arch -arm64 python -m pip install --force-reinstall --no-cache-dir pyinstaller -r requirements.txt
+            arch -arm64 python -m pip install --force-reinstall --no-cache-dir pyinstaller nuitka ordered-set zstandard -r requirements.txt
           fi
 
       - name: Install dependencies (other)
         if: matrix.platform != 'macos' && !(matrix.platform == 'win' && matrix.arch == 'aarch64')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyinstaller
+          python -m pip install pyinstaller nuitka ordered-set zstandard
           python -m pip install -r ./requirements.txt
 
       - name: Download i18n
@@ -200,16 +200,16 @@ jobs:
           name: i18n
           path: app/i18n
 
-      - name: Install(macos)
+      - name: Build (macos)
         if: matrix.platform == 'macos'
         run: |
-          sudo python ./tools/build.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
+          sudo python ./tools/build_nuitka.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
 
 
-      - name: Install(other)
+      - name: Build (other)
         if: matrix.platform != 'macos'
         run: |
-          python ./tools/build.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
+          python ./tools/build_nuitka.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
         shell: pwsh  
 
       - name: Upload artifact
@@ -221,7 +221,7 @@ jobs:
 
   release:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
-    needs: [meta, pyinstaller,changelog]
+    needs: [meta, nuitka, changelog]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -229,16 +229,25 @@ jobs:
           path: assets
 
       - run: |
+          set -e
           cd assets
+          tag="${{ needs.meta.outputs.tag }}"
           for f in *; do
-            if [ "$f" != "i18n" ]; then
-              (cd $f && zip -r ../$f-${{ needs.meta.outputs.tag }}.zip .)
+            if [ "$f" = "i18n" ]; then
+              continue
+            fi
+            if [[ "$f" == MFW-PyQt6-linux-* ]] || [[ "$f" == MFW-PyQt6-macos-* ]]; then
+              (cd "$f" && tar -czvf "../${f}-${tag}.tar.gz" .)
+            else
+              (cd "$f" && zip -r "../${f}-${tag}.zip" .)
             fi
           done
 
       - uses: softprops/action-gh-release@v2.2.2
         with:
-          files: assets/*.zip
+          files: |
+            assets/*.zip
+            assets/*.tar.gz
           tag_name: ${{ needs.meta.outputs.tag }}
           body: ${{ needs.changelog.outputs.release_body }}
           draft: false

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -172,8 +172,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel maturin  # maturin 用于 Rust-Python 混合编译
 
-          # 安装其他依赖
-          python -m pip install pyinstaller nuitka ordered-set zstandard
+          # 安装其他依赖（全 Nuitka，含 macOS）
+          python -m pip install nuitka ordered-set zstandard
           python -m pip install -r ./requirements.txt
         shell: pwsh
 
@@ -182,16 +182,16 @@ jobs:
         run: |
           uname -m
           if [[ ${{ matrix.arch }} == "x86_64" ]]; then
-            arch -x86_64 python -m pip install --force-reinstall --no-cache-dir pyinstaller nuitka ordered-set zstandard -r requirements.txt
+            arch -x86_64 python -m pip install --force-reinstall --no-cache-dir nuitka ordered-set zstandard -r requirements.txt
           elif [[ ${{ matrix.arch }} == "aarch64" ]]; then
-            arch -arm64 python -m pip install --force-reinstall --no-cache-dir pyinstaller nuitka ordered-set zstandard -r requirements.txt
+            arch -arm64 python -m pip install --force-reinstall --no-cache-dir nuitka ordered-set zstandard -r requirements.txt
           fi
 
       - name: Install dependencies (other)
         if: matrix.platform != 'macos' && !(matrix.platform == 'win' && matrix.arch == 'aarch64')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyinstaller nuitka ordered-set zstandard
+          python -m pip install nuitka ordered-set zstandard
           python -m pip install -r ./requirements.txt
 
       - name: Download i18n
@@ -200,17 +200,8 @@ jobs:
           name: i18n
           path: app/i18n
 
-      - name: Build (macos)
-        if: matrix.platform == 'macos'
-        run: |
-          sudo python ./tools/build_nuitka.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
-
-
-      - name: Build (other)
-        if: matrix.platform != 'macos'
-        run: |
-          python ./tools/build_nuitka.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
-        shell: pwsh  
+      - name: Build (Nuitka)
+        run: python ./tools/build_nuitka.py ${{ matrix.platform }} ${{ matrix.arch }} ${{ needs.meta.outputs.tag }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/mirrorchyan.yml
+++ b/.github/workflows/mirrorchyan.yml
@@ -27,7 +27,7 @@ jobs:
         if: always()
         with:
           filetype: latest-release
-          fileName: "MFW*-macos-aarch64-*.zip"
+          fileName: "MFW*-macos-aarch64-*.tar.gz"
           mirrorchyan_rid: MFW-PyQt6
 
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
         if: always()
         with:
           filetype: latest-release
-          fileName: "MFW*-macos-x86_64-*.zip"
+          fileName: "MFW*-macos-x86_64-*.tar.gz"
           mirrorchyan_rid: MFW-PyQt6
 
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
         if: always()
         with:
           filetype: latest-release
-          fileName: "MFW*-linux-aarch64-*.zip"
+          fileName: "MFW*-linux-aarch64-*.tar.gz"
           mirrorchyan_rid: MFW-PyQt6
 
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
         if: always()
         with:
           filetype: latest-release
-          fileName: "MFW*-linux-x86_64-*.zip"
+          fileName: "MFW*-linux-x86_64-*.tar.gz"
           mirrorchyan_rid: MFW-PyQt6
 
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/app/utils/runtime_maafw.py
+++ b/app/utils/runtime_maafw.py
@@ -1,0 +1,85 @@
+"""
+外置 MaaFramework 运行库（maafw）路径配置。
+
+与 MXU 一致：在可执行文件同目录下使用子目录 maafw，存放官方发布包中的 bin 内容。
+maa 包在 import 时会读取环境变量 MAAFW_BINARY_PATH（见 site-packages/maa/__init__.py）。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def is_bundled_executable() -> bool:
+    """是否为 PyInstaller / Nuitka 等打包后的可执行文件环境。"""
+    v = getattr(sys, "frozen", False)
+    if isinstance(v, str):
+        return v.lower() in ("yes", "true", "1")
+    return bool(v)
+
+
+def maafw_directory(app_root: Path) -> Path:
+    return app_root / "maafw"
+
+
+def _framework_filenames() -> tuple[str, ...]:
+    if sys.platform == "win32":
+        return ("MaaFramework.dll",)
+    if sys.platform == "darwin":
+        return ("libMaaFramework.dylib",)
+    return ("libMaaFramework.so",)
+
+
+def _maafw_has_framework_libs(directory: Path) -> bool:
+    if not directory.is_dir():
+        return False
+    return any((directory / name).is_file() for name in _framework_filenames())
+
+
+def apply_maafw_runtime_layout(
+    app_root: Path, *, require_external_when_bundled: bool | None = None
+) -> Path | None:
+    """
+    在首次 import maa 之前调用。
+
+    - 打包环境：要求 app_root/maafw 存在且含 MaaFramework 主库，并设置 MAAFW_BINARY_PATH；
+      Windows 下同时将 maafw 注册为 DLL 搜索目录。
+    - 开发环境：若存在 app_root/maafw 且含主库，则优先使用；否则不设置环境变量，
+      由 maa 回退到 site-packages/maa/bin。
+
+    返回实际使用的 maafw 绝对路径；若使用内置 pip bin 则返回 None。
+    """
+    root = app_root.resolve()
+    ext = maafw_directory(root)
+    if require_external_when_bundled is None:
+        require_external_when_bundled = is_bundled_executable()
+
+    has_libs = _maafw_has_framework_libs(ext)
+
+    if require_external_when_bundled:
+        if not has_libs:
+            names = ", ".join(_framework_filenames())
+            print(
+                "未找到外置 MaaFramework 运行库（maafw）。\n"
+                f"请将官方运行库压缩包中的 bin 目录内文件解压到：\n  {ext}\n"
+                f"并确保其中包含：{names}\n"
+                "说明与 MXU 相同：主程序旁放置 maafw 文件夹承载原生库。\n",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        resolved = ext.resolve()
+        os.environ["MAAFW_BINARY_PATH"] = str(resolved)
+        if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(str(resolved))
+        return resolved
+
+    if has_libs:
+        resolved = ext.resolve()
+        os.environ["MAAFW_BINARY_PATH"] = str(resolved)
+        if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(str(resolved))
+        return resolved
+
+    return None

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,11 +108,12 @@ python -m pip install -r requirements.txt
 
 ```powershell
 python tools/build.py win x86_64 v1.2.3
+# 或：python tools/build_nuitka.py win x86_64 v1.2.3
 ```
 
-参数依次为：平台、架构、版本号。详细说明见 `tools/README.md`。
+参数依次为：平台、架构、版本号。发行目录内需自备 **`maafw/`**（官方 MaaFramework `bin` 内容，与 MXU 相同）。详细说明见 `tools/README.md`。
 
-自动构建可参考 `deploy/install.yml` 与 `.github/workflows`。
+自动构建可参考 `deploy/install.yml` 与 `.github/workflows/install.yml`（主构建为 Nuitka）。
 
 ## 7. 开发约定
 

--- a/main.py
+++ b/main.py
@@ -27,14 +27,20 @@ import sys
 import argparse
 import atexit
 import traceback
+from pathlib import Path
+
+from app.utils.runtime_maafw import apply_maafw_runtime_layout
 
 
-# 设置工作目录为运行方式位置
+# 设置工作目录为运行方式位置；外置 maafw 必须在 import maa 之前完成
 if getattr(sys, "frozen", False):
-    os.chdir(os.path.dirname(sys.executable))
-    os.environ["MAAFW_BINARY_PATH"] = os.getcwd()
+    _app_root = Path(sys.executable).resolve().parent
+    os.chdir(_app_root)
 else:
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    _app_root = Path(__file__).resolve().parent
+    os.chdir(_app_root)
+
+apply_maafw_runtime_layout(_app_root)
 
 
 def _show_fatal_startup_error(exc_type, exc_value, exc_traceback) -> None:
@@ -89,7 +95,6 @@ def _run() -> int:
     logger.info(f"当前工作目录: {os.getcwd()}")
 
     import faulthandler
-    from pathlib import Path
 
     log_dir = Path("debug")
     log_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary by Sourcery

Refactor the build and release pipeline to use Nuitka-based packaging and introduce external MaaFramework runtime layout handling.

Enhancements:
- Introduce a runtime helper to configure external MaaFramework binaries and integrate it into application startup to support bundled executables.

Build:
- Switch the GitHub Actions build job from PyInstaller to a Nuitka-based workflow and update dependency installation accordingly.
- Adjust release asset packaging to emit .tar.gz archives for Linux and macOS builds and include them in GitHub releases.
- Update mirrorchyan workflow patterns to consume .tar.gz artifacts for Linux and macOS targets.

Documentation:
- Document the Nuitka-based build option, external maafw directory requirement, and updated CI workflow references.