### PR TITLE
feat: 实现多实例模式支持，增强配置管理与日志隔离

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -488,7 +488,7 @@ MPA_custom/*
 MPAcustom_custom/*
 tasks/*
 .llm.txt
-
+agent
 # Codex local environments
 .codex/environments/
 

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -26,6 +26,7 @@ MFW-ChainFlow Assistant 配置
 import sys
 from pathlib import Path
 from enum import Enum
+import json
 
 from PySide6.QtCore import QLocale
 from qfluentwidgets import (
@@ -195,7 +196,7 @@ class Config(QConfig):
     )  # GPU 硬件加速开关（关闭时强制 CPU 推理）
     task_interface_panel_layout = ConfigItem("Task", "task_interface_panel_layout", "")
     multi_instance_mode = ConfigItem(
-        "Task", "multi_instance_mode", False, BoolValidator()
+        "Compatibility", "multi_instance_mode", False, BoolValidator()
     )  # 多实例模式：开启后允许多个配置同时运行，并在运行时切换配置
 
     # ===== 日志设置 =====
@@ -342,7 +343,46 @@ class Config(QConfig):
 
 cfg = Config()
 cfg.themeMode.value = Theme.AUTO
-qconfig.load("config/config.json", cfg)
+
+
+def _migrate_multi_instance_mode_config(config_path: Path) -> None:
+    """将 multi_instance_mode 从 Task 分组迁移到 Compatibility（一次性）。"""
+    if not config_path.is_file():
+        return
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    task_section = data.get("Task")
+    if not isinstance(task_section, dict):
+        return
+    if "multi_instance_mode" not in task_section:
+        return
+    compat_section = data.get("Compatibility")
+    if not isinstance(compat_section, dict):
+        compat_section = {}
+    if "multi_instance_mode" not in compat_section:
+        compat_section["multi_instance_mode"] = task_section.pop(
+            "multi_instance_mode"
+        )
+        data["Compatibility"] = compat_section
+        data["Task"] = task_section
+        config_path.write_text(
+            json.dumps(data, indent=4, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    elif "multi_instance_mode" in task_section:
+        task_section.pop("multi_instance_mode", None)
+        data["Task"] = task_section
+        config_path.write_text(
+            json.dumps(data, indent=4, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+_config_path = Path("config/config.json")
+_migrate_multi_instance_mode_config(_config_path)
+qconfig.load(str(_config_path), cfg)
 
 
 def detect_system_language() -> Language:

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -194,6 +194,9 @@ class Config(QConfig):
         "Task", "enable_gpu_acceleration", True, BoolValidator()
     )  # GPU 硬件加速开关（关闭时强制 CPU 推理）
     task_interface_panel_layout = ConfigItem("Task", "task_interface_panel_layout", "")
+    multi_instance_mode = ConfigItem(
+        "Task", "multi_instance_mode", False, BoolValidator()
+    )  # 多实例模式：开启后允许多个配置同时运行，并在运行时切换配置
 
     # ===== 日志设置 =====
     log_zip_include_images = ConfigItem(

--- a/app/common/signal_bus.py
+++ b/app/common/signal_bus.py
@@ -103,5 +103,20 @@ class SignalBus(QObject):
     # 任务识别命中 ROI（供监控预览叠加）
     monitor_recognition_roi = Signal(dict)
 
+    # ==================== 多实例模式 ====================
+    # 多实例模式开关变化（cfg.multi_instance_mode）
+    multi_instance_mode_changed = Signal(bool)
+
+    # 携带 config_id 的运行时事件（多实例隔离用）。
+    # 旧的无 config_id 信号仍保留，代表“当前激活配置”，以兼容现有视图。
+    log_output_at = Signal(str, str, str)  # (config_id, level, text)
+    log_clear_requested_at = Signal(str)  # (config_id)
+    task_status_changed_at = Signal(str, str, str)  # (config_id, task_id, status)
+    task_flow_finished_at = Signal(str, dict)  # (config_id, payload)
+    monitor_recognition_roi_at = Signal(str, dict)  # (config_id, payload)
+
+    # 某个配置的运行状态变化（供配置列表显示独立运行指示）
+    config_run_state_changed = Signal(str, bool)  # (config_id, running)
+
 
 signalBus = SignalBus()

--- a/app/core/core.py
+++ b/app/core/core.py
@@ -897,6 +897,12 @@ class ServiceCoordinator:
         self.task_service.on_config_changed(config_id)
         self.option_service.clear_selection()
 
+        # 同步到全局 signalBus，供监控页、日志面板等订阅方感知当前配置切换
+        try:
+            signalBus.config_changed.emit(config_id)
+        except Exception as exc:
+            logger.debug("转发 config_changed 到 signalBus 失败: %s", exc)
+
         # 多实例模式下：切换当前配置后，同步主开始按钮以反映新当前配置的运行态
         try:
             if cfg.get(cfg.multi_instance_mode):

--- a/app/core/core.py
+++ b/app/core/core.py
@@ -21,12 +21,23 @@ from app.core.service.option_service import OptionService
 from app.core.service.interface_manager import get_interface_manager, InterfaceManager
 from app.core.runner.task_flow import TaskFlowRunner
 from app.core.log_processor import CallbackLogProcessor
+from app.core.runtime_manager import RuntimeInstanceManager, RuntimeInstance, _TaggedRunnerBridge
 from app.utils.logger import logger
+from app.common.config import cfg
 from app.common.signal_bus import signalBus
 
 
 class _RunnerUiSignalBridge(QObject):
-    """将 Runner 信号安全转发到全局 signalBus。"""
+    """将 Runner 信号安全转发到全局 signalBus。
+
+    同时发射「无 config_id」（兼容旧视图，代表当前激活配置）与「带 config_id」
+    （多实例隔离用）两套信号。``config_id`` 在任务流开始时由协调器设置为本次运行的配置。
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # 本桥关联的配置 ID（单实例主运行器在每次启动时更新为当前配置）
+        self.config_id: str = ""
 
     @Slot(dict)
     def forward_callback(self, payload: dict):
@@ -35,6 +46,7 @@ class _RunnerUiSignalBridge(QObject):
     @Slot(str, str)
     def forward_log_output(self, level: str, text: str):
         signalBus.log_output.emit(level, text)
+        signalBus.log_output_at.emit(self.config_id, level, text)
 
     @Slot(str)
     def forward_set_window_title(self, title: str):
@@ -43,14 +55,17 @@ class _RunnerUiSignalBridge(QObject):
     @Slot(str, str)
     def forward_task_status_changed(self, task_id: str, status: str):
         signalBus.task_status_changed.emit(task_id, status)
+        signalBus.task_status_changed_at.emit(self.config_id, task_id, status)
 
     @Slot(dict)
     def forward_task_flow_finished(self, payload: dict):
         signalBus.task_flow_finished.emit(payload)
+        signalBus.task_flow_finished_at.emit(self.config_id, payload)
 
     @Slot()
     def forward_log_clear_requested(self):
         signalBus.log_clear_requested.emit()
+        signalBus.log_clear_requested_at.emit(self.config_id)
 
     @Slot(str, str)
     def forward_info_bar_requested(self, level: str, message: str):
@@ -79,6 +94,7 @@ class _RunnerUiSignalBridge(QObject):
     @Slot(dict)
     def forward_monitor_recognition_roi(self, payload: dict):
         signalBus.monitor_recognition_roi.emit(payload)
+        signalBus.monitor_recognition_roi_at.emit(self.config_id, payload)
 
 
 class ServiceCoordinator:
@@ -163,6 +179,9 @@ class ServiceCoordinator:
         # 初始化日志处理器（将 callback 信号转换为 log_output 信号）
         self.log_processor = CallbackLogProcessor(self.runner_events)
         self._runner_ui_bridge = _RunnerUiSignalBridge()
+
+        # 多实例运行时管理器：仅在多实例模式开启时用于创建独立运行体
+        self.runtime_manager = RuntimeInstanceManager(self)
 
         # 连接信号
         self._connect_signals()
@@ -843,56 +862,28 @@ class ServiceCoordinator:
         # 热更新完成后重新初始化
         signalBus.fs_reinit_requested.connect(self.reinit)
         # 使用 QObject 槽转发，确保来自 runner/底层回调线程的信号稳定回到 UI 线程。
-        self.runner_events.callback.connect(
-            self._runner_ui_bridge.forward_callback, Qt.ConnectionType.QueuedConnection
+        self._wire_runner_events(self.runner_events, self._runner_ui_bridge)
+
+    @staticmethod
+    def _wire_runner_events(runner_events, bridge) -> None:
+        """将一个 RunnerEvents 的全部事件以队列连接方式接到对应的桥接对象。"""
+        conn = Qt.ConnectionType.QueuedConnection
+        runner_events.callback.connect(bridge.forward_callback, conn)
+        runner_events.log_output.connect(bridge.forward_log_output, conn)
+        runner_events.set_window_title.connect(bridge.forward_set_window_title, conn)
+        runner_events.task_status_changed.connect(bridge.forward_task_status_changed, conn)
+        runner_events.task_flow_finished.connect(bridge.forward_task_flow_finished, conn)
+        runner_events.log_clear_requested.connect(bridge.forward_log_clear_requested, conn)
+        runner_events.info_bar_requested.connect(bridge.forward_info_bar_requested, conn)
+        runner_events.focus_toast.connect(bridge.forward_focus_toast, conn)
+        runner_events.focus_notification.connect(bridge.forward_focus_notification, conn)
+        runner_events.focus_dialog.connect(bridge.forward_focus_dialog, conn)
+        runner_events.focus_modal.connect(bridge.forward_focus_modal, conn)
+        runner_events.controller_setup_hint_requested.connect(
+            bridge.forward_controller_setup_hint_requested, conn
         )
-        self.runner_events.log_output.connect(
-            self._runner_ui_bridge.forward_log_output,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.set_window_title.connect(
-            self._runner_ui_bridge.forward_set_window_title,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.task_status_changed.connect(
-            self._runner_ui_bridge.forward_task_status_changed,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.task_flow_finished.connect(
-            self._runner_ui_bridge.forward_task_flow_finished,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.log_clear_requested.connect(
-            self._runner_ui_bridge.forward_log_clear_requested,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.info_bar_requested.connect(
-            self._runner_ui_bridge.forward_info_bar_requested,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.focus_toast.connect(
-            self._runner_ui_bridge.forward_focus_toast,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.focus_notification.connect(
-            self._runner_ui_bridge.forward_focus_notification,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.focus_dialog.connect(
-            self._runner_ui_bridge.forward_focus_dialog,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.focus_modal.connect(
-            self._runner_ui_bridge.forward_focus_modal,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.controller_setup_hint_requested.connect(
-            self._runner_ui_bridge.forward_controller_setup_hint_requested,
-            Qt.ConnectionType.QueuedConnection,
-        )
-        self.runner_events.monitor_recognition_roi.connect(
-            self._runner_ui_bridge.forward_monitor_recognition_roi,
-            Qt.ConnectionType.QueuedConnection,
+        runner_events.monitor_recognition_roi.connect(
+            bridge.forward_monitor_recognition_roi, conn
         )
 
     def _on_config_changed(self, config_id: str):
@@ -905,6 +896,19 @@ class ServiceCoordinator:
 
         self.task_service.on_config_changed(config_id)
         self.option_service.clear_selection()
+
+        # 多实例模式下：切换当前配置后，同步主开始按钮以反映新当前配置的运行态
+        try:
+            if cfg.get(cfg.multi_instance_mode):
+                running = self.runtime_manager.is_running(config_id)
+                payload = (
+                    {"text": "STOP", "status": "enabled"}
+                    if running
+                    else {"text": "START", "status": "enabled"}
+                )
+                self.fs_signal_bus.fs_start_button_status.emit(payload)
+        except Exception as exc:
+            logger.debug(f"切换配置后同步开始按钮失败: {exc}")
 
     # region 配置相关方法
     def update_bundle_path(
@@ -1168,6 +1172,16 @@ class ServiceCoordinator:
 
     def delete_config(self, config_id: str) -> bool:
         """删除配置，传入 config id"""
+        # 运行中的配置不允许删除（多实例与单实例通用）
+        if self.is_config_running(config_id):
+            logger.info("配置 %s 正在运行，拒绝删除", config_id)
+            try:
+                signalBus.info_bar_requested.emit(
+                    "warning", "Cannot delete a configuration while it is running"
+                )
+            except Exception:
+                pass
+            return False
         ok = self.config_service.delete_config(config_id)
         if ok:
             # notify UI incremental removal
@@ -1175,14 +1189,83 @@ class ServiceCoordinator:
         return ok
 
     def select_config(self, config_id: str) -> bool:
-        """选择配置，传入 config id"""
+        """选择配置，传入 config id。
+
+        多实例模式关闭时：若有任务正在运行，则禁止在运行时切换当前配置。
+        多实例模式开启时：始终允许切换（各配置独立运行，互不影响）。
+        """
         # 验证配置存在
         if not self.config_service.get_config(config_id):
+            return False
+
+        if config_id == self.config_service.current_config_id:
+            return True
+
+        if not self.is_switch_config_allowed():
+            logger.info("多实例模式关闭且有任务运行中，已拒绝切换配置: %s", config_id)
+            self.fs_signal_bus.fs_start_button_status.emit(
+                {"text": "STOP", "status": "enabled"}
+            )
+            try:
+                signalBus.info_bar_requested.emit(
+                    "warning",
+                    "Cannot switch configuration while a task is running",
+                )
+            except Exception:
+                pass
             return False
 
         # 使用 ConfigService setter，回调将同步任务和选项
         self.config_service.current_config_id = config_id
         return self.config_service.current_config_id == config_id
+
+    # region 多实例运行状态查询
+    def is_multi_instance_enabled(self) -> bool:
+        """读取多实例模式开关。"""
+        try:
+            return bool(cfg.get(cfg.multi_instance_mode))
+        except Exception:
+            return False
+
+    def is_switch_config_allowed(self) -> bool:
+        """是否允许在当前状态下切换激活配置。
+
+        多实例开启时始终允许；关闭时仅在没有任何任务运行时允许。
+        """
+        if self.is_multi_instance_enabled():
+            return True
+        return not self.any_config_running()
+
+    def is_config_running(self, config_id: str) -> bool:
+        """指定配置是否正在运行。"""
+        if not config_id:
+            return False
+        if self.is_multi_instance_enabled():
+            return self.runtime_manager.is_running(config_id)
+        # 单实例模式：主运行器运行的即当前配置
+        if config_id == self.config_service.current_config_id:
+            return bool(self.task_runner.is_running)
+        return False
+
+    def is_current_config_running(self) -> bool:
+        """当前激活配置是否正在运行。"""
+        return self.is_config_running(self.config_service.current_config_id)
+
+    def any_config_running(self) -> bool:
+        """是否有任意配置正在运行。"""
+        if self.runtime_manager.any_running():
+            return True
+        return bool(self.task_runner.is_running)
+
+    def running_config_ids(self) -> List[str]:
+        """返回正在运行的配置 ID 列表。"""
+        ids = list(self.runtime_manager.running_config_ids())
+        if self.task_runner.is_running:
+            curr = self.config_service.current_config_id
+            if curr and curr not in ids:
+                ids.append(curr)
+        return ids
+    # endregion
 
     # endregion
 
@@ -1293,12 +1376,27 @@ class ServiceCoordinator:
             logger.error(f"重新初始化服务协调器失败: {e}")
 
     async def run_tasks_flow(
-        self, task_id: str | None = None
+        self,
+        task_id: str | None = None,
+        *,
+        config_id: str | None = None,
+        start_task_id: str | None = None,
     ):
         """运行任务流的对外封装。
 
         :param task_id: 指定只运行某个任务（可选）
+        :param config_id: 指定运行的配置（可选，默认当前激活配置）。多实例模式下用于并行运行。
+        :param start_task_id: 从指定任务开始执行（可选）。
         """
+        target_config_id = config_id or self.config_service.current_config_id
+
+        # 多实例模式：通过运行时管理器为目标配置创建/复用独立运行体
+        if self.is_multi_instance_enabled():
+            return await self.runtime_manager.run(
+                target_config_id, task_id, start_task_id=start_task_id
+            )
+
+        # 单实例模式：沿用主运行器（仅当前配置）
         restore_checked = False
         if task_id:
             task = self.task_service.get_task(task_id)
@@ -1310,19 +1408,132 @@ class ServiceCoordinator:
             self.task_service.refresh_hidden_flags()
         except Exception:
             pass
+        # 标记主桥接当前运行的配置，使带 config_id 的信号正确归属
+        self._runner_ui_bridge.config_id = target_config_id
         try:
-            return await self.task_runner.run_tasks_flow(task_id)
+            return await self.task_runner.run_tasks_flow(
+                task_id, start_task_id=start_task_id
+            )
         finally:
             if restore_checked:
                 self.update_task_checked(task_id, False)
 
-    async def stop_task_flow(self):
-        """停止当前任务流（UI/外部调用，视为手动停止）。"""
+    @property
+    def current_runner(self) -> TaskFlowRunner:
+        """返回当前激活配置正在使用的运行器。
+
+        多实例模式下若当前配置存在独立运行体则返回之，否则回退到主运行器。
+        """
+        if self.is_multi_instance_enabled():
+            inst = self.runtime_manager.get_instance(
+                self.config_service.current_config_id
+            )
+            if inst is not None:
+                return inst.runner
+        return self.task_runner
+
+    async def stop_task_flow(self, *, config_id: str | None = None):
+        """停止任务流（UI/外部调用，视为手动停止）。
+
+        :param config_id: 多实例模式下指定停止的配置，默认当前激活配置。
+        """
+        if self.is_multi_instance_enabled():
+            target = config_id or self.config_service.current_config_id
+            return await self.runtime_manager.stop(target, manual=True)
         return await self.task_runner.stop_task(manual=True)
 
-    async def stop_task(self, *, manual: bool = False):
-        """停止当前任务流（供内部/调度等模块调用，可指定是否视为手动停止）。"""
+    async def stop_task(self, *, manual: bool = False, config_id: str | None = None):
+        """停止任务流（供内部/调度等模块调用，可指定是否视为手动停止）。"""
+        if self.is_multi_instance_enabled():
+            target = config_id or self.config_service.current_config_id
+            return await self.runtime_manager.stop(target, manual=manual)
         return await self.task_runner.stop_task(manual=manual)
+
+    async def stop_all_tasks(self, *, manual: bool = True):
+        """停止所有正在运行的配置（应用退出/全局停止用）。"""
+        if self.runtime_manager.any_running():
+            await self.runtime_manager.stop_all(manual=manual)
+        if self.task_runner.is_running:
+            await self.task_runner.stop_task(manual=manual)
+
+    # region 多实例运行体构建
+    def _build_interface_for_config(self, config_id: str) -> Dict[str, Any]:
+        """为指定配置解析其 bundle 对应的 interface（与当前 bundle 相同则复用）。"""
+        try:
+            config = self.config_service.get_config(config_id)
+        except Exception:
+            config = None
+        bundle_name = getattr(config, "bundle", None) if config else None
+        if bundle_name:
+            try:
+                path = self._resolve_interface_path_from_bundle(bundle_name)
+                if path and path != self._interface_path:
+                    previewed = self.interface_manager.preview_interface(path)
+                    if previewed:
+                        return previewed
+            except Exception as exc:
+                logger.debug(f"为配置 {config_id} 解析独立 interface 失败，复用当前: {exc}")
+        return self._interface
+
+    def _build_runtime_instance(self, config_id: str) -> RuntimeInstance:
+        """为指定配置构建独立运行体（独立 Config/Task 服务栈 + Runner + MaaFW）。"""
+        repo = JsonConfigRepository(
+            self.config_repo.main_config_path,
+            self.config_repo.configs_dir,
+            interface=self._interface,
+        )
+        # 独立的内部信号总线，避免污染 UI 侧的 CoreSignalBus
+        private_bus = CoreSignalBus()
+        config_service = ConfigService(repo, private_bus)
+        # 在内存中把该独立服务栈钉死到目标配置，不写回全局 curr_config_id
+        if config_service._main_config is not None:
+            config_service._main_config["curr_config_id"] = config_id
+
+        interface = self._build_interface_for_config(config_id)
+        task_service = TaskService(config_service, CoreSignalBus(), interface)
+
+        runner_events = RunnerEvents()
+        fs_bus = FromeServiceCoordinator()
+        runner = TaskFlowRunner(
+            task_service=task_service,
+            config_service=config_service,
+            runner_events=runner_events,
+            fs_signal_bus=fs_bus,
+        )
+        log_processor = CallbackLogProcessor(runner_events)
+        # 完成后“运行其他配置”改为通过管理器启动独立运行体
+        runner.run_other_config_callback = (
+            lambda cid: self.runtime_manager.run(cid)
+        )
+        bridge = _TaggedRunnerBridge(
+            config_id,
+            is_current=lambda cid: self.config_service.current_config_id == cid,
+        )
+        self._wire_runner_events(runner_events, bridge)
+
+        return RuntimeInstance(
+            config_id=config_id,
+            runner=runner,
+            runner_events=runner_events,
+            fs_signal_bus=fs_bus,
+            log_processor=log_processor,
+            bridge=bridge,
+            config_service=config_service,
+            task_service=task_service,
+        )
+
+    def _refresh_runtime_instance(self, inst: RuntimeInstance) -> None:
+        """运行前刷新独立运行体的配置/任务快照，确保读取最新磁盘数据。"""
+        cs = inst.config_service
+        cs.load_main_config()
+        if cs._main_config is not None:
+            cs._main_config["curr_config_id"] = inst.config_id
+        inst.task_service.on_config_changed(inst.config_id)
+        try:
+            inst.task_service.refresh_hidden_flags()
+        except Exception:
+            pass
+    # endregion
 
     @property
     def run_manager(self) -> TaskFlowRunner:

--- a/app/core/item.py
+++ b/app/core/item.py
@@ -41,6 +41,9 @@ class FromeServiceCoordinator(QObject):
     fs_start_button_status = Signal(
         dict
     )  # 控制开始按钮状态和文本，载荷如 {"text": "开始", "status": "enabled"}
+    fs_start_button_status_at = Signal(
+        str, dict
+    )  # 携带 config_id 的开始按钮状态（多实例隔离用），载荷为 (config_id, {"text": ..., "status": ...})
 
 
 class RunnerEvents(QObject):

--- a/app/core/runner/embedded_agent_log_bridge.py
+++ b/app/core/runner/embedded_agent_log_bridge.py
@@ -109,8 +109,8 @@ def _is_client_log_path(file_path: str) -> bool:
 def _is_under_custom_roots(file_path: str, allowed_roots: tuple[str, ...]) -> bool:
     if not file_path or not allowed_roots or _is_client_log_path(file_path):
         return False
-    resolved = _normalize_path(_resolve_log_path(file_path))
-    if any(resolved.startswith(root) for root in allowed_roots):
+    normalized = _normalize_path(file_path)
+    if any(normalized.startswith(root) for root in allowed_roots):
         return True
     try:
         path_obj = Path(_resolve_log_path(file_path)).resolve()
@@ -129,10 +129,15 @@ def _should_skip_logging_logger(logger_obj: logging.Logger) -> bool:
 
 
 def collect_agent_loggers(
-    custom_root: Path, allowed_roots: tuple[str, ...]
+    custom_root: Path,
+    allowed_roots: tuple[str, ...],
+    *,
+    module_keys: Sequence[str] | None = None,
 ) -> list[Any]:
     """
     收集 custom 工程内的 logger（含 root），去重后挂载；由路径过滤保证不污染 app 日志。
+
+    module_keys: 内置 agent 加载后已导入的模块名，传入时仅扫描这些模块，避免遍历 sys.modules。
     """
     found: list[Any] = []
     seen_logging_names: set[str] = set()
@@ -161,12 +166,22 @@ def collect_agent_loggers(
         for attr in ("logger", "log"):
             _add(getattr(mod, attr, None))
 
-    for mod in list(sys.modules.values()):
-        if mod is None:
-            continue
-        file_name = getattr(mod, "__file__", None)
-        if not file_name or not _is_under_custom_roots(file_name, allowed_roots):
-            continue
+    if module_keys:
+        modules_to_scan = [
+            sys.modules[key]
+            for key in module_keys
+            if isinstance(key, str) and sys.modules.get(key) is not None
+        ]
+    else:
+        modules_to_scan = [
+            mod
+            for mod in sys.modules.values()
+            if mod is not None
+            and getattr(mod, "__file__", None)
+            and _is_under_custom_roots(str(mod.__file__), allowed_roots)
+        ]
+
+    for mod in modules_to_scan:
         for attr in ("logger", "log"):
             _add(getattr(mod, attr, None))
 
@@ -210,15 +225,19 @@ class EmbeddedAgentLogBridge:
         *,
         custom_root: Path,
         extra_roots: Sequence[Path] = (),
+        module_keys: Sequence[str] | None = None,
     ) -> int:
         """
         :param custom_root: interface.custom 解析后的绝对路径（agent 源码根目录）
         :param extra_roots: 可选补充根（如与 custom 不同的入口父目录）
+        :param module_keys: 内置 agent 已导入的模块名，用于加速 logger 收集
         """
         self.detach()
         self._allowed_roots = _build_allowed_roots(custom_root, extra_roots)
         attached = 0
-        for logger_obj in collect_agent_loggers(custom_root, self._allowed_roots):
+        for logger_obj in collect_agent_loggers(
+            custom_root, self._allowed_roots, module_keys=module_keys
+        ):
             if _is_logging_logger(logger_obj):
                 handler = _RunnerUiLogHandler(emit_fn, self._allowed_roots)
                 logger_obj.addHandler(handler)

--- a/app/core/runner/maafw.py
+++ b/app/core/runner/maafw.py
@@ -76,6 +76,80 @@ _EMBEDDED_AGENT_SERVER_SINK_DECORATORS = {
 }
 
 
+@dataclass
+class _EmbeddedAgentRegistryEntry:
+    root: Path
+    sys_paths: list[str]
+
+
+class _EmbeddedAgentLoadCoordinator:
+    """串行化多实例内置 agent 加载，并在加载前清理其他 bundle 的 sys.path / 模块缓存。"""
+
+    _lock = threading.RLock()
+    _entries: dict[int, _EmbeddedAgentRegistryEntry] = {}
+
+    @classmethod
+    def begin_load(cls, maafw: "MaaFW", root: Path) -> None:
+        with cls._lock:
+            current_id = id(maafw)
+            other_roots: list[Path] = []
+            for maafw_id, entry in list(cls._entries.items()):
+                if maafw_id == current_id:
+                    continue
+                other_roots.append(entry.root)
+                for path in entry.sys_paths:
+                    while path in sys.path:
+                        sys.path.remove(path)
+                maafw._purge_modules_under_root(entry.root)
+
+            if other_roots:
+                logger.info(
+                    "多实例内置 agent 加载前已清理其他 bundle 的 sys.path 与模块缓存: %s",
+                    ", ".join(str(item) for item in other_roots),
+                )
+
+            module_names = MaaFW._collect_module_names_under_root(root)
+            top_levels = sorted({name.split(".")[0] for name in module_names})
+            for package_name in top_levels:
+                module = sys.modules.get(package_name)
+                if module is not None and not MaaFW._module_belongs_to_root(
+                    module, root
+                ):
+                    MaaFW._purge_module_and_submodules(package_name)
+            for module_name in module_names:
+                module = sys.modules.get(module_name)
+                if module is not None and not MaaFW._module_belongs_to_root(
+                    module, root
+                ):
+                    MaaFW._purge_module_and_submodules(module_name)
+
+    @classmethod
+    def commit_load(
+        cls, maafw_id: int, root: Path, sys_paths: list[str]
+    ) -> None:
+        with cls._lock:
+            cls._entries[maafw_id] = _EmbeddedAgentRegistryEntry(
+                root=root, sys_paths=list(sys_paths)
+            )
+
+    @classmethod
+    def release(cls, maafw_id: int) -> None:
+        with cls._lock:
+            cls._entries.pop(maafw_id, None)
+
+    @classmethod
+    def finish_load(cls, maafw_id: int) -> None:
+        """加载结束后把其他实例的 sys.path 恢复到末尾，避免永久移除。"""
+        with cls._lock:
+            for other_id, entry in cls._entries.items():
+                if other_id == maafw_id:
+                    continue
+                for path in entry.sys_paths:
+                    if path in sys.path:
+                        sys.path.remove(path)
+                    sys.path.append(path)
+
+
 def iter_agent_entries(agent_config: Any):
     """遍历 interface.agent 中的全部启动项（dict 为单项，list 为多项）。"""
     if isinstance(agent_config, dict):
@@ -481,6 +555,7 @@ class MaaFW(QObject):
         self._embedded_controller_sinks.clear()
         self._embedded_tasker_sinks.clear()
         self._embedded_context_sinks.clear()
+        _EmbeddedAgentLoadCoordinator.begin_load(self, agent_path)
         self._purge_modules_under_root(self._last_custom_root)
         self._remove_custom_sys_paths()
         self._last_custom_root = agent_path
@@ -490,6 +565,9 @@ class MaaFW(QObject):
             if sys_path not in sys.path:
                 sys.path.insert(0, sys_path)
                 self._custom_sys_paths.append(sys_path)
+        _EmbeddedAgentLoadCoordinator.commit_load(
+            id(self), agent_path, self._custom_sys_paths
+        )
 
         resource = self._init_resource()
         self.custom_load_report = {
@@ -529,6 +607,7 @@ class MaaFW(QObject):
         finally:
             os.chdir(cwd)
             resource_patch()
+            _EmbeddedAgentLoadCoordinator.finish_load(id(self))
 
         actions = list(resource.custom_action_list or [])
         recognitions = list(resource.custom_recognition_list or [])
@@ -899,7 +978,7 @@ class MaaFW(QObject):
                 if self._module_belongs_to_root(sys.modules[module_name], root):
                     logger.debug("内置 agent 装饰器模块已由依赖链导入: %s", module_name)
                     continue
-                del sys.modules[module_name]
+                self._purge_module_and_submodules(module_name)
             logger.info("导入内置 agent 装饰器模块: %s", module_name)
             importlib.import_module(module_name)
 
@@ -963,12 +1042,53 @@ class MaaFW(QObject):
     @staticmethod
     def _module_belongs_to_root(module: Any, root: Path) -> bool:
         module_file = getattr(module, "__file__", None)
-        if not module_file:
-            return False
-        try:
-            return Path(module_file).resolve().is_relative_to(root)
-        except (OSError, ValueError):
-            return False
+        if module_file:
+            try:
+                if Path(module_file).resolve().is_relative_to(root):
+                    return True
+            except (OSError, ValueError):
+                pass
+        module_path = getattr(module, "__path__", None)
+        if module_path:
+            for path_entry in module_path:
+                try:
+                    if Path(path_entry).resolve().is_relative_to(root):
+                        return True
+                except (OSError, ValueError):
+                    continue
+        return False
+
+    @staticmethod
+    def _collect_module_names_under_root(root: Path) -> set[str]:
+        names: set[str] = set()
+        if not root.is_dir():
+            return names
+        skip_dirs = MaaFW._EMBEDDED_SKIP_DIRS
+        for file_path in root.rglob("*.py"):
+            try:
+                relative = file_path.relative_to(root)
+            except ValueError:
+                continue
+            if any(part in skip_dirs for part in relative.parts):
+                continue
+            module_name = MaaFW._module_name_from_path(root, file_path)
+            if module_name:
+                names.add(module_name)
+        return names
+
+    @staticmethod
+    def _purge_module_and_submodules(module_name: str) -> None:
+        prefix = module_name + "."
+        keys = [
+            key
+            for key in list(sys.modules.keys())
+            if isinstance(key, str) and (key == module_name or key.startswith(prefix))
+        ]
+        for key in keys:
+            try:
+                del sys.modules[key]
+            except KeyError:
+                pass
 
     def _purge_modules_under_root(self, root: Path | None) -> None:
         if not root:
@@ -1492,6 +1612,7 @@ class MaaFW(QObject):
             self.agent_env_vars = {}
             self.agent_connection_timeout_seconds = None
             self._last_agent_connect_timeout_seconds = None
+            _EmbeddedAgentLoadCoordinator.release(id(self))
             self._purge_modules_under_root(self._last_custom_root)
             self._last_custom_root = None
             self._embedded_resource_sinks.clear()

--- a/app/core/runner/maafw.py
+++ b/app/core/runner/maafw.py
@@ -440,6 +440,7 @@ class MaaFW(QObject):
         self._custom_sys_paths: List[str] = []
         # 记录上次加载的 custom_root，用于清理模块缓存
         self._last_custom_root: Path | None = None
+        self._last_embedded_module_keys: list[str] = []
         # 内置模式下的额外 Maa event sink。
         self._embedded_resource_sinks: List[ResourceEventSink] = []
         self._embedded_controller_sinks: List[ControllerEventSink] = []
@@ -552,6 +553,10 @@ class MaaFW(QObject):
         if recognitions:
             logger.info("成功加载内置自定义识别器: %s", ", ".join(recognitions))
 
+        self._last_embedded_module_keys = self._collect_embedded_module_keys(
+            agent_path, modules_before
+        )
+
         if not actions and not recognitions and not self._has_embedded_sinks():
             imported_modules = self._collect_imported_modules_under_root(
                 agent_path, modules_before
@@ -593,6 +598,32 @@ class MaaFW(QObject):
             ("context_sink", sink)
             for sink in self._embedded_context_sinks[counts["context_sink"] :]
         ]
+
+    @staticmethod
+    def _collect_embedded_module_keys(
+        root: Path, modules_before: set[Any]
+    ) -> list[str]:
+        """收集本次内置 agent 加载导入的模块名（字符串前缀匹配，避免 resolve 开销）。"""
+        try:
+            root_prefix = str(root.resolve()).replace("\\", "/").lower()
+        except OSError:
+            return []
+        if not root_prefix.endswith("/"):
+            root_prefix += "/"
+        keys: list[str] = []
+        for module_key in sys.modules.keys() - modules_before:
+            if not isinstance(module_key, str):
+                continue
+            module = sys.modules.get(module_key)
+            if module is None:
+                continue
+            module_file = getattr(module, "__file__", None)
+            if not module_file:
+                continue
+            normalized = str(module_file).replace("\\", "/").lower()
+            if normalized.startswith(root_prefix):
+                keys.append(module_key)
+        return sorted(keys)
 
     @staticmethod
     def _collect_imported_modules_under_root(

--- a/app/core/runner/task_flow.py
+++ b/app/core/runner/task_flow.py
@@ -106,6 +106,9 @@ class TaskFlowRunner(QObject):
         # 防止同一次任务流退出时重复发射“结束”信号（幂等保护）
         self._task_flow_finished_emitted: bool = False
         self._next_config_to_run: str | None = None
+        # 多实例模式下由协调器注入：完成后“运行其他配置”改为启动独立运行体，
+        # 不再篡改本运行体的当前配置。签名为 async def(config_id: str)。
+        self.run_other_config_callback = None
         self.adb_controller_raw: dict[str, Any] | None = None
         self.adb_activate_controller: str | None = None
         self.adb_controller_config: dict[str, Any] | None = None
@@ -3076,6 +3079,14 @@ class TaskFlowRunner(QObject):
         target_config = config_service.get_config(config_id)
         if not target_config:
             logger.warning(f"完成后操作指定的配置不存在: {config_id}")
+            return
+
+        # 多实例模式：交由协调器以独立运行体启动目标配置，不篡改本运行体当前配置
+        if self.run_other_config_callback is not None:
+            try:
+                await self.run_other_config_callback(config_id)
+            except Exception as exc:
+                logger.error(f"完成后启动其他配置失败: {config_id}: {exc}")
             return
 
         config_service.current_config_id = config_id

--- a/app/core/runner/task_flow.py
+++ b/app/core/runner/task_flow.py
@@ -180,6 +180,36 @@ class TaskFlowRunner(QObject):
         interface_manager.reload(interface_path=interface_path)
         self.task_service.update_runtime_interface(interface_manager.get_interface() or {})
 
+    def _load_embedded_custom_blocking(
+        self,
+        agent_root_path: Path,
+        agent_entry_path: Path | None,
+        log_extra_roots: tuple[Path, ...] = (),
+    ) -> tuple[bool, int]:
+        """在线程池中加载内置 agent 自定义组件并挂载日志桥接。"""
+        resource = self.maafw.resource
+        if resource is None:
+            return False, 0
+        resource.clear_custom_recognition()
+        resource.clear_custom_action()
+        if not self.maafw.load_embedded_agent_custom(
+            agent_root=agent_root_path,
+            agent_entry=agent_entry_path,
+        ):
+            return False, 0
+        if not self.maafw.load_embedded_aspect_ratio_sink():
+            return False, 0
+        attached = self._embedded_agent_log_bridge.attach(
+            self._emit_embedded_agent_log,
+            custom_root=agent_root_path,
+            extra_roots=log_extra_roots,
+            module_keys=self.maafw._last_embedded_module_keys,
+        )
+        return True, attached
+
+    def _emit_embedded_agent_log(self, level: str, text: str) -> None:
+        self.log_output.emit(level, text)
+
     @property
     def callback(self):
         return self.runner_events.callback
@@ -503,7 +533,7 @@ class TaskFlowRunner(QObject):
                 self.fs_signal_bus.fs_start_button_status.emit(
                     {"text": "STOP", "status": "disabled"}
                 )
-            self._reload_interface_for_current_bundle()
+            await asyncio.to_thread(self._reload_interface_for_current_bundle)
             controller_cfg = self.task_service.get_task(_CONTROLLER_)
             if not controller_cfg:
                 raise ValueError("未找到基础预配置任务")
@@ -608,8 +638,6 @@ class TaskFlowRunner(QObject):
                 self.log_output.emit(
                     "INFO", self.tr("Starting to load custom components...")
                 )
-                self.maafw.resource.clear_custom_recognition()
-                self.maafw.resource.clear_custom_action()
 
                 bundle_path_str = self.bundle_path or "./"
                 base_dir = Path(bundle_path_str)
@@ -645,10 +673,19 @@ class TaskFlowRunner(QObject):
                     agent_entry_path,
                 )
 
-                if not self.maafw.load_embedded_agent_custom(
-                    agent_root=agent_root_path,
-                    agent_entry=agent_entry_path,
-                ):
+                log_extra_roots: list[Path] = []
+                if agent_entry_path is not None:
+                    entry_parent = agent_entry_path.parent.resolve()
+                    if entry_parent != agent_root_path.resolve():
+                        log_extra_roots.append(entry_parent)
+
+                embedded_loaded, attached = await asyncio.to_thread(
+                    self._load_embedded_custom_blocking,
+                    agent_root_path,
+                    agent_entry_path,
+                    tuple(log_extra_roots),
+                )
+                if not embedded_loaded:
                     logger.error("内置 agent 自定义组件加载失败")
                     self.log_output.emit(
                         "ERROR",
@@ -662,29 +699,6 @@ class TaskFlowRunner(QObject):
                     await self.stop_task()
                     return
 
-                if not self.maafw.load_embedded_aspect_ratio_sink():
-                    logger.error("内置模式分辨率检查 sink 加载失败")
-                    self.log_output.emit(
-                        "ERROR",
-                        self.tr(
-                            "Embedded aspect ratio checker failed to load, "
-                            "the flow is terminated."
-                        ),
-                    )
-                    await self.stop_task()
-                    return
-
-                # custom 根目录来自 interface（InterfaceManager 根据 agent.child_args 写入 custom）
-                log_extra_roots: list[Path] = []
-                if agent_entry_path is not None:
-                    entry_parent = agent_entry_path.parent.resolve()
-                    if entry_parent != agent_root_path.resolve():
-                        log_extra_roots.append(entry_parent)
-                attached = self._embedded_agent_log_bridge.attach(
-                    lambda level, text: self.log_output.emit(level, text),
-                    custom_root=agent_root_path,
-                    extra_roots=log_extra_roots,
-                )
                 if attached:
                     logger.debug(
                         "embedded agent 日志已桥接到 UI（custom=%s），挂载 logger 数量: %s",
@@ -3050,7 +3064,7 @@ class TaskFlowRunner(QObject):
     ) -> Dict[str, Any] | None:
         """自动搜索 ADB 设备并找到与旧配置一致的那一项"""
         try:
-            devices = Toolkit.find_adb_devices()
+            devices = await self.maafw.detect_adb()
             if not devices:
                 logger.warning("未找到任何 ADB 设备")
                 return None
@@ -3112,7 +3126,7 @@ class TaskFlowRunner(QObject):
     ) -> Dict[str, Any] | None:
         """自动搜索 Win32 窗口并找到与旧配置一致的那一项"""
         try:
-            windows = Toolkit.find_desktop_windows()
+            windows = await asyncio.to_thread(Toolkit.find_desktop_windows)
             if not windows:
                 logger.warning("未找到任何 Win32 窗口")
                 return None
@@ -3176,7 +3190,7 @@ class TaskFlowRunner(QObject):
     ) -> Dict[str, Any] | None:
         """自动搜索 MacOS 窗口并找到与旧配置一致的那一项"""
         try:
-            windows = Toolkit.find_desktop_windows()
+            windows = await asyncio.to_thread(Toolkit.find_desktop_windows)
             if not windows:
                 logger.warning("未找到任何 MacOS 窗口")
                 return None

--- a/app/core/runtime_manager.py
+++ b/app/core/runtime_manager.py
@@ -1,0 +1,262 @@
+"""
+MFW-ChainFlow Assistant
+多实例运行时管理器
+
+按 config_id 管理独立的运行体（TaskFlowRunner + MaaFW + RunnerEvents + 日志处理器 +
+独立的 Config/Task 服务栈）。每个配置的启动/停止、日志、监控相互隔离。
+
+架构约束：本文件位于 app/core/（与 core.py、log_processor.py 同级），允许像 core.py
+那样向全局 signalBus 转发；但仍通过 RunnerEvents -> 桥接 -> signalBus 的链路，
+不让 Runner 自身直接 import signalBus。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional
+
+from PySide6.QtCore import QObject, Qt, Slot
+
+from app.common.signal_bus import signalBus
+from app.utils.logger import logger
+
+if TYPE_CHECKING:  # 避免循环导入
+    from app.core.core import ServiceCoordinator
+    from app.core.runner.task_flow import TaskFlowRunner
+    from app.core.item import RunnerEvents, FromeServiceCoordinator
+    from app.core.log_processor import CallbackLogProcessor
+    from app.core.service.config_service import ConfigService
+    from app.core.service.task_service import TaskService
+
+
+class _TaggedRunnerBridge(QObject):
+    """将某个配置专属运行体的事件转发到全局 signalBus。
+
+    - 始终发射带 config_id 的信号（多实例隔离）。
+    - 当该配置恰为当前激活配置时，额外发射无 config_id 的旧信号，
+      使既有视图（按当前配置工作）保持原有行为。
+    """
+
+    def __init__(self, config_id: str, is_current: Callable[[str], bool], parent=None):
+        super().__init__(parent)
+        self.config_id = config_id
+        self._is_current = is_current
+
+    def _current(self) -> bool:
+        try:
+            return bool(self._is_current(self.config_id))
+        except Exception:
+            return False
+
+    @Slot(dict)
+    def forward_callback(self, payload: dict):
+        if self._current():
+            signalBus.callback.emit(payload)
+
+    @Slot(str, str)
+    def forward_log_output(self, level: str, text: str):
+        signalBus.log_output_at.emit(self.config_id, level, text)
+        if self._current():
+            signalBus.log_output.emit(level, text)
+
+    @Slot(str)
+    def forward_set_window_title(self, title: str):
+        if self._current():
+            signalBus.set_window_title.emit(title)
+
+    @Slot(str, str)
+    def forward_task_status_changed(self, task_id: str, status: str):
+        signalBus.task_status_changed_at.emit(self.config_id, task_id, status)
+        if self._current():
+            signalBus.task_status_changed.emit(task_id, status)
+
+    @Slot(dict)
+    def forward_task_flow_finished(self, payload: dict):
+        signalBus.task_flow_finished_at.emit(self.config_id, payload)
+        if self._current():
+            signalBus.task_flow_finished.emit(payload)
+
+    @Slot()
+    def forward_log_clear_requested(self):
+        signalBus.log_clear_requested_at.emit(self.config_id)
+        if self._current():
+            signalBus.log_clear_requested.emit()
+
+    @Slot(str, str)
+    def forward_info_bar_requested(self, level: str, message: str):
+        if self._current():
+            signalBus.info_bar_requested.emit(level, message)
+
+    @Slot(str)
+    def forward_focus_toast(self, message: str):
+        if self._current():
+            signalBus.focus_toast.emit(message)
+
+    @Slot(str)
+    def forward_focus_notification(self, message: str):
+        # 系统级通知与配置是否为当前无关，始终发送
+        signalBus.focus_notification.emit(message)
+
+    @Slot(str)
+    def forward_focus_dialog(self, message: str):
+        if self._current():
+            signalBus.focus_dialog.emit(message)
+
+    @Slot(str)
+    def forward_focus_modal(self, message: str):
+        if self._current():
+            signalBus.focus_modal.emit(message)
+
+    @Slot(dict)
+    def forward_controller_setup_hint_requested(self, payload: dict):
+        if self._current():
+            signalBus.controller_setup_hint_requested.emit(payload)
+
+    @Slot(dict)
+    def forward_monitor_recognition_roi(self, payload: dict):
+        signalBus.monitor_recognition_roi_at.emit(self.config_id, payload)
+        if self._current():
+            signalBus.monitor_recognition_roi.emit(payload)
+
+
+class RuntimeInstance:
+    """单个配置的运行体（专属服务栈 + Runner + 事件桥接）。"""
+
+    def __init__(
+        self,
+        config_id: str,
+        runner: "TaskFlowRunner",
+        runner_events: "RunnerEvents",
+        fs_signal_bus: "FromeServiceCoordinator",
+        log_processor: "CallbackLogProcessor",
+        bridge: _TaggedRunnerBridge,
+        config_service: "ConfigService",
+        task_service: "TaskService",
+    ):
+        self.config_id = config_id
+        self.runner = runner
+        self.runner_events = runner_events
+        self.fs_signal_bus = fs_signal_bus
+        self.log_processor = log_processor
+        self.bridge = bridge
+        self.config_service = config_service
+        self.task_service = task_service
+        # 运行态由按钮状态信号与 run/stop 调用共同维护
+        self.running: bool = False
+
+    @property
+    def is_running(self) -> bool:
+        try:
+            return bool(self.running or self.runner.is_running)
+        except Exception:
+            return self.running
+
+
+class RuntimeInstanceManager:
+    """按 config_id 管理多个并行运行体。
+
+    仅在多实例模式开启时被协调器用于创建独立运行体；单实例模式下协调器仍使用
+    其内置的主运行器（不经过本管理器）。
+    """
+
+    def __init__(self, coordinator: "ServiceCoordinator"):
+        self._coordinator = coordinator
+        self._instances: Dict[str, RuntimeInstance] = {}
+
+    # ---- 查询 ----
+    def get_instance(self, config_id: str) -> Optional[RuntimeInstance]:
+        return self._instances.get(config_id)
+
+    def is_running(self, config_id: str) -> bool:
+        inst = self._instances.get(config_id)
+        return bool(inst and inst.is_running)
+
+    def any_running(self) -> bool:
+        return any(inst.is_running for inst in self._instances.values())
+
+    def running_config_ids(self) -> List[str]:
+        return [cid for cid, inst in self._instances.items() if inst.is_running]
+
+    # ---- 生命周期 ----
+    def _get_or_create(self, config_id: str) -> RuntimeInstance:
+        inst = self._instances.get(config_id)
+        if inst is not None:
+            return inst
+        inst = self._coordinator._build_runtime_instance(config_id)
+        # 关联按钮状态信号到管理器，转换为带 config_id 的状态广播
+        inst.fs_signal_bus.fs_start_button_status.connect(
+            lambda payload, cid=config_id: self._on_instance_button_status(cid, payload),
+            Qt.ConnectionType.QueuedConnection,
+        )
+        self._instances[config_id] = inst
+        return inst
+
+    async def run(self, config_id: str, task_id: str | None = None, *, start_task_id: str | None = None):
+        """启动指定配置的任务流（独立运行体）。"""
+        if not config_id:
+            logger.warning("RuntimeInstanceManager.run: 空的 config_id，忽略")
+            return
+        if self.is_running(config_id):
+            logger.warning("配置 %s 已在运行，忽略重复启动", config_id)
+            return
+        inst = self._get_or_create(config_id)
+        # 启动前刷新该配置的服务栈快照，确保读取最新磁盘数据
+        try:
+            self._coordinator._refresh_runtime_instance(inst)
+        except Exception as exc:
+            logger.warning("刷新运行体 %s 失败（继续尝试运行）: %s", config_id, exc)
+        inst.running = True
+        signalBus.config_run_state_changed.emit(config_id, True)
+        try:
+            return await inst.runner.run_tasks_flow(task_id, start_task_id=start_task_id)
+        finally:
+            # 运行结束后由按钮状态信号同步 running=False；此处兜底
+            if not inst.runner.is_running:
+                inst.running = False
+                signalBus.config_run_state_changed.emit(config_id, False)
+
+    async def stop(self, config_id: str, *, manual: bool = False):
+        inst = self._instances.get(config_id)
+        if not inst:
+            return
+        try:
+            return await inst.runner.stop_task(manual=manual)
+        finally:
+            inst.running = False
+            signalBus.config_run_state_changed.emit(config_id, False)
+
+    async def stop_all(self, *, manual: bool = False):
+        for config_id in list(self._instances.keys()):
+            try:
+                await self.stop(config_id, manual=manual)
+            except Exception as exc:
+                logger.warning("停止配置 %s 失败: %s", config_id, exc)
+
+    def shutdown_sync(self):
+        """应用退出时的同步兜底清理。"""
+        for config_id, inst in list(self._instances.items()):
+            try:
+                shutdown = getattr(inst.runner, "shutdown_runtime_sync", None)
+                if callable(shutdown):
+                    shutdown()
+            except Exception as exc:
+                logger.warning("同步关闭运行体 %s 失败: %s", config_id, exc)
+            inst.running = False
+
+    # ---- 内部 ----
+    def _on_instance_button_status(self, config_id: str, payload: dict):
+        inst = self._instances.get(config_id)
+        running = isinstance(payload, dict) and payload.get("text") == "STOP"
+        if inst is not None:
+            inst.running = running
+        # 带 config_id 的按钮状态（供配置列表/各配置卡片）
+        try:
+            self._coordinator.fs_signal_bus.fs_start_button_status_at.emit(config_id, payload)
+        except Exception:
+            pass
+        signalBus.config_run_state_changed.emit(config_id, running)
+        # 若该配置为当前激活配置，则同步主开始按钮
+        try:
+            if self._coordinator.config_service.current_config_id == config_id:
+                self._coordinator.fs_signal_bus.fs_start_button_status.emit(payload)
+        except Exception:
+            pass

--- a/app/core/service/schedule_service.py
+++ b/app/core/service/schedule_service.py
@@ -500,6 +500,17 @@ class ScheduleService(QObject):
             await self._try_start_next()
 
     async def _force_start(self, entry: ScheduleEntry) -> None:
+        if self.service_coordinator.is_multi_instance_enabled():
+            # 多实例：仅停止目标配置，不影响其它正在运行的配置
+            target = (
+                entry.config_id or self.service_coordinator.config.current_config_id
+            )
+            if self.service_coordinator.is_config_running(target):
+                await self.service_coordinator.stop_task(config_id=target)
+            self._pending_queue.appendleft(entry)
+            await self._try_start_next()
+            return
+
         if self.service_coordinator.run_manager.is_running or (
             self._current_task and not self._current_task.done()
         ):
@@ -519,10 +530,15 @@ class ScheduleService(QObject):
             return
         while self._pending_queue:
             next_entry = self._pending_queue[0]
-            if (
-                self.service_coordinator.run_manager.is_running
-                and not next_entry.force_start
-            ):
+            if self.service_coordinator.is_multi_instance_enabled():
+                # 多实例：仅当目标配置自身在运行时才等待
+                busy = self.service_coordinator.is_config_running(
+                    next_entry.config_id
+                    or self.service_coordinator.config.current_config_id
+                )
+            else:
+                busy = self.service_coordinator.run_manager.is_running
+            if busy and not next_entry.force_start:
                 await asyncio.sleep(1)
                 continue
             next_entry = self._pending_queue.popleft()
@@ -530,12 +546,43 @@ class ScheduleService(QObject):
             return
 
     async def _execute_entry(self, entry: ScheduleEntry) -> None:
-        signalBus.log_clear_requested.emit()
         self._log_info(
             self.tr("Schedule: {name} ({describe}) started").format(
                 name=entry.name, describe=entry.describe(self.tr)
             )
         )
+        # 多实例模式：直接运行目标配置实例，不切换全局当前配置
+        if self.service_coordinator.is_multi_instance_enabled():
+            target_config = (
+                entry.config_id or self.service_coordinator.config.current_config_id
+            )
+            if not self.service_coordinator.config.get_config(target_config):
+                self._log_info(
+                    self.tr(
+                        "Schedule: target config {config_id} not found, skipped"
+                    ).format(config_id=target_config)
+                )
+                self._current_task = None
+                await self._try_start_next()
+                return
+            # 仅清空目标配置的日志缓冲
+            signalBus.log_clear_requested_at.emit(target_config)
+            try:
+                await self.service_coordinator.run_tasks_flow(config_id=target_config)
+            except Exception as exc:
+                logger.exception("计划任务执行失败: %s", exc)
+                self._log_info(
+                    self.tr("Schedule: {name} failed: {error}").format(
+                        name=entry.name, error=exc
+                    )
+                )
+            finally:
+                self._current_task = None
+                await self._try_start_next()
+            return
+
+        # 单实例模式：切换到目标配置、运行、再恢复
+        signalBus.log_clear_requested.emit()
         original_config = self.service_coordinator.config.current_config_id
         switched = False
         if entry.config_id and entry.config_id != original_config:

--- a/app/i18n/i18n.ja_JP.ts
+++ b/app/i18n/i18n.ja_JP.ts
@@ -1,6038 +1,6079 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ja_JP">
-    <context>
-        <name />
-        <message>
-            <source>Single at {time}</source>
-            <translation type="vanished">{time}に単発</translation>
-        </message>
-        <message>
-            <source>Daily every {n} day(s) at {time}</source>
-            <translation type="vanished">{n}日ごとに毎日 {time}</translation>
-        </message>
-        <message>
-            <source>Weekly every {n} week(s) at {time}</source>
-            <translation type="vanished">{n}週ごとに毎週 {time}</translation>
-        </message>
-        <message>
-            <source>Every month</source>
-            <translation type="vanished">毎月</translation>
-        </message>
-        <message>
-            <source>Last</source>
-            <translation type="vanished">最終</translation>
-        </message>
-        <message>
-            <source>Monthly ({month}) on the {ordinal} {weekday} at {time}</source>
-            <translation type="vanished">毎月（{month}）の第{ordinal}{weekday} {time}</translation>
-        </message>
-        <message>
-            <source>Monthly ({month}) on day {day} at {time}</source>
-            <translation type="vanished">毎月（{month}）の{day}日 {time}</translation>
-        </message>
-        <message>
-            <source>Custom</source>
-            <translation type="vanished">カスタム</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="181" />
-            <source>GitHub API rate limit exceeded. Please try again later or configure a GitHub Token.</source>
-            <translation>GitHub APIのレート制限に達しました。後でもう一度試すか、GitHub Tokenを設定してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="185" />
-            <source>GitHub SSL connection failed. Check system time, proxy, or certificate settings.</source>
-            <translation>GitHub SSL接続に失敗しました。システム時刻、プロキシ、または証明書の設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="189" />
-            <source>GitHub request timed out. Check your network or proxy and try again.</source>
-            <translation>GitHubリクエストがタイムアウトしました。ネットワークまたはプロキシを確認して、もう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="193" />
-            <source>GitHub domain could not be resolved. Check DNS or network settings.</source>
-            <translation>GitHubドメインを解決できませんでした。DNSまたはネットワーク設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="197" />
-            <source>GitHub connection failed. Check your network and try again.</source>
-            <translation>GitHub接続に失敗しました。ネットワークを確認して、もう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="200" />
-            <source>GitHub request was rejected. Check the project URL or permissions.</source>
-            <translation>GitHubリクエストが拒否されました。プロジェクトURLまたは権限を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="202" />
-            <source>GitHub service is temporarily unavailable. Please try again later.</source>
-            <translation>GitHubサービスが一時的に利用できません。後でもう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="204" />
-            <source>GitHub returned an invalid response. Please try again later.</source>
-            <translation>GitHubから無効な応答がありました。後でもう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="205" />
-            <source>GitHub {action} failed. Please try again later.</source>
-            <translation>GitHub {action}に失敗しました。後でもう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="215" />
-            <source> Will try GitHub source for update check.</source>
-            <translation>更新確認にGitHubソースを使用します。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="222" />
-            <source>MirrorChyan SSL connection failed. Check system time, proxy, or certificate settings.</source>
-            <translation>MirrorChyan SSL接続に失敗しました。システム時刻、プロキシ、または証明書の設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="226" />
-            <source>MirrorChyan request timed out. Check your network or proxy.</source>
-            <translation>MirrorChyanリクエストがタイムアウトしました。ネットワークまたはプロキシを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="229" />
-            <source>MirrorChyan domain could not be resolved. Check DNS or network settings.</source>
-            <translation>MirrorChyanドメインを解決できませんでした。DNSまたはネットワーク設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="232" />
-            <source>MirrorChyan connection failed. Check your network and try again.</source>
-            <translation>MirrorChyan接続に失敗しました。ネットワークを確認して、もう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="235" />
-            <source>MirrorChyan request was rejected. Check CDK or resource settings.</source>
-            <translation>MirrorChyanリクエストが拒否されました。CDKまたはリソース設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="238" />
-            <source>MirrorChyan service is temporarily unavailable.</source>
-            <translation>MirrorChyanサービスが一時的に利用できません。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="241" />
-            <source>MirrorChyan CDK has expired.</source>
-            <translation>MirrorChyan CDKの有効期限が切れました。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="243" />
-            <source>MirrorChyan CDK is invalid. Check your CDK in settings.</source>
-            <translation>MirrorChyan CDKが無効です。設定でCDKを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="245" />
-            <source>MirrorChyan resource quota exhausted.</source>
-            <translation>MirrorChyanリソースの割り当てが枯渇しました。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="247" />
-            <source>MirrorChyan CDK does not match this resource.</source>
-            <translation>MirrorChyan CDKがこのリソースと一致しません。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="249" />
-            <source>MirrorChyan resource was not found. Check the resource ID.</source>
-            <translation>MirrorChyanリソースが見つかりませんでした。リソースIDを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="251" />
-            <source>MirrorChyan OS parameter is invalid for this resource.</source>
-            <translation>MirrorChyan OSパラメータがこのリソースに無効です。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="253" />
-            <source>MirrorChyan architecture parameter is invalid for this resource.</source>
-            <translation>MirrorChyanアーキテクチャパラメータがこのリソースに無効です。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="255" />
-            <source>MirrorChyan channel parameter is invalid for this resource.</source>
-            <translation>MirrorChyanチャンネルパラメータがこのリソースに無効です。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="257" />
-            <source>MirrorChyan request parameters are invalid.</source>
-            <translation>MirrorChyanリクエストパラメータが無効です。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="258" />
-            <source>MirrorChyan update check failed.</source>
-            <translation>MirrorChyan更新確認に失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="409" />
-            <source>GitHub download timed out. Check your network or proxy.</source>
-            <translation>GitHubダウンロードがタイムアウトしました。ネットワークまたはプロキシを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="412" />
-            <source>GitHub download SSL failed. Check certificate or proxy settings.</source>
-            <translation>GitHubダウンロードのSSL接続に失敗しました。証明書またはプロキシ設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="415" />
-            <source>GitHub download connection failed. Check your network.</source>
-            <translation>GitHubダウンロードの接続に失敗しました。ネットワークを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="416" />
-            <source>GitHub download failed. Please try again.</source>
-            <translation>GitHubダウンロードに失敗しました。もう一度お試しください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="418" />
-            <source>MirrorChyan download timed out. Check your network or proxy.</source>
-            <translation>MirrorChyanダウンロードがタイムアウトしました。ネットワークまたはプロキシを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="421" />
-            <source>MirrorChyan download SSL failed. Check certificate or proxy settings.</source>
-            <translation>MirrorChyanダウンロードのSSL接続に失敗しました。証明書またはプロキシ設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="424" />
-            <source>MirrorChyan download connection failed. Check your network.</source>
-            <translation>MirrorChyanダウンロードの接続に失敗しました。ネットワークを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="425" />
-            <source>MirrorChyan download failed. Please try again.</source>
-            <translation>MirrorChyanダウンロードに失敗しました。もう一度お試しください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="269" />
-            <source>{channel} send failed: SSL error. Check certificate or proxy settings.</source>
-            <translation>{channel}送信失敗: SSLエラー。証明書またはプロキシ設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="272" />
-            <source>{channel} send failed: request timed out. Check your network.</source>
-            <translation>{channel}送信失敗: リクエストがタイムアウトしました。ネットワークを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="277" />
-            <source>{channel} send failed: domain could not be resolved. Check DNS settings.</source>
-            <translation>{channel}送信失敗: ドメインを解決できませんでした。DNS設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="281" />
-            <source>{channel} send failed: connection error. Check server address and network.</source>
-            <translation>{channel}送信失敗: 接続エラー。サーバーアドレスとネットワークを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="285" />
-            <source>{channel} send failed: request rejected. Check URL, token, or webhook key.</source>
-            <translation>{channel}送信失敗: リクエストが拒否されました。URL、トークン、またはWebhookキーを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="289" />
-            <source>{channel} send failed: remote service error. Try again later.</source>
-            <translation>{channel}送信失敗: リモートサービスエラー。後でもう一度試してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="293" />
-            <source>{channel} send failed: invalid response from server. Check configuration.</source>
-            <translation>{channel}送信失敗: サーバーから無効な応答がありました。設定を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="295" />
-            <source>{channel} send failed due to a network error.</source>
-            <translation>{channel}送信失敗: ネットワークエラー。</translation>
-        </message>
-        <message>
-            <source>{channel} sent successfully.</source>
-            <translation type="vanished">{channel}送信成功。</translation>
-        </message>
-        <message>
-            <source>{channel} notifications are disabled.</source>
-            <translation type="vanished">{channel}通知が無効になっています。</translation>
-        </message>
-        <message>
-            <source>{channel}: required settings are empty.</source>
-            <translation type="vanished">{channel}: 必要な設定が空です。</translation>
-        </message>
-        <message>
-            <source>{channel}: invalid URL or parameter format.</source>
-            <translation type="vanished">{channel}: URLまたはパラメータ形式が無効です。</translation>
-        </message>
-        <message>
-            <source>{channel} send failed due to a network error. (Network)</source>
-            <translation type="vanished">{channel}送信失敗: ネットワークエラー。</translation>
-        </message>
-        <message>
-            <source>{channel} send failed: server returned an error. Check webhook or token.</source>
-            <translation type="vanished">{channel}送信失敗: サーバーがエラーを返しました。Webhookまたはトークンを確認してください。</translation>
-        </message>
-        <message>
-            <source>{channel}: SMTP port must be a valid number. (Config)</source>
-            <translation type="vanished">{channel}: SMTPポートは有効な数値である必要があります。</translation>
-        </message>
-        <message>
-            <source>{channel} SMTP connection failed. Check server address, port, and credentials. (Connection)</source>
-            <translation type="vanished">{channel} SMTP接続に失敗しました。サーバーアドレス、ポート、認証情報を確認してください。</translation>
-        </message>
-        <message>
-            <source>{channel} send failed with an unknown error. (Unknown)</source>
-            <translation type="vanished">{channel}送信失敗: 不明なエラー。</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddBundleDialog</name>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1514" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1518" />
-            <source>Add Resource Bundle</source>
-            <translation>リソースバンドルを追加</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1524" />
-            <source>Bundle Name:</source>
-            <translation>バンドル名：</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1526" />
-            <source>Enter the name of the bundle</source>
-            <translation>バンドルの名前を入力してください</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1533" />
-            <source>Interface File:</source>
-            <translation>インターフェースファイル：</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1536" />
-            <source>Select interface.json or interface.jsonc file</source>
-            <translation>interface.jsonまたはinterface.jsoncファイルを選択</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1555" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1556" />
-            <source>Cancel</source>
-            <translation>キャンセル</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1573" />
-            <source>Choose Interface File</source>
-            <translation>インターフェースファイルを選択</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1575" />
-            <source>Interface Files (interface.json interface.jsonc)</source>
-            <translation>インターフェースファイル (interface.json interface.jsonc)</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1577" />
-            <source>JSON Files (*.json *.jsonc)</source>
-            <translation>JSONファイル (*.json *.jsonc)</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1579" />
-            <source>All Files (*)</source>
-            <translation>すべてのファイル (*)</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1594" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1668" />
-            <source>Please select interface.json or interface.jsonc file</source>
-            <translation>interface.jsonまたはinterface.jsoncファイルを選択してください</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1614" />
-            <source>Default Bundle</source>
-            <translation>デフォルトバンドル</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1644" />
-            <source>Interface file path cannot be empty</source>
-            <translation>インターフェースファイルのパスは空にできません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1654" />
-            <source>Selected interface file does not exist</source>
-            <translation>選択したインターフェースファイルが存在しません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1660" />
-            <source>Selected path is not a file</source>
-            <translation>選択したパスはファイルではありません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1691" />
-            <source>Failed to read interface.json: {}</source>
-            <translation>interface.jsonの読み込みに失敗しました：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1697" />
-            <source>interface.json does not contain a valid 'name' field</source>
-            <translation>interface.jsonに有効な'name'フィールドが含まれていません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1707" />
-            <source>Service is not ready, cannot save bundle</source>
-            <translation>サービスが準備できていないため、バンドルを保存できません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1723" />
-            <source>Bundle name already exists</source>
-            <translation>バンドル名は既に存在します</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1728" />
-            <source>Failed to check existing bundles: {}</source>
-            <translation>既存バンドルの確認に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1741" />
-            <source>Bundle directory does not exist: {}</source>
-            <translation>バンドルディレクトリが存在しません: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1747" />
-            <source>Bundle path is not a directory: {}</source>
-            <translation>バンドルパスはディレクトリではありません: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1787" />
-            <source>Cannot move bundle: target directory is inside source directory</source>
-            <translation>バンドルを移動できません: ターゲットディレクトリがソースディレクトリ内にあります</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1816" />
-            <source>Failed to remove existing bundle directory: {}</source>
-            <translation>既存バンドルディレクトリの削除に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1844" />
-            <source>Failed to create bundle directory: {}</source>
-            <translation>バンドルディレクトリの作成に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1890" />
-            <source>Failed to move bundle to target directory: {}</source>
-            <translation>ターゲットディレクトリへのバンドル移動に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1938" />
-            <source>Failed to update bundle path</source>
-            <translation>バンドルパスの更新に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1943" />
-            <source>Failed to update bundle path: {}</source>
-            <translation>バンドルパスの更新に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1958" />
-            <source>An unexpected error occurred: {}</source>
-            <translation>予期しないエラーが発生しました: {}</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddConfigDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="98" />
-            <source>Add New Config</source>
-            <translation>新規設定を追加</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="104" />
-            <source>Config Name:</source>
-            <translation>設定名:</translation>
-        </message>
-        <message>
-            <source>Enter the name of the config</source>
-            <translation type="vanished">設定の名前を入力してください</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="116" />
-            <source>Resource Bundle:</source>
-            <translation>リソースバンドル:</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="135" />
-            <source>Preset:</source>
-            <translation>プリセット:</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="226" />
-            <source>Default (all tasks)</source>
-            <translation>デフォルト (すべてのタスク)</translation>
-        </message>
-        <message>
-            <source>Config name cannot be empty</source>
-            <translation type="vanished">設定名を空にすることはできません</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="107" />
-            <source>Enter name, or leave empty for auto (preset name + index)</source>
-            <translation>名前を入力するか、空欄のまま自動生成（プリセット名＋インデックス）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="147" />
-            <source>Import shared config:</source>
-            <translation>共有設定をインポート：</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="149" />
-            <source>Off</source>
-            <translation>オフ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="150" />
-            <source>On</source>
-            <translation>オン</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="158" />
-            <source>Paste shared config content here</source>
-            <translation>共有設定の内容を貼り付け</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="306" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="308" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="401" />
-            <source>Config</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="310" />
-            <source>{0} {1}</source>
-            <translation>{0} {1}</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="334" />
-            <source>Please paste shared config content</source>
-            <translation>共有設定の内容を貼り付けてください</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="339" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="342" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="368" />
-            <source>Invalid shared config content</source>
-            <translation>無効な共有設定の内容です</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="345" />
-            <source>Shared config contains no tasks</source>
-            <translation>共有設定にタスクが含まれていません</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="350" />
-            <source>Please select a resource bundle</source>
-            <translation>リソースバンドルを選択してください</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="362" />
-            <source>Resource mismatch: shared config is for "{0}", but you selected "{1}".</source>
-            <translation>リソースが一致しません：共有設定は「{0}」用ですが、「{1}」が選択されています。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="403" />
-            <source>New Config</source>
-            <translation>新規設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="406" />
-            <source>Could not allocate a unique config name</source>
-            <translation>一意な設定名を割り当てられませんでした</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="412" />
-            <source>Cannot use 'default' as config name</source>
-            <translation>設定名に「default」は使用できません</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="427" />
-            <source>Resource bundle not found</source>
-            <translation>リソースバンドルが見つかりません</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="453" />
-            <source>Interface file not found in bundle: {}</source>
-            <translation>バンドル内にインターフェースファイルが見つかりません: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="464" />
-            <source>Failed to load interface from bundle: {}</source>
-            <translation>バンドルからのインターフェース読み込みに失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="470" />
-            <source>Controller not found in bundle interface</source>
-            <translation>バンドルインターフェース内にコントローラーが見つかりません</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="473" />
-            <source>Resource not found in bundle interface</source>
-            <translation>バンドルインターフェース内にリソースが見つかりません</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddTaskDialog</name>
-        <message>
-            <source>Framework Built-in Tasks</source>
-            <translation type="vanished">フレームワーク組み込みタスク</translation>
-        </message>
-        <message>
-            <source>Builtin tasks loaded by the framework.</source>
-            <translation type="vanished">フレームワークによって読み込まれた組み込みタスク</translation>
-        </message>
-        <message>
-            <source>Launch Program</source>
-            <translation type="vanished">プログラムを起動</translation>
-        </message>
-        <message>
-            <source>Launch an external program and optionally wait for it to exit.</source>
-            <translation type="vanished">外部プログラムを起動し、必要に応じて終了を待機します。</translation>
-        </message>
-        <message>
-            <source>Wait</source>
-            <translation type="vanished">待機</translation>
-        </message>
-        <message>
-            <source>Wait for the specified number of seconds before continuing.</source>
-            <translation type="vanished">指定した秒数だけ待機してから後続タスクを続行します。</translation>
-        </message>
-        <message>
-            <source>Wait Until</source>
-            <translation type="vanished">時刻まで待機</translation>
-        </message>
-        <message>
-            <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
-            <translation type="vanished">指定した時刻まで待機します。HH:MM または YYYY-MM-DD HH:MM に対応しています。</translation>
-        </message>
-        <message>
-            <source>System Notification</source>
-            <translation type="vanished">システム通知</translation>
-        </message>
-        <message>
-            <source>Send a system notification and optionally play the system sound.</source>
-            <translation type="vanished">システム通知を送信し、必要に応じてシステム音を再生します。</translation>
-        </message>
-        <message>
-            <source>External Notification</source>
-            <translation type="vanished">外部通知</translation>
-        </message>
-        <message>
-            <source>Send a message to all currently enabled external notification channels.</source>
-            <translation type="vanished">現在有効なすべての外部通知チャンネルにメッセージを送信します。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="544" />
-            <source>Add New Task</source>
-            <translation>新規タスクを追加</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="547" />
-            <source>Close</source>
-            <translation>閉じる</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="548" />
-            <source>Add</source>
-            <translation>追加</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="554" />
-            <source>Task List</source>
-            <translation>タスク一覧</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="556" />
-            <source>Select one task from the groups below.</source>
-            <translation>以下のグループからタスクを1つ選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="652" />
-            <source>Default Group</source>
-            <translation>デフォルトグループ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="653" />
-            <source>Tasks without an explicit group</source>
-            <translation>明示的なグループがないタスク</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="727" />
-            <source>{} tasks</source>
-            <translation>{} タスク</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="794" />
-            <source>Please select a task</source>
-            <translation>タスクを選択してください</translation>
-        </message>
-    </context>
-    <context>
-        <name>AprilFoolsEasterEgg</name>
-        <message>
-            <source> Checking anti-addiction system...</source>
-            <translation type="vanished"> 依存防止システムをチェック中...</translation>
-        </message>
-        <message>
-            <source> April Fools detected. System verdict: "Limited-time April Fools addiction mode".</source>
-            <translation type="vanished"> 本日はエイプリルフールのため、システム判定は「期間限定エイプリルフール依存モード」です。</translation>
-        </message>
-        <message>
-            <source> Task execution failed! Reason: You are granted "slacking rights" today. Please grab a coffee manually.</source>
-            <translation type="vanished"> タスク実行失敗！理由：今日は「サボり権」が付与されました。手動でコーヒーを飲みに行ってください。</translation>
-        </message>
-        <message>
-            <source> Just kidding, back to serious work...</source>
-            <translation type="vanished"> うそです。真面目に作業を開始します...</translation>
-        </message>
-        <message>
-            <source> Today's task progress: ▓▓▓▓▓▓▓▓▓▓ 100%</source>
-            <translation type="vanished"> 本日のタスク進捗: ▓▓▓▓▓▓▓▓▓▓ 100%</translation>
-        </message>
-        <message>
-            <source> Verifying... Verification failed!</source>
-            <translation type="vanished"> 検証中... 検証失敗！</translation>
-        </message>
-        <message>
-            <source> Server fluctuation detected (actually April Fools fluctuation), progress rolled back to 0%.</source>
-            <translation type="vanished"> サーバーの揺らぎを検出（実はエイプリルフール揺らぎ）。進捗は 0% にロールバックされました。</translation>
-        </message>
-        <message>
-            <source> Re-executing...</source>
-            <translation type="vanished"> 再実行中...</translation>
-        </message>
-        <message>
-            <source> [System Notice] Since today is April Fools, all players can claim the limited title "Ultimate Sucker" upon login.</source>
-            <translation type="vanished"> [システム告知] 本日はエイプリルフールのため、ログインした全プレイヤーに限定称号「大冤種」を配布します。</translation>
-        </message>
-        <message>
-            <source> Title claimed automatically. Please restart the game to view it.</source>
-            <translation type="vanished"> 称号は自動受け取り済みです。確認するにはゲームを再起動してください。</translation>
-        </message>
-        <message>
-            <source> Daily task completion: ■■□□□ 40%</source>
-            <translation type="vanished"> デイリー任務達成度：■■□□□ 40%</translation>
-        </message>
-        <message>
-            <source> Injecting April Fools special patch...</source>
-            <translation type="vanished"> エイプリルフール特別パッチを注入中...</translation>
-        </message>
-        <message>
-            <source> Output: sudo rm -rf</source>
-            <translation type="vanished"> 出力結果：sudo rm -rf</translation>
-        </message>
-        <message>
-            <source> Got scared? Back to normal task execution...</source>
-            <translation type="vanished"> びっくりしましたか？通常タスクを実行します...</translation>
-        </message>
-        <message>
-            <source> April Fools detected, enabling "Anti-Boss Mode" automatically.</source>
-            <translation type="vanished"> 本日がエイプリルフールのため、「上司対策モード」を自動で有効化しました。</translation>
-        </message>
-        <message>
-            <source> Taskbar title changed to: "2026 Q2 Quarterly Report - Data Analysis.exe"</source>
-            <translation type="vanished"> タスクバーのタイトルを「2026年Q2四半期レポート - データ分析.exe」に変更しました。</translation>
-        </message>
-        <message>
-            <source>2026 Q2 Quarterly Report - Data Analysis.exe</source>
-            <translation type="vanished">2026年Q2四半期レポート - データ分析.exe</translation>
-        </message>
-        <message>
-            <source> Pretending to load Excel...</source>
-            <translation type="vanished"> Excelを読み込んでいるふりをしています...</translation>
-        </message>
-        <message>
-            <source> Today's task list: 1. Enter game; 2. Claim rewards; 3. Be kind to yourself.</source>
-            <translation type="vanished"> 本日のタスクリスト：1.ゲーム起動；2.報酬受取；3.自分を大切にする。</translation>
-        </message>
-        <message>
-            <source> The first two are already done for you, please do the third one yourself.</source>
-            <translation type="vanished"> 最初の2項目は代行しました。3項目目はご自身でお願いします。</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseAddDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="58" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="59" />
-            <source>Cancel</source>
-            <translation>キャンセル</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="78" />
-            <source>Error</source>
-            <translation>エラー</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseListToolBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="72" />
-            <source>Select All</source>
-            <translation>すべて選択</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="76" />
-            <source>Deselect All</source>
-            <translation>すべて選択解除</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="80" />
-            <source>Add</source>
-            <translation>追加</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="84" />
-            <source>Delete</source>
-            <translation>削除</translation>
-        </message>
-        <message>
-            <source>Switch to Special Tasks</source>
-            <translation type="vanished">特殊タスクに切り替え</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="29" />
-            <source>Test</source>
-            <translation>テスト</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="93" />
-            <source>decrypt notice key failed: {}，please fill in again and save.</source>
-            <translation>通知キーの復号に失敗しました: {}、再度入力して保存してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="99" />
-            <source>parse notice key error: {}，please save again.</source>
-            <translation>通知キーの解析エラー: {}、再度保存してください。</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseUpdate</name>
-        <message>
-            <location filename="../utils/update.py" line="240" />
-            <location filename="../utils/update.py" line="272" />
-            <source>User cancelled</source>
-            <translation>ユーザーがキャンセルしました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="274" />
-            <source>Download interrupted</source>
-            <translation>ダウンロードが中断されました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="856" />
-            <source>GitHub API returned an error: {message}</source>
-            <translation>GitHub APIがエラーを返しました: {message}</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="878" />
-            <source>GitHub returned an invalid response. Please try again later. (Response)</source>
-            <translation>GitHubから無効な応答がありました。後でもう一度試してください。</translation>
-        </message>
-        <message>
-            <source>Update check failed HTTP error,code: </source>
-            <translation type="vanished">更新チェックに失敗しました HTTPエラー、コード: </translation>
-        </message>
-        <message>
-            <source>GitHub API request limit exceeded,please try again later</source>
-            <translation type="vanished">GitHub APIリクエスト制限を超えました、後ほど再試行してください</translation>
-        </message>
-        <message>
-            <source>Github Update check failed HTTP error,code: </source>
-            <translation type="vanished">Github更新チェックに失敗しました HTTPエラー、コード: </translation>
-        </message>
-        <message>
-            <source>MirrorChyan Update check failed SSL error</source>
-            <translation type="vanished">MirrorChyan 更新チェック失敗 SSLエラー</translation>
-        </message>
-        <message>
-            <source>switching to Github download</source>
-            <translation type="vanished">GitHubダウンロードに切り替え中</translation>
-        </message>
-        <message>
-            <source>Github Update check failed SSL error</source>
-            <translation type="vanished">GitHub更新チェック失敗 SSLエラー</translation>
-        </message>
-        <message>
-            <source>INVALID_PARAMS</source>
-            <translation type="vanished">無効なパラメータ</translation>
-        </message>
-        <message>
-            <source>KEY_EXPIRED</source>
-            <translation type="vanished">キー期限切れ</translation>
-        </message>
-        <message>
-            <source>KEY_INVALID</source>
-            <translation type="vanished">無効なキー</translation>
-        </message>
-        <message>
-            <source>RESOURCE_QUOTA_EXHAUSTED</source>
-            <translation type="vanished">リソース割り当て超過</translation>
-        </message>
-        <message>
-            <source>KEY_MISMATCHED</source>
-            <translation type="vanished">キー不一致</translation>
-        </message>
-        <message>
-            <source>RESOURCE_NOT_FOUND</source>
-            <translation type="vanished">リソースが見つかりません</translation>
-        </message>
-        <message>
-            <source>INVALID_OS</source>
-            <translation type="vanished">無効なOS</translation>
-        </message>
-        <message>
-            <source>INVALID_ARCH</source>
-            <translation type="vanished">無効なアーキテクチャ</translation>
-        </message>
-        <message>
-            <source>INVALID_CHANNEL</source>
-            <translation type="vanished">無効なチャンネル</translation>
-        </message>
-        <message>
-            <source>Unknown error</source>
-            <translation type="vanished">不明なエラー</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="835" />
-            <location filename="../utils/update.py" line="866" />
-            <source>current version is latest</source>
-            <translation>現在のバージョンが最新です</translation>
-        </message>
-        <message>
-            <source>GitHub API ERROR: </source>
-            <translation type="vanished">GitHub APIエラー: </translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="933" />
-            <source>Failed to clean up temporary files</source>
-            <translation>一時ファイルのクリーンアップに失敗しました</translation>
-        </message>
-    </context>
-    <context>
-        <name>BundleDetailWidget</name>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="199" />
-            <source>Description</source>
-            <translation>説明</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="205" />
-            <source>No description available</source>
-            <translation>説明は利用できません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="220" />
-            <source>Contact</source>
-            <translation>連絡先</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="224" />
-            <source>No contact information available</source>
-            <translation>連絡先情報は利用できません</translation>
-        </message>
-    </context>
-    <context>
-        <name>BundleInterface</name>
-        <message>
-            <source>Open update log</source>
-            <translation type="vanished">更新ログを開く</translation>
-        </message>
-        <message>
-            <source>Delete bundle</source>
-            <translation type="vanished">バンドルを削除</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="455" />
-            <source>Bundle List</source>
-            <translation>バンドル一覧</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="456" />
-            <source>Bundle Details</source>
-            <translation>バンドル詳細</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="457" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="459" />
-            <source>Auto Update</source>
-            <translation>自動更新</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="460" />
-            <source>Add Bundle</source>
-            <translation>バンドルを追加</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="461" />
-            <source>Update All Bundles</source>
-            <translation>すべてのバンドルを更新</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="463" />
-            <source>Please select a Bundle from the left</source>
-            <translation>左側からバンドルを選択してください</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="591" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="926" />
-            <source>Unknown version</source>
-            <translation>不明なバージョン</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="734" />
-            <source>No license information for this bundle</source>
-            <translation>このバンドルのライセンス情報がありません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="465" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="739" />
-            <source>License</source>
-            <translation>ライセンス</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="781" />
-            <source>No welcome message for this bundle</source>
-            <translation>このバンドルのウェルカムメッセージがありません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="466" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="786" />
-            <source>Welcome</source>
-            <translation>ウェルカム</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1018" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1076" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1298" />
-            <source>Multi-resource adaptation is not enabled. Please enable it in Settings first.</source>
-            <translation>マルチリソース適応が有効になっていません。まず設定で有効にしてください。</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1055" />
-            <source>All bundles are up to date</source>
-            <translation>すべてのバンドルは最新です</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1106" />
-            <source>{count} bundle update(s) failed</source>
-            <translation>{count}件のバンドル更新に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1115" />
-            <source>All updates completed</source>
-            <translation>すべての更新が完了しました</translation>
-        </message>
-        <message>
-            <source>Updating bundle: {bundle_name}</source>
-            <translation type="vanished">バンドルを更新中: {bundle_name}</translation>
-        </message>
-        <message>
-            <source>Bundle '{bundle_name}' updated successfully</source>
-            <translation type="vanished">バンドル '{bundle_name}' が正常に更新されました</translation>
-        </message>
-        <message>
-            <source>Update cancelled: {bundle_name}</source>
-            <translation type="vanished">更新がキャンセルされました: {bundle_name}</translation>
-        </message>
-        <message>
-            <source>Restart required for bundle: {bundle_name}</source>
-            <translation type="vanished">バンドルの再起動が必要です: {bundle_name}</translation>
-        </message>
-        <message>
-            <source>Update failed for bundle: {bundle_name}</source>
-            <translation type="vanished">バンドルの更新に失敗しました: {bundle_name}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1170" />
-            <source>Updating bundle: {}</source>
-            <translation>バンドルを更新中: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1195" />
-            <source>Bundle '{}' updated successfully</source>
-            <translation>バンドル '{}' の更新が完了しました</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1208" />
-            <source>Update cancelled: {}</source>
-            <translation>更新がキャンセルされました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1216" />
-            <source>Restart required for bundle: {}</source>
-            <translation>バンドル {} の再起動が必要です</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1227" />
-            <source>Update failed for bundle: {}</source>
-            <translation>バンドル {} の更新に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1248" />
-            <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
-            <translation>CI/Alphaリソースバージョンでは自動更新が無効です。手動で更新してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1336" />
-            <source>Bundle '{}' added successfully</source>
-            <translation>バンドル '{}' が正常に追加されました</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1379" />
-            <source>No update log</source>
-            <translation>更新ログがありません</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1380" />
-            <source>No update log found locally for this bundle.
+<context>
+    <name></name>
+    <message>
+        <source>Single at {time}</source>
+        <translation type="vanished">{time}に単発</translation>
+    </message>
+    <message>
+        <source>Daily every {n} day(s) at {time}</source>
+        <translation type="vanished">{n}日ごとに毎日 {time}</translation>
+    </message>
+    <message>
+        <source>Weekly every {n} week(s) at {time}</source>
+        <translation type="vanished">{n}週ごとに毎週 {time}</translation>
+    </message>
+    <message>
+        <source>Every month</source>
+        <translation type="vanished">毎月</translation>
+    </message>
+    <message>
+        <source>Last</source>
+        <translation type="vanished">最終</translation>
+    </message>
+    <message>
+        <source>Monthly ({month}) on the {ordinal} {weekday} at {time}</source>
+        <translation type="vanished">毎月（{month}）の第{ordinal}{weekday} {time}</translation>
+    </message>
+    <message>
+        <source>Monthly ({month}) on day {day} at {time}</source>
+        <translation type="vanished">毎月（{month}）の{day}日 {time}</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="vanished">カスタム</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="181"/>
+        <source>GitHub API rate limit exceeded. Please try again later or configure a GitHub Token.</source>
+        <translation>GitHub APIのレート制限に達しました。後でもう一度試すか、GitHub Tokenを設定してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="185"/>
+        <source>GitHub SSL connection failed. Check system time, proxy, or certificate settings.</source>
+        <translation>GitHub SSL接続に失敗しました。システム時刻、プロキシ、または証明書の設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="189"/>
+        <source>GitHub request timed out. Check your network or proxy and try again.</source>
+        <translation>GitHubリクエストがタイムアウトしました。ネットワークまたはプロキシを確認して、もう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="193"/>
+        <source>GitHub domain could not be resolved. Check DNS or network settings.</source>
+        <translation>GitHubドメインを解決できませんでした。DNSまたはネットワーク設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="197"/>
+        <source>GitHub connection failed. Check your network and try again.</source>
+        <translation>GitHub接続に失敗しました。ネットワークを確認して、もう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="200"/>
+        <source>GitHub request was rejected. Check the project URL or permissions.</source>
+        <translation>GitHubリクエストが拒否されました。プロジェクトURLまたは権限を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="202"/>
+        <source>GitHub service is temporarily unavailable. Please try again later.</source>
+        <translation>GitHubサービスが一時的に利用できません。後でもう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="204"/>
+        <source>GitHub returned an invalid response. Please try again later.</source>
+        <translation>GitHubから無効な応答がありました。後でもう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="205"/>
+        <source>GitHub {action} failed. Please try again later.</source>
+        <translation>GitHub {action}に失敗しました。後でもう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="215"/>
+        <source> Will try GitHub source for update check.</source>
+        <translation>更新確認にGitHubソースを使用します。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="222"/>
+        <source>MirrorChyan SSL connection failed. Check system time, proxy, or certificate settings.</source>
+        <translation>MirrorChyan SSL接続に失敗しました。システム時刻、プロキシ、または証明書の設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="226"/>
+        <source>MirrorChyan request timed out. Check your network or proxy.</source>
+        <translation>MirrorChyanリクエストがタイムアウトしました。ネットワークまたはプロキシを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="229"/>
+        <source>MirrorChyan domain could not be resolved. Check DNS or network settings.</source>
+        <translation>MirrorChyanドメインを解決できませんでした。DNSまたはネットワーク設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="232"/>
+        <source>MirrorChyan connection failed. Check your network and try again.</source>
+        <translation>MirrorChyan接続に失敗しました。ネットワークを確認して、もう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="235"/>
+        <source>MirrorChyan request was rejected. Check CDK or resource settings.</source>
+        <translation>MirrorChyanリクエストが拒否されました。CDKまたはリソース設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="238"/>
+        <source>MirrorChyan service is temporarily unavailable.</source>
+        <translation>MirrorChyanサービスが一時的に利用できません。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="241"/>
+        <source>MirrorChyan CDK has expired.</source>
+        <translation>MirrorChyan CDKの有効期限が切れました。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="243"/>
+        <source>MirrorChyan CDK is invalid. Check your CDK in settings.</source>
+        <translation>MirrorChyan CDKが無効です。設定でCDKを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="245"/>
+        <source>MirrorChyan resource quota exhausted.</source>
+        <translation>MirrorChyanリソースの割り当てが枯渇しました。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="247"/>
+        <source>MirrorChyan CDK does not match this resource.</source>
+        <translation>MirrorChyan CDKがこのリソースと一致しません。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="249"/>
+        <source>MirrorChyan resource was not found. Check the resource ID.</source>
+        <translation>MirrorChyanリソースが見つかりませんでした。リソースIDを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="251"/>
+        <source>MirrorChyan OS parameter is invalid for this resource.</source>
+        <translation>MirrorChyan OSパラメータがこのリソースに無効です。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="253"/>
+        <source>MirrorChyan architecture parameter is invalid for this resource.</source>
+        <translation>MirrorChyanアーキテクチャパラメータがこのリソースに無効です。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="255"/>
+        <source>MirrorChyan channel parameter is invalid for this resource.</source>
+        <translation>MirrorChyanチャンネルパラメータがこのリソースに無効です。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="257"/>
+        <source>MirrorChyan request parameters are invalid.</source>
+        <translation>MirrorChyanリクエストパラメータが無効です。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="258"/>
+        <source>MirrorChyan update check failed.</source>
+        <translation>MirrorChyan更新確認に失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="409"/>
+        <source>GitHub download timed out. Check your network or proxy.</source>
+        <translation>GitHubダウンロードがタイムアウトしました。ネットワークまたはプロキシを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="412"/>
+        <source>GitHub download SSL failed. Check certificate or proxy settings.</source>
+        <translation>GitHubダウンロードのSSL接続に失敗しました。証明書またはプロキシ設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="415"/>
+        <source>GitHub download connection failed. Check your network.</source>
+        <translation>GitHubダウンロードの接続に失敗しました。ネットワークを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="416"/>
+        <source>GitHub download failed. Please try again.</source>
+        <translation>GitHubダウンロードに失敗しました。もう一度お試しください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="418"/>
+        <source>MirrorChyan download timed out. Check your network or proxy.</source>
+        <translation>MirrorChyanダウンロードがタイムアウトしました。ネットワークまたはプロキシを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="421"/>
+        <source>MirrorChyan download SSL failed. Check certificate or proxy settings.</source>
+        <translation>MirrorChyanダウンロードのSSL接続に失敗しました。証明書またはプロキシ設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="424"/>
+        <source>MirrorChyan download connection failed. Check your network.</source>
+        <translation>MirrorChyanダウンロードの接続に失敗しました。ネットワークを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="425"/>
+        <source>MirrorChyan download failed. Please try again.</source>
+        <translation>MirrorChyanダウンロードに失敗しました。もう一度お試しください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="269"/>
+        <source>{channel} send failed: SSL error. Check certificate or proxy settings.</source>
+        <translation>{channel}送信失敗: SSLエラー。証明書またはプロキシ設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="272"/>
+        <source>{channel} send failed: request timed out. Check your network.</source>
+        <translation>{channel}送信失敗: リクエストがタイムアウトしました。ネットワークを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="277"/>
+        <source>{channel} send failed: domain could not be resolved. Check DNS settings.</source>
+        <translation>{channel}送信失敗: ドメインを解決できませんでした。DNS設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="281"/>
+        <source>{channel} send failed: connection error. Check server address and network.</source>
+        <translation>{channel}送信失敗: 接続エラー。サーバーアドレスとネットワークを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="285"/>
+        <source>{channel} send failed: request rejected. Check URL, token, or webhook key.</source>
+        <translation>{channel}送信失敗: リクエストが拒否されました。URL、トークン、またはWebhookキーを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="289"/>
+        <source>{channel} send failed: remote service error. Try again later.</source>
+        <translation>{channel}送信失敗: リモートサービスエラー。後でもう一度試してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="293"/>
+        <source>{channel} send failed: invalid response from server. Check configuration.</source>
+        <translation>{channel}送信失敗: サーバーから無効な応答がありました。設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="295"/>
+        <source>{channel} send failed due to a network error.</source>
+        <translation>{channel}送信失敗: ネットワークエラー。</translation>
+    </message>
+    <message>
+        <source>{channel} sent successfully.</source>
+        <translation type="vanished">{channel}送信成功。</translation>
+    </message>
+    <message>
+        <source>{channel} notifications are disabled.</source>
+        <translation type="vanished">{channel}通知が無効になっています。</translation>
+    </message>
+    <message>
+        <source>{channel}: required settings are empty.</source>
+        <translation type="vanished">{channel}: 必要な設定が空です。</translation>
+    </message>
+    <message>
+        <source>{channel}: invalid URL or parameter format.</source>
+        <translation type="vanished">{channel}: URLまたはパラメータ形式が無効です。</translation>
+    </message>
+    <message>
+        <source>{channel} send failed due to a network error. (Network)</source>
+        <translation type="vanished">{channel}送信失敗: ネットワークエラー。</translation>
+    </message>
+    <message>
+        <source>{channel} send failed: server returned an error. Check webhook or token.</source>
+        <translation type="vanished">{channel}送信失敗: サーバーがエラーを返しました。Webhookまたはトークンを確認してください。</translation>
+    </message>
+    <message>
+        <source>{channel}: SMTP port must be a valid number. (Config)</source>
+        <translation type="vanished">{channel}: SMTPポートは有効な数値である必要があります。</translation>
+    </message>
+    <message>
+        <source>{channel} SMTP connection failed. Check server address, port, and credentials. (Connection)</source>
+        <translation type="vanished">{channel} SMTP接続に失敗しました。サーバーアドレス、ポート、認証情報を確認してください。</translation>
+    </message>
+    <message>
+        <source>{channel} send failed with an unknown error. (Unknown)</source>
+        <translation type="vanished">{channel}送信失敗: 不明なエラー。</translation>
+    </message>
+</context>
+<context>
+    <name>AddBundleDialog</name>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1514"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1518"/>
+        <source>Add Resource Bundle</source>
+        <translation>リソースバンドルを追加</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1524"/>
+        <source>Bundle Name:</source>
+        <translation>バンドル名：</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1526"/>
+        <source>Enter the name of the bundle</source>
+        <translation>バンドルの名前を入力してください</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1533"/>
+        <source>Interface File:</source>
+        <translation>インターフェースファイル：</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1536"/>
+        <source>Select interface.json or interface.jsonc file</source>
+        <translation>interface.jsonまたはinterface.jsoncファイルを選択</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1555"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1556"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1573"/>
+        <source>Choose Interface File</source>
+        <translation>インターフェースファイルを選択</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1575"/>
+        <source>Interface Files (interface.json interface.jsonc)</source>
+        <translation>インターフェースファイル (interface.json interface.jsonc)</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1577"/>
+        <source>JSON Files (*.json *.jsonc)</source>
+        <translation>JSONファイル (*.json *.jsonc)</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1579"/>
+        <source>All Files (*)</source>
+        <translation>すべてのファイル (*)</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1594"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1668"/>
+        <source>Please select interface.json or interface.jsonc file</source>
+        <translation>interface.jsonまたはinterface.jsoncファイルを選択してください</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1614"/>
+        <source>Default Bundle</source>
+        <translation>デフォルトバンドル</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1644"/>
+        <source>Interface file path cannot be empty</source>
+        <translation>インターフェースファイルのパスは空にできません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1654"/>
+        <source>Selected interface file does not exist</source>
+        <translation>選択したインターフェースファイルが存在しません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1660"/>
+        <source>Selected path is not a file</source>
+        <translation>選択したパスはファイルではありません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1691"/>
+        <source>Failed to read interface.json: {}</source>
+        <translation>interface.jsonの読み込みに失敗しました：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1697"/>
+        <source>interface.json does not contain a valid &apos;name&apos; field</source>
+        <translation>interface.jsonに有効な&apos;name&apos;フィールドが含まれていません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1707"/>
+        <source>Service is not ready, cannot save bundle</source>
+        <translation>サービスが準備できていないため、バンドルを保存できません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1723"/>
+        <source>Bundle name already exists</source>
+        <translation>バンドル名は既に存在します</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1728"/>
+        <source>Failed to check existing bundles: {}</source>
+        <translation>既存バンドルの確認に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1741"/>
+        <source>Bundle directory does not exist: {}</source>
+        <translation>バンドルディレクトリが存在しません: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1747"/>
+        <source>Bundle path is not a directory: {}</source>
+        <translation>バンドルパスはディレクトリではありません: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1787"/>
+        <source>Cannot move bundle: target directory is inside source directory</source>
+        <translation>バンドルを移動できません: ターゲットディレクトリがソースディレクトリ内にあります</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1816"/>
+        <source>Failed to remove existing bundle directory: {}</source>
+        <translation>既存バンドルディレクトリの削除に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1844"/>
+        <source>Failed to create bundle directory: {}</source>
+        <translation>バンドルディレクトリの作成に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1890"/>
+        <source>Failed to move bundle to target directory: {}</source>
+        <translation>ターゲットディレクトリへのバンドル移動に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1938"/>
+        <source>Failed to update bundle path</source>
+        <translation>バンドルパスの更新に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1943"/>
+        <source>Failed to update bundle path: {}</source>
+        <translation>バンドルパスの更新に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1958"/>
+        <source>An unexpected error occurred: {}</source>
+        <translation>予期しないエラーが発生しました: {}</translation>
+    </message>
+</context>
+<context>
+    <name>AddConfigDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="98"/>
+        <source>Add New Config</source>
+        <translation>新規設定を追加</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="104"/>
+        <source>Config Name:</source>
+        <translation>設定名:</translation>
+    </message>
+    <message>
+        <source>Enter the name of the config</source>
+        <translation type="vanished">設定の名前を入力してください</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="116"/>
+        <source>Resource Bundle:</source>
+        <translation>リソースバンドル:</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="135"/>
+        <source>Preset:</source>
+        <translation>プリセット:</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="226"/>
+        <source>Default (all tasks)</source>
+        <translation>デフォルト (すべてのタスク)</translation>
+    </message>
+    <message>
+        <source>Config name cannot be empty</source>
+        <translation type="vanished">設定名を空にすることはできません</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="107"/>
+        <source>Enter name, or leave empty for auto (preset name + index)</source>
+        <translation>名前を入力するか、空欄のまま自動生成（プリセット名＋インデックス）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="147"/>
+        <source>Import shared config:</source>
+        <translation>共有設定をインポート：</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="149"/>
+        <source>Off</source>
+        <translation>オフ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="150"/>
+        <source>On</source>
+        <translation>オン</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="158"/>
+        <source>Paste shared config content here</source>
+        <translation>共有設定の内容を貼り付け</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="306"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="308"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="401"/>
+        <source>Config</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="310"/>
+        <source>{0} {1}</source>
+        <translation>{0} {1}</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="334"/>
+        <source>Please paste shared config content</source>
+        <translation>共有設定の内容を貼り付けてください</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="339"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="342"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="368"/>
+        <source>Invalid shared config content</source>
+        <translation>無効な共有設定の内容です</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="345"/>
+        <source>Shared config contains no tasks</source>
+        <translation>共有設定にタスクが含まれていません</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="350"/>
+        <source>Please select a resource bundle</source>
+        <translation>リソースバンドルを選択してください</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="362"/>
+        <source>Resource mismatch: shared config is for &quot;{0}&quot;, but you selected &quot;{1}&quot;.</source>
+        <translation>リソースが一致しません：共有設定は「{0}」用ですが、「{1}」が選択されています。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="403"/>
+        <source>New Config</source>
+        <translation>新規設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="406"/>
+        <source>Could not allocate a unique config name</source>
+        <translation>一意な設定名を割り当てられませんでした</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="412"/>
+        <source>Cannot use &apos;default&apos; as config name</source>
+        <translation>設定名に「default」は使用できません</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="427"/>
+        <source>Resource bundle not found</source>
+        <translation>リソースバンドルが見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="453"/>
+        <source>Interface file not found in bundle: {}</source>
+        <translation>バンドル内にインターフェースファイルが見つかりません: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="464"/>
+        <source>Failed to load interface from bundle: {}</source>
+        <translation>バンドルからのインターフェース読み込みに失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="470"/>
+        <source>Controller not found in bundle interface</source>
+        <translation>バンドルインターフェース内にコントローラーが見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="473"/>
+        <source>Resource not found in bundle interface</source>
+        <translation>バンドルインターフェース内にリソースが見つかりません</translation>
+    </message>
+</context>
+<context>
+    <name>AddTaskDialog</name>
+    <message>
+        <source>Framework Built-in Tasks</source>
+        <translation type="vanished">フレームワーク組み込みタスク</translation>
+    </message>
+    <message>
+        <source>Builtin tasks loaded by the framework.</source>
+        <translation type="vanished">フレームワークによって読み込まれた組み込みタスク</translation>
+    </message>
+    <message>
+        <source>Launch Program</source>
+        <translation type="vanished">プログラムを起動</translation>
+    </message>
+    <message>
+        <source>Launch an external program and optionally wait for it to exit.</source>
+        <translation type="vanished">外部プログラムを起動し、必要に応じて終了を待機します。</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation type="vanished">待機</translation>
+    </message>
+    <message>
+        <source>Wait for the specified number of seconds before continuing.</source>
+        <translation type="vanished">指定した秒数だけ待機してから後続タスクを続行します。</translation>
+    </message>
+    <message>
+        <source>Wait Until</source>
+        <translation type="vanished">時刻まで待機</translation>
+    </message>
+    <message>
+        <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
+        <translation type="vanished">指定した時刻まで待機します。HH:MM または YYYY-MM-DD HH:MM に対応しています。</translation>
+    </message>
+    <message>
+        <source>System Notification</source>
+        <translation type="vanished">システム通知</translation>
+    </message>
+    <message>
+        <source>Send a system notification and optionally play the system sound.</source>
+        <translation type="vanished">システム通知を送信し、必要に応じてシステム音を再生します。</translation>
+    </message>
+    <message>
+        <source>External Notification</source>
+        <translation type="vanished">外部通知</translation>
+    </message>
+    <message>
+        <source>Send a message to all currently enabled external notification channels.</source>
+        <translation type="vanished">現在有効なすべての外部通知チャンネルにメッセージを送信します。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="544"/>
+        <source>Add New Task</source>
+        <translation>新規タスクを追加</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="547"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="548"/>
+        <source>Add</source>
+        <translation>追加</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="554"/>
+        <source>Task List</source>
+        <translation>タスク一覧</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="556"/>
+        <source>Select one task from the groups below.</source>
+        <translation>以下のグループからタスクを1つ選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="652"/>
+        <source>Default Group</source>
+        <translation>デフォルトグループ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="653"/>
+        <source>Tasks without an explicit group</source>
+        <translation>明示的なグループがないタスク</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="727"/>
+        <source>{} tasks</source>
+        <translation>{} タスク</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="794"/>
+        <source>Please select a task</source>
+        <translation>タスクを選択してください</translation>
+    </message>
+</context>
+<context>
+    <name>AprilFoolsEasterEgg</name>
+    <message>
+        <source> Checking anti-addiction system...</source>
+        <translation type="vanished"> 依存防止システムをチェック中...</translation>
+    </message>
+    <message>
+        <source> April Fools detected. System verdict: &quot;Limited-time April Fools addiction mode&quot;.</source>
+        <translation type="vanished"> 本日はエイプリルフールのため、システム判定は「期間限定エイプリルフール依存モード」です。</translation>
+    </message>
+    <message>
+        <source> Task execution failed! Reason: You are granted &quot;slacking rights&quot; today. Please grab a coffee manually.</source>
+        <translation type="vanished"> タスク実行失敗！理由：今日は「サボり権」が付与されました。手動でコーヒーを飲みに行ってください。</translation>
+    </message>
+    <message>
+        <source> Just kidding, back to serious work...</source>
+        <translation type="vanished"> うそです。真面目に作業を開始します...</translation>
+    </message>
+    <message>
+        <source> Today&apos;s task progress: ▓▓▓▓▓▓▓▓▓▓ 100%</source>
+        <translation type="vanished"> 本日のタスク進捗: ▓▓▓▓▓▓▓▓▓▓ 100%</translation>
+    </message>
+    <message>
+        <source> Verifying... Verification failed!</source>
+        <translation type="vanished"> 検証中... 検証失敗！</translation>
+    </message>
+    <message>
+        <source> Server fluctuation detected (actually April Fools fluctuation), progress rolled back to 0%.</source>
+        <translation type="vanished"> サーバーの揺らぎを検出（実はエイプリルフール揺らぎ）。進捗は 0% にロールバックされました。</translation>
+    </message>
+    <message>
+        <source> Re-executing...</source>
+        <translation type="vanished"> 再実行中...</translation>
+    </message>
+    <message>
+        <source> [System Notice] Since today is April Fools, all players can claim the limited title &quot;Ultimate Sucker&quot; upon login.</source>
+        <translation type="vanished"> [システム告知] 本日はエイプリルフールのため、ログインした全プレイヤーに限定称号「大冤種」を配布します。</translation>
+    </message>
+    <message>
+        <source> Title claimed automatically. Please restart the game to view it.</source>
+        <translation type="vanished"> 称号は自動受け取り済みです。確認するにはゲームを再起動してください。</translation>
+    </message>
+    <message>
+        <source> Daily task completion: ■■□□□ 40%</source>
+        <translation type="vanished"> デイリー任務達成度：■■□□□ 40%</translation>
+    </message>
+    <message>
+        <source> Injecting April Fools special patch...</source>
+        <translation type="vanished"> エイプリルフール特別パッチを注入中...</translation>
+    </message>
+    <message>
+        <source> Output: sudo rm -rf</source>
+        <translation type="vanished"> 出力結果：sudo rm -rf</translation>
+    </message>
+    <message>
+        <source> Got scared? Back to normal task execution...</source>
+        <translation type="vanished"> びっくりしましたか？通常タスクを実行します...</translation>
+    </message>
+    <message>
+        <source> April Fools detected, enabling &quot;Anti-Boss Mode&quot; automatically.</source>
+        <translation type="vanished"> 本日がエイプリルフールのため、「上司対策モード」を自動で有効化しました。</translation>
+    </message>
+    <message>
+        <source> Taskbar title changed to: &quot;2026 Q2 Quarterly Report - Data Analysis.exe&quot;</source>
+        <translation type="vanished"> タスクバーのタイトルを「2026年Q2四半期レポート - データ分析.exe」に変更しました。</translation>
+    </message>
+    <message>
+        <source>2026 Q2 Quarterly Report - Data Analysis.exe</source>
+        <translation type="vanished">2026年Q2四半期レポート - データ分析.exe</translation>
+    </message>
+    <message>
+        <source> Pretending to load Excel...</source>
+        <translation type="vanished"> Excelを読み込んでいるふりをしています...</translation>
+    </message>
+    <message>
+        <source> Today&apos;s task list: 1. Enter game; 2. Claim rewards; 3. Be kind to yourself.</source>
+        <translation type="vanished"> 本日のタスクリスト：1.ゲーム起動；2.報酬受取；3.自分を大切にする。</translation>
+    </message>
+    <message>
+        <source> The first two are already done for you, please do the third one yourself.</source>
+        <translation type="vanished"> 最初の2項目は代行しました。3項目目はご自身でお願いします。</translation>
+    </message>
+</context>
+<context>
+    <name>BaseAddDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="58"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="59"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="78"/>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+</context>
+<context>
+    <name>BaseListToolBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="72"/>
+        <source>Select All</source>
+        <translation>すべて選択</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="76"/>
+        <source>Deselect All</source>
+        <translation>すべて選択解除</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="80"/>
+        <source>Add</source>
+        <translation>追加</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="84"/>
+        <source>Delete</source>
+        <translation>削除</translation>
+    </message>
+    <message>
+        <source>Switch to Special Tasks</source>
+        <translation type="vanished">特殊タスクに切り替え</translation>
+    </message>
+</context>
+<context>
+    <name>BaseNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="29"/>
+        <source>Test</source>
+        <translation>テスト</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="93"/>
+        <source>decrypt notice key failed: {}，please fill in again and save.</source>
+        <translation>通知キーの復号に失敗しました: {}、再度入力して保存してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="99"/>
+        <source>parse notice key error: {}，please save again.</source>
+        <translation>通知キーの解析エラー: {}、再度保存してください。</translation>
+    </message>
+</context>
+<context>
+    <name>BaseUpdate</name>
+    <message>
+        <location filename="../utils/update.py" line="240"/>
+        <location filename="../utils/update.py" line="272"/>
+        <source>User cancelled</source>
+        <translation>ユーザーがキャンセルしました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="274"/>
+        <source>Download interrupted</source>
+        <translation>ダウンロードが中断されました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="856"/>
+        <source>GitHub API returned an error: {message}</source>
+        <translation>GitHub APIがエラーを返しました: {message}</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="878"/>
+        <source>GitHub returned an invalid response. Please try again later. (Response)</source>
+        <translation>GitHubから無効な応答がありました。後でもう一度試してください。</translation>
+    </message>
+    <message>
+        <source>Update check failed HTTP error,code: </source>
+        <translation type="vanished">更新チェックに失敗しました HTTPエラー、コード: </translation>
+    </message>
+    <message>
+        <source>GitHub API request limit exceeded,please try again later</source>
+        <translation type="vanished">GitHub APIリクエスト制限を超えました、後ほど再試行してください</translation>
+    </message>
+    <message>
+        <source>Github Update check failed HTTP error,code: </source>
+        <translation type="vanished">Github更新チェックに失敗しました HTTPエラー、コード: </translation>
+    </message>
+    <message>
+        <source>MirrorChyan Update check failed SSL error</source>
+        <translation type="vanished">MirrorChyan 更新チェック失敗 SSLエラー</translation>
+    </message>
+    <message>
+        <source>switching to Github download</source>
+        <translation type="vanished">GitHubダウンロードに切り替え中</translation>
+    </message>
+    <message>
+        <source>Github Update check failed SSL error</source>
+        <translation type="vanished">GitHub更新チェック失敗 SSLエラー</translation>
+    </message>
+    <message>
+        <source>INVALID_PARAMS</source>
+        <translation type="vanished">無効なパラメータ</translation>
+    </message>
+    <message>
+        <source>KEY_EXPIRED</source>
+        <translation type="vanished">キー期限切れ</translation>
+    </message>
+    <message>
+        <source>KEY_INVALID</source>
+        <translation type="vanished">無効なキー</translation>
+    </message>
+    <message>
+        <source>RESOURCE_QUOTA_EXHAUSTED</source>
+        <translation type="vanished">リソース割り当て超過</translation>
+    </message>
+    <message>
+        <source>KEY_MISMATCHED</source>
+        <translation type="vanished">キー不一致</translation>
+    </message>
+    <message>
+        <source>RESOURCE_NOT_FOUND</source>
+        <translation type="vanished">リソースが見つかりません</translation>
+    </message>
+    <message>
+        <source>INVALID_OS</source>
+        <translation type="vanished">無効なOS</translation>
+    </message>
+    <message>
+        <source>INVALID_ARCH</source>
+        <translation type="vanished">無効なアーキテクチャ</translation>
+    </message>
+    <message>
+        <source>INVALID_CHANNEL</source>
+        <translation type="vanished">無効なチャンネル</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation type="vanished">不明なエラー</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="835"/>
+        <location filename="../utils/update.py" line="866"/>
+        <source>current version is latest</source>
+        <translation>現在のバージョンが最新です</translation>
+    </message>
+    <message>
+        <source>GitHub API ERROR: </source>
+        <translation type="vanished">GitHub APIエラー: </translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="933"/>
+        <source>Failed to clean up temporary files</source>
+        <translation>一時ファイルのクリーンアップに失敗しました</translation>
+    </message>
+</context>
+<context>
+    <name>BundleDetailWidget</name>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="199"/>
+        <source>Description</source>
+        <translation>説明</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="205"/>
+        <source>No description available</source>
+        <translation>説明は利用できません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="220"/>
+        <source>Contact</source>
+        <translation>連絡先</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="224"/>
+        <source>No contact information available</source>
+        <translation>連絡先情報は利用できません</translation>
+    </message>
+</context>
+<context>
+    <name>BundleInterface</name>
+    <message>
+        <source>Open update log</source>
+        <translation type="vanished">更新ログを開く</translation>
+    </message>
+    <message>
+        <source>Delete bundle</source>
+        <translation type="vanished">バンドルを削除</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="455"/>
+        <source>Bundle List</source>
+        <translation>バンドル一覧</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="456"/>
+        <source>Bundle Details</source>
+        <translation>バンドル詳細</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="457"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="459"/>
+        <source>Auto Update</source>
+        <translation>自動更新</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="460"/>
+        <source>Add Bundle</source>
+        <translation>バンドルを追加</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="461"/>
+        <source>Update All Bundles</source>
+        <translation>すべてのバンドルを更新</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="463"/>
+        <source>Please select a Bundle from the left</source>
+        <translation>左側からバンドルを選択してください</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="591"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="926"/>
+        <source>Unknown version</source>
+        <translation>不明なバージョン</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="734"/>
+        <source>No license information for this bundle</source>
+        <translation>このバンドルのライセンス情報がありません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="465"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="739"/>
+        <source>License</source>
+        <translation>ライセンス</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="781"/>
+        <source>No welcome message for this bundle</source>
+        <translation>このバンドルのウェルカムメッセージがありません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="466"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="786"/>
+        <source>Welcome</source>
+        <translation>ウェルカム</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1018"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1076"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1298"/>
+        <source>Multi-resource adaptation is not enabled. Please enable it in Settings first.</source>
+        <translation>マルチリソース適応が有効になっていません。まず設定で有効にしてください。</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1055"/>
+        <source>All bundles are up to date</source>
+        <translation>すべてのバンドルは最新です</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1106"/>
+        <source>{count} bundle update(s) failed</source>
+        <translation>{count}件のバンドル更新に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1115"/>
+        <source>All updates completed</source>
+        <translation>すべての更新が完了しました</translation>
+    </message>
+    <message>
+        <source>Updating bundle: {bundle_name}</source>
+        <translation type="vanished">バンドルを更新中: {bundle_name}</translation>
+    </message>
+    <message>
+        <source>Bundle &apos;{bundle_name}&apos; updated successfully</source>
+        <translation type="vanished">バンドル &apos;{bundle_name}&apos; が正常に更新されました</translation>
+    </message>
+    <message>
+        <source>Update cancelled: {bundle_name}</source>
+        <translation type="vanished">更新がキャンセルされました: {bundle_name}</translation>
+    </message>
+    <message>
+        <source>Restart required for bundle: {bundle_name}</source>
+        <translation type="vanished">バンドルの再起動が必要です: {bundle_name}</translation>
+    </message>
+    <message>
+        <source>Update failed for bundle: {bundle_name}</source>
+        <translation type="vanished">バンドルの更新に失敗しました: {bundle_name}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1170"/>
+        <source>Updating bundle: {}</source>
+        <translation>バンドルを更新中: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1195"/>
+        <source>Bundle &apos;{}&apos; updated successfully</source>
+        <translation>バンドル &apos;{}&apos; の更新が完了しました</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1208"/>
+        <source>Update cancelled: {}</source>
+        <translation>更新がキャンセルされました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1216"/>
+        <source>Restart required for bundle: {}</source>
+        <translation>バンドル {} の再起動が必要です</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1227"/>
+        <source>Update failed for bundle: {}</source>
+        <translation>バンドル {} の更新に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1248"/>
+        <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
+        <translation>CI/Alphaリソースバージョンでは自動更新が無効です。手動で更新してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1336"/>
+        <source>Bundle &apos;{}&apos; added successfully</source>
+        <translation>バンドル &apos;{}&apos; が正常に追加されました</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1379"/>
+        <source>No update log</source>
+        <translation>更新ログがありません</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1380"/>
+        <source>No update log found locally for this bundle.
 
 Please check for updates first, or visit the GitHub releases page.</source>
-            <translation>このバンドルのローカル更新ログが見つかりませんでした。
+        <translation>このバンドルのローカル更新ログが見つかりませんでした。
 
 まず更新を確認するか、GitHub リリースページをご覧ください。</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1392" />
-            <source>Update Log</source>
-            <translation>更新ログ</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1429" />
-            <source>Failed to find configurations using this bundle: {}</source>
-            <translation>このバンドルを使用する設定が見つかりませんでした: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1437" />
-            <source>Are you sure you want to delete bundle '{}'?
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1392"/>
+        <source>Update Log</source>
+        <translation>更新ログ</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1429"/>
+        <source>Failed to find configurations using this bundle: {}</source>
+        <translation>このバンドルを使用する設定が見つかりませんでした: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1437"/>
+        <source>Are you sure you want to delete bundle &apos;{}&apos;?
 
 The following configurations using this bundle will also be deleted:
 {}</source>
-            <translation>バンドル '{}' を削除してもよろしいですか？
+        <translation>バンドル &apos;{}&apos; を削除してもよろしいですか？
 
 このバンドルを使用する以下の設定も削除されます:
 {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1443" />
-            <source>Are you sure you want to delete bundle '{}'?</source>
-            <translation>バンドル '{}' を削除してもよろしいですか？</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1450" />
-            <source>Delete Bundle</source>
-            <translation>バンドルを削除</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1479" />
-            <source>Bundle '{}' and {} related configuration(s) deleted successfully</source>
-            <translation>バンドル '{}' と {} 件の関連設定が正常に削除されました</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1496" />
-            <source>Failed to delete bundle: {}</source>
-            <translation>バンドルの削除に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1502" />
-            <source>An error occurred while deleting bundle: {}</source>
-            <translation>バンドル削除中にエラーが発生しました: {}</translation>
-        </message>
-    </context>
-    <context>
-        <name>BundleListItem</name>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="133" />
-            <source>Open update log</source>
-            <translation>更新ログを開く</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="142" />
-            <source>Delete bundle</source>
-            <translation>バンドルを削除</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="154" />
-            <source>Latest version: {}</source>
-            <translation>最新バージョン: {}</translation>
-        </message>
-    </context>
-    <context>
-        <name>CallbackLogProcessor</name>
-        <message>
-            <location filename="../core/log_processor.py" line="38" />
-            <source>screenshot test success, time: </source>
-            <translation>スクリーンショットテスト成功、時間: </translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="76" />
-            <source>Resource Loading Failed</source>
-            <translation>リソース読み込み失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="83" />
-            <source>Controller Started Connect</source>
-            <translation>コントローラー接続開始</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="86" />
-            <source>Controller Connect Failed</source>
-            <translation>コントローラー接続失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="92" />
-            <source>Unknown Task</source>
-            <translation>不明なタスク</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="97" />
-            <source>Task started execution: </source>
-            <translation>タスク実行開始: </translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="100" />
-            <source>Task execution failed: </source>
-            <translation>タスク実行失敗: </translation>
-        </message>
-    </context>
-    <context>
-        <name>ConfigListItem</name>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1103" />
-            <source>Rename config</source>
-            <translation>設定名変更</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1108" />
-            <source>Copy config ID</source>
-            <translation>設定IDコピー</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1113" />
-            <source>Share config</source>
-            <translation>設定を共有</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1188" />
-            <source>Failed to load config for sharing.</source>
-            <translation>共有用の設定の読み込みに失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1195" />
-            <source>Config has no resource bundle, cannot share.</source>
-            <translation>設定にリソースバンドルがないため、共有できません。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1211" />
-            <location filename="../view/task_interface/components/list_item.py" line="1216" />
-            <source>Failed to encode config for sharing.</source>
-            <translation>共有用の設定のエンコードに失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1222" />
-            <source>Config copied to clipboard.</source>
-            <translation>設定をクリップボードにコピーしました。</translation>
-        </message>
-    </context>
-    <context>
-        <name>ConfigListToolBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="139" />
-            <source>Configurations</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="184" />
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="253" />
-            <source>Task is running, configurations are locked.</source>
-            <translation>タスク実行中、設定はロックされています。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="239" />
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="240" />
-            <source>unknown</source>
-            <translation>不明</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="244" />
-            <source>Shared config version ({0}) differs from current resource version ({1}); imported anyway.</source>
-            <translation>共有設定のバージョン（{0}）が現在のリソースバージョン（{1}）と異なりますが、インポートしました。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="259" />
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="262" />
-            <source>Cannot delete the last configuration!</source>
-            <translation>最後の設定は削除できません！</translation>
-        </message>
-    </context>
-    <context>
-        <name>ControllerSettingWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="841" />
-            <source>Controller Type</source>
-            <translation>コントローラータイプ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="842" />
-            <source>this controller requires admin permission to run</source>
-            <translation>このコントローラーは管理者権限が必要です</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="898" />
-            <source>Search Device</source>
-            <translation>デバイス検索</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="912" />
-            <source>Agent Timeout</source>
-            <translation>エージェントタイムアウト</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="916" />
-            <source>-1 means infinite</source>
-            <translation>-1は無制限を意味します</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="958" />
-            <source>Custom Module Path</source>
-            <translation>カスタムモジュールパス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="967" />
-            <source>GPU Acceleration</source>
-            <translation>GPUアクセラレーション</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="987" />
-            <source>Auto</source>
-            <translation>自動</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="988" />
-            <source>CPU</source>
-            <translation>CPU</translation>
-        </message>
-        <message>
-            <source>Description: No specific method (Null).
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1443"/>
+        <source>Are you sure you want to delete bundle &apos;{}&apos;?</source>
+        <translation>バンドル &apos;{}&apos; を削除してもよろしいですか？</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1450"/>
+        <source>Delete Bundle</source>
+        <translation>バンドルを削除</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1479"/>
+        <source>Bundle &apos;{}&apos; and {} related configuration(s) deleted successfully</source>
+        <translation>バンドル &apos;{}&apos; と {} 件の関連設定が正常に削除されました</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1496"/>
+        <source>Failed to delete bundle: {}</source>
+        <translation>バンドルの削除に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1502"/>
+        <source>An error occurred while deleting bundle: {}</source>
+        <translation>バンドル削除中にエラーが発生しました: {}</translation>
+    </message>
+</context>
+<context>
+    <name>BundleListItem</name>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="133"/>
+        <source>Open update log</source>
+        <translation>更新ログを開く</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="142"/>
+        <source>Delete bundle</source>
+        <translation>バンドルを削除</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="154"/>
+        <source>Latest version: {}</source>
+        <translation>最新バージョン: {}</translation>
+    </message>
+</context>
+<context>
+    <name>CallbackLogProcessor</name>
+    <message>
+        <location filename="../core/log_processor.py" line="38"/>
+        <source>screenshot test success, time: </source>
+        <translation>スクリーンショットテスト成功、時間: </translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="76"/>
+        <source>Resource Loading Failed</source>
+        <translation>リソース読み込み失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="83"/>
+        <source>Controller Started Connect</source>
+        <translation>コントローラー接続開始</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="86"/>
+        <source>Controller Connect Failed</source>
+        <translation>コントローラー接続失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="92"/>
+        <source>Unknown Task</source>
+        <translation>不明なタスク</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="97"/>
+        <source>Task started execution: </source>
+        <translation>タスク実行開始: </translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="100"/>
+        <source>Task execution failed: </source>
+        <translation>タスク実行失敗: </translation>
+    </message>
+</context>
+<context>
+    <name>ConfigListItem</name>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1016"/>
+        <source>Running</source>
+        <translation>実行中</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1124"/>
+        <source>Rename config</source>
+        <translation>設定名変更</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1129"/>
+        <source>Copy config ID</source>
+        <translation>設定IDコピー</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1134"/>
+        <source>Share config</source>
+        <translation>設定を共有</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1209"/>
+        <source>Failed to load config for sharing.</source>
+        <translation>共有用の設定の読み込みに失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1216"/>
+        <source>Config has no resource bundle, cannot share.</source>
+        <translation>設定にリソースバンドルがないため、共有できません。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1232"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1237"/>
+        <source>Failed to encode config for sharing.</source>
+        <translation>共有用の設定のエンコードに失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1243"/>
+        <source>Config copied to clipboard.</source>
+        <translation>設定をクリップボードにコピーしました。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigListToolBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="139"/>
+        <source>Configurations</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="203"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="272"/>
+        <source>Task is running, configurations are locked.</source>
+        <translation>タスク実行中、設定はロックされています。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="258"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="259"/>
+        <source>unknown</source>
+        <translation>不明</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="263"/>
+        <source>Shared config version ({0}) differs from current resource version ({1}); imported anyway.</source>
+        <translation>共有設定のバージョン（{0}）が現在のリソースバージョン（{1}）と異なりますが、インポートしました。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="278"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="281"/>
+        <source>Cannot delete the last configuration!</source>
+        <translation>最後の設定は削除できません！</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigMonitorTile</name>
+    <message>
+        <location filename="../view/monitor_interface/multi_config_monitor_grid.py" line="99"/>
+        <source>Running</source>
+        <translation>実行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/multi_config_monitor_grid.py" line="129"/>
+        <source>Not running</source>
+        <translation>未実行</translation>
+    </message>
+</context>
+<context>
+    <name>ControllerSettingWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="841"/>
+        <source>Controller Type</source>
+        <translation>コントローラータイプ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="842"/>
+        <source>this controller requires admin permission to run</source>
+        <translation>このコントローラーは管理者権限が必要です</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="898"/>
+        <source>Search Device</source>
+        <translation>デバイス検索</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="912"/>
+        <source>Agent Timeout</source>
+        <translation>エージェントタイムアウト</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="916"/>
+        <source>-1 means infinite</source>
+        <translation>-1は無制限を意味します</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="958"/>
+        <source>Custom Module Path</source>
+        <translation>カスタムモジュールパス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="967"/>
+        <source>GPU Acceleration</source>
+        <translation>GPUアクセラレーション</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="987"/>
+        <source>Auto</source>
+        <translation>自動</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="988"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <source>Description: No specific method (Null).
 Speed: Depends on framework fallback.
 Mouse capture: N/A (desktop).
 Compatibility: Framework-defined.
 Admin rights: Usually not required; elevate if the target process runs elevated.</source>
-            <translation type="vanished">説明: 特定のメソッドなし（Null）。
+        <translation type="vanished">説明: 特定のメソッドなし（Null）。
 速度: フレームワークのフォールバックに依存。
 マウスキャプチャ: なし（デスクトップ）。
 互換性: フレームワーク定義。
 管理者権限: 通常不要。対象プロセスが昇格している場合は昇格が必要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1118" />
-            <source>(No description for this category.)</source>
-            <translation>（このカテゴリの説明はありません。）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1123" />
-            <source>Description: Injects input on the target window thread; closest to real mouse/keyboard.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1118"/>
+        <source>(No description for this category.)</source>
+        <translation>（このカテゴリの説明はありません。）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1123"/>
+        <source>Description: Injects input on the target window thread; closest to real mouse/keyboard.
 Speed: Fast.
 Mouse capture: Yes (continuous capture of the window input queue).
 Compatibility: High.
 Admin rights: Usually not required; match elevation if the target runs elevated.</source>
-            <translation>説明: 対象ウィンドウのスレッドに入力を注入。実際のマウス/キーボードに最も近い。
+        <translation>説明: 対象ウィンドウのスレッドに入力を注入。実際のマウス/キーボードに最も近い。
 速度: 高速。
 マウスキャプチャ: あり（ウィンドウ入力キューの継続的キャプチャ）。
 互換性: 高。
 管理者権限: 通常不要。対象が昇格している場合は昇格を合わせる。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1131" />
-            <source>Description: Synchronously posts window messages via SendMessage.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1131"/>
+        <source>Description: Synchronously posts window messages via SendMessage.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Medium; some games/anti-cheat ignore synthetic messages.
 Admin rights: Often depends on the target process (elevated targets need an elevated client).</source>
-            <translation>説明: SendMessage でウィンドウメッセージを同期的に送信。
+        <translation>説明: SendMessage でウィンドウメッセージを同期的に送信。
 速度: 中。
 マウスキャプチャ: なし。
 互換性: 中。一部のゲーム/アンチチートは合成メッセージを無視。
 管理者権限: 対象プロセスに依存（昇格対象には昇格クライアントが必要）。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1139" />
-            <source>Description: Asynchronously posts window messages via PostMessage.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1139"/>
+        <source>Description: Asynchronously posts window messages via PostMessage.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Medium; some games/anti-cheat ignore synthetic messages.
 Admin rights: Often depends on the target process (elevated targets need an elevated client).</source>
-            <translation>説明: PostMessage でウィンドウメッセージを非同期的に送信。
+        <translation>説明: PostMessage でウィンドウメッセージを非同期的に送信。
 速度: 中。
 マウスキャプチャ: なし。
 互換性: 中。一部のゲーム/アンチチートは合成メッセージを無視。
 管理者権限: 対象プロセスに依存（昇格対象には昇格クライアントが必要）。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1147" />
-            <source>Description: Legacy event-injection path.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1147"/>
+        <source>Description: Legacy event-injection path.
 Speed: Medium.
 Mouse capture: Yes.
 Compatibility: Low.
 Admin rights: Usually not required; depends on the target process.</source>
-            <translation>説明: レガシーイベント注入パス。
+        <translation>説明: レガシーイベント注入パス。
 速度: 中。
 マウスキャプチャ: あり。
 互換性: 低。
 管理者権限: 通常不要。対象プロセスに依存。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1155" />
-            <source>Description: Posts messages to the window's owning thread.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1155"/>
+        <source>Description: Posts messages to the window&apos;s owning thread.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Low.
 Admin rights: Often depends on the target process.</source>
-            <translation>説明: ウィンドウを所有するスレッドにメッセージを送信。
+        <translation>説明: ウィンドウを所有するスレッドにメッセージを送信。
 速度: 中。
 マウスキャプチャ: なし。
 互換性: 低。
 管理者権限: 対象プロセスに依存。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1163" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1171" />
-            <source>Description: Briefly moves the cursor to the target point, sends the message, then restores the cursor.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1163"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1171"/>
+        <source>Description: Briefly moves the cursor to the target point, sends the message, then restores the cursor.
 Speed: Medium.
 Mouse capture: Brief cursor movement.
 Compatibility: Medium.
 Admin rights: Often depends on the target process.</source>
-            <translation>説明: カーソルを対象点に一時移動、メッセージ送信後、カーソルを復元。
+        <translation>説明: カーソルを対象点に一時移動、メッセージ送信後、カーソルを復元。
 速度: 中。
 マウスキャプチャ: 一時的なカーソル移動。
 互換性: 中。
 管理者権限: 対象プロセスに依存。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1179" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1187" />
-            <source>Description: Briefly moves the window so the target aligns with the current cursor, sends the message, then restores the window.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1179"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1187"/>
+        <source>Description: Briefly moves the window so the target aligns with the current cursor, sends the message, then restores the window.
 Speed: Medium.
 Mouse capture: No (the window moves, not the cursor).
 Compatibility: Medium; may fail for fullscreen or locked-layout games.
 Admin rights: Often depends on the target process.</source>
-            <translation>説明: ウィンドウを一時移動して対象を現在のカーソルに合わせ、メッセージ送信後、ウィンドウを復元。
+        <translation>説明: ウィンドウを一時移動して対象を現在のカーソルに合わせ、メッセージ送信後、ウィンドウを復元。
 速度: 中。
 マウスキャプチャ: なし（カーソルではなくウィンドウが移動）。
 互換性: 中。フルスクリーンやレイアウト固定のゲームでは失敗する可能性あり。
 管理者権限: 対象プロセスに依存。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1108" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1193" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1273" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1354" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1405" />
-            <source>(No description for this method.)</source>
-            <translation>（このメソッドの説明はありません。）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="938" />
-            <source>Embedded Agent Mode</source>
-            <translation>埋め込みエージェントモード</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="940" />
-            <source>On</source>
-            <translation>オン</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="941" />
-            <source>Off</source>
-            <translation>オフ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1198" />
-            <source>Description: GDI capture of the window client area.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1108"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1193"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1273"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1354"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1405"/>
+        <source>(No description for this method.)</source>
+        <translation>（このメソッドの説明はありません。）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="938"/>
+        <source>Embedded Agent Mode</source>
+        <translation>埋め込みエージェントモード</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="940"/>
+        <source>On</source>
+        <translation>オン</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="941"/>
+        <source>Off</source>
+        <translation>オフ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1198"/>
+        <source>Description: GDI capture of the window client area.
 Speed: Fast.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.
 Background: Often fails while minimized.</source>
-            <translation>説明: GDI によるウィンドウクライアント領域のキャプチャ。
+        <translation>説明: GDI によるウィンドウクライアント領域のキャプチャ。
 速度: 高速。
 マウスキャプチャ: なし。
 互換性: 中。
 管理者権限: 通常不要。
 背景: 最小化中は失敗することが多い。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1207" />
-            <source>Description: Windows.Graphics.Capture (Windows 10 1903+).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1207"/>
+        <source>Description: Windows.Graphics.Capture (Windows 10 1903+).
 Speed: Very fast.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.
 Background: Better for pseudo-minimized / quasi-background capture.</source>
-            <translation>説明: Windows.Graphics.Capture（Windows 10 1903+）。
+        <translation>説明: Windows.Graphics.Capture（Windows 10 1903+）。
 速度: 非常に高速。
 マウスキャプチャ: なし。
 互換性: 中。
 管理者権限: 通常不要。
 背景: 擬似最小化/準バックグラウンドキャプチャに適している。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1216" />
-            <source>Description: DXGI desktop duplication (full screen) then crop.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1216"/>
+        <source>Description: DXGI desktop duplication (full screen) then crop.
 Speed: Very fast.
 Mouse capture: No.
 Compatibility: Lower (drivers / multi-GPU sensitive).
 Admin rights: Usually not required.
 Background: Full-screen duplication; not window-exclusive.</source>
-            <translation>説明: DXGI デスクトップ複製（全画面）をクロップ。
+        <translation>説明: DXGI デスクトップ複製（全画面）をクロップ。
 速度: 非常に高速。
 マウスキャプチャ: なし。
 互換性: 低め（ドライバー/マルチGPUに敏感）。
 管理者権限: 通常不要。
 背景: 全画面複製。ウィンドウ限定ではない。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1225" />
-            <source>Description: Desktop duplication cropped to the window region.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1225"/>
+        <source>Description: Desktop duplication cropped to the window region.
 Speed: Very fast.
 Mouse capture: No.
 Compatibility: Lower.
 Admin rights: Usually not required.</source>
-            <translation>説明: デスクトップ複製をウィンドウ領域にクロップ。
+        <translation>説明: デスクトップ複製をウィンドウ領域にクロップ。
 速度: 非常に高速。
 マウスキャプチャ: なし。
 互換性: 低め。
 管理者権限: 通常不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1233" />
-            <source>Description: Capture via PrintWindow and related paths.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1233"/>
+        <source>Description: Capture via PrintWindow and related paths.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.
 Background: Friendlier to pseudo-minimized scenarios.</source>
-            <translation>説明: PrintWindow および関連パスによるキャプチャ。
+        <translation>説明: PrintWindow および関連パスによるキャプチャ。
 速度: 中。
 マウスキャプチャ: なし。
 互換性: 中。
 管理者権限: 通常不要。
 背景: 擬似最小化シナリオに適している。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1242" />
-            <source>Description: Screen DC and other compatible paths.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1242"/>
+        <source>Description: Screen DC and other compatible paths.
 Speed: Fast.
 Mouse capture: No.
 Compatibility: High.
 Admin rights: Usually not required.
 Background: Mostly foreground-oriented.</source>
-            <translation>説明: Screen DC およびその他の互換パス。
+        <translation>説明: Screen DC およびその他の互換パス。
 速度: 高速。
 マウスキャプチャ: なし。
 互換性: 高。
 管理者権限: 通常不要。
 背景: 主にフォアグラウンド向け。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1251" />
-            <source>Description: Foreground preset (DXGI_DesktopDup_Window | ScreenDC).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1251"/>
+        <source>Description: Foreground preset (DXGI_DesktopDup_Window | ScreenDC).
 Speed: Fast.
 Mouse capture: No.
 Compatibility: Medium to low.
 Admin rights: Usually not required.</source>
-            <translation>説明: フォアグラウンドプリセット（DXGI_DesktopDup_Window | ScreenDC）。
+        <translation>説明: フォアグラウンドプリセット（DXGI_DesktopDup_Window | ScreenDC）。
 速度: 高速。
 マウスキャプチャ: なし。
 互換性: 中～低。
 管理者権限: 通常不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1259" />
-            <source>Description: Background preset (FramePool | PrintWindow).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1259"/>
+        <source>Description: Background preset (FramePool | PrintWindow).
 Speed: Fast.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.</source>
-            <translation>説明: バックグラウンドプリセット（FramePool | PrintWindow）。
+        <translation>説明: バックグラウンドプリセット（FramePool | PrintWindow）。
 速度: 高速。
 マウスキャプチャ: なし。
 互換性: 中。
 管理者権限: 通常不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1267" />
-            <source>Description: Bitwise OR of all Win32 capture flags.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1267"/>
+        <source>Description: Bitwise OR of all Win32 capture flags.
 Speed: Framework picks the fastest available method.
 Mouse capture: No.
 Compatibility: Varies by combination.
 Admin rights: Usually not required.</source>
-            <translation>説明: すべての Win32 キャプチャフラグのビット単位 OR。
+        <translation>説明: すべての Win32 キャプチャフラグのビット単位 OR。
 速度: フレームワークが利用可能な最速メソッドを選択。
 マウスキャプチャ: なし。
 互換性: 組み合わせにより異なる。
 管理者権限: 通常不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1278" />
-            <source>Description: Encodes to a file on the device, then adb pull.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1278"/>
+        <source>Description: Encodes to a file on the device, then adb pull.
 Speed: Slow.
 Mouse capture: N/A (device-side).
 Compatibility: High.
 Admin rights: Not required on PC; USB debugging authorization on the device.
 Encoding: Lossless.</source>
-            <translation>説明: デバイス上のファイルにエンコード後、adb pull。
+        <translation>説明: デバイス上のファイルにエンコード後、adb pull。
 速度: 低速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 高。
 管理者権限: PCでは不要。デバイスでUSBデバッグ認証が必要。
 エンコード: ロスレス。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1287" />
-            <source>Description: Encoded stream pulled over the adb pipe.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1287"/>
+        <source>Description: Encoded stream pulled over the adb pipe.
 Speed: Slow.
 Mouse capture: N/A (device-side).
 Compatibility: High.
 Admin rights: Not required.
 Encoding: Lossless.</source>
-            <translation>説明: adb パイプ経由でエンコードストリームを取得。
+        <translation>説明: adb パイプ経由でエンコードストリームを取得。
 速度: 低速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 高。
 管理者権限: 不要。
 エンコード: ロスレス。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1296" />
-            <source>Description: Raw frames with gzip compression.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1296"/>
+        <source>Description: Raw frames with gzip compression.
 Speed: Medium.
 Mouse capture: N/A (device-side).
 Compatibility: High.
 Admin rights: Not required.
 Encoding: Lossless.</source>
-            <translation>説明: gzip 圧縮の生フレーム。
+        <translation>説明: gzip 圧縮の生フレーム。
 速度: 中。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 高。
 管理者権限: 不要。
 エンコード: ロスレス。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1305" />
-            <source>Description: Raw frames over netcat.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1305"/>
+        <source>Description: Raw frames over netcat.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low (environment-dependent).
 Admin rights: Not required.</source>
-            <translation>説明: netcat 経由の生フレーム。
+        <translation>説明: netcat 経由の生フレーム。
 速度: 高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 低（環境依存）。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1313" />
-            <source>Description: Minicap direct connection.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1313"/>
+        <source>Description: Minicap direct connection.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low.
 Admin rights: Not required.
 Encoding: Lossy JPEG; may hurt template matching — not recommended.</source>
-            <translation>説明: Minicap 直接接続。
+        <translation>説明: Minicap 直接接続。
 速度: 高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 低。
 管理者権限: 不要。
 エンコード: 非可逆JPEG。テンプレートマッチングに悪影響を与える可能性があるため非推奨。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1322" />
-            <source>Description: Minicap streaming.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1322"/>
+        <source>Description: Minicap streaming.
 Speed: Very fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low.
 Admin rights: Not required.
 Encoding: Lossy JPEG — not recommended.</source>
-            <translation>説明: Minicap ストリーミング。
+        <translation>説明: Minicap ストリーミング。
 速度: 非常に高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 低。
 管理者権限: 不要。
 エンコード: 非可逆JPEG。非推奨。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1331" />
-            <source>Description: Emulator-specific fast path (e.g. MuMu 12, LDPlayer 9).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1331"/>
+        <source>Description: Emulator-specific fast path (e.g. MuMu 12, LDPlayer 9).
 Speed: Very fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low (specific emulators).
 Admin rights: Not required.
 Encoding: Lossless.</source>
-            <translation>説明: エミュレータ固有の高速パス（例: MuMu 12、LDPlayer 9）。
+        <translation>説明: エミュレータ固有の高速パス（例: MuMu 12、LDPlayer 9）。
 速度: 非常に高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 低（特定エミュレータ）。
 管理者権限: 不要。
 エンコード: ロスレス。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1340" />
-            <source>Description: All ADB capture flags enabled; framework benchmarks and picks one.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1340"/>
+        <source>Description: All ADB capture flags enabled; framework benchmarks and picks one.
 Speed: Fastest available on the device.
 Mouse capture: N/A (device-side).
 Compatibility: Device-dependent.
 Admin rights: Not required.</source>
-            <translation>説明: すべての ADB キャプチャフラグを有効化。フレームワークがベンチマークし、一つを選択。
+        <translation>説明: すべての ADB キャプチャフラグを有効化。フレームワークがベンチマークし、一つを選択。
 速度: デバイスで利用可能な最速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: デバイス依存。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1348" />
-            <source>Description: Framework default flag set (typically excludes netcat and lossy Minicap).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1348"/>
+        <source>Description: Framework default flag set (typically excludes netcat and lossy Minicap).
 Speed: Best within the default set.
 Mouse capture: N/A (device-side).
 Compatibility: Medium to high.
 Admin rights: Not required.</source>
-            <translation>説明: フレームワークのデフォルトフラグセット（通常 netcat と非可逆 Minicap を除外）。
+        <translation>説明: フレームワークのデフォルトフラグセット（通常 netcat と非可逆 Minicap を除外）。
 速度: デフォルトセット内で最良。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 中～高。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1359" />
-            <source>Description: Standard adb shell input commands.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1359"/>
+        <source>Description: Standard adb shell input commands.
 Speed: Slow.
 Mouse capture: N/A (injected on the device).
 Compatibility: High.
 Admin rights: Not required.</source>
-            <translation>説明: 標準の adb shell input コマンド。
+        <translation>説明: 標準の adb shell input コマンド。
 速度: 低速。
 マウスキャプチャ: なし（デバイスに注入）。
 互換性: 高。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1367" />
-            <source>Description: Minitouch with adb key fallback.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1367"/>
+        <source>Description: Minitouch with adb key fallback.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Medium.
 Admin rights: Not required.</source>
-            <translation>説明: Minitouch + adb key フォールバック。
+        <translation>説明: Minitouch + adb key フォールバック。
 速度: 高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 中。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1375" />
-            <source>Description: Maatouch protocol for touch injection.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1375"/>
+        <source>Description: Maatouch protocol for touch injection.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Medium.
 Admin rights: Not required.</source>
-            <translation>説明: タッチ注入用 Maatouch プロトコル。
+        <translation>説明: タッチ注入用 Maatouch プロトコル。
 速度: 高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 中。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1383" />
-            <source>Description: Emulator extras (e.g. MuMu 12).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1383"/>
+        <source>Description: Emulator extras (e.g. MuMu 12).
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low (specific emulators).
 Admin rights: Not required.</source>
-            <translation>説明: エミュレータ拡張（例: MuMu 12）。
+        <translation>説明: エミュレータ拡張（例: MuMu 12）。
 速度: 高速。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 低（特定エミュレータ）。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1391" />
-            <source>Description: All ADB input flags; order EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1391"/>
+        <source>Description: All ADB input flags; order EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell.
 Speed: First available wins.
 Mouse capture: N/A (device-side).
 Compatibility: Device-dependent.
 Admin rights: Not required.</source>
-            <translation>説明: すべての ADB 入力フラグ。優先順位: EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell。
+        <translation>説明: すべての ADB 入力フラグ。優先順位: EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell。
 速度: 最初に利用可能なものが使用される。
 マウスキャプチャ: なし（デバイス側）。
 互換性: デバイス依存。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1399" />
-            <source>Description: Default set with EmulatorExtras disabled; remaining methods by priority.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1399"/>
+        <source>Description: Default set with EmulatorExtras disabled; remaining methods by priority.
 Speed: Device-dependent.
 Mouse capture: N/A (device-side).
 Compatibility: Medium to high.
 Admin rights: Not required.</source>
-            <translation>説明: EmulatorExtras を無効にしたデフォルトセット。残りのメソッドを優先順位で使用。
+        <translation>説明: EmulatorExtras を無効にしたデフォルトセット。残りのメソッドを優先順位で使用。
 速度: デバイス依存。
 マウスキャプチャ: なし（デバイス側）。
 互換性: 中～高。
 管理者権限: 不要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1437" />
-            <source>ADB Path</source>
-            <translation>ADBパス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1444" />
-            <source>ADB Address</source>
-            <translation>ADBアドレス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1450" />
-            <source>Emulator Path</source>
-            <translation>エミュレーターパス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1457" />
-            <source>Emulator Params</source>
-            <translation>エミュレーターパラメータ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1463" />
-            <source>Wait for Emulator StartUp Time</source>
-            <translation>エミュレーター起動待機時間</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1475" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1550" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1644" />
-            <source>Screencap Method</source>
-            <translation>スクリーンキャプチャ方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1484" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1650" />
-            <source>Input Method</source>
-            <translation>入力方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1493" />
-            <source>Special Config</source>
-            <translation>特別設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1508" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1567" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1624" />
-            <source>Program Path</source>
-            <translation>プログラムのパス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1515" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1574" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1630" />
-            <source>Program Params</source>
-            <translation>プログラムパラメータ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1521" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1580" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1635" />
-            <source>Wait for Launch Time</source>
-            <translation>起動待機時間</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1533" />
-            <source>Mouse Input Method</source>
-            <translation>マウス入力方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1541" />
-            <source>Keyboard Input Method</source>
-            <translation>キーボード入力方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1591" />
-            <source>Gamepad Type</source>
-            <translation>ゲームパッドタイプ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1601" />
-            <source>Address</source>
-            <translation>アドレス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1610" />
-            <source>Wayland Socket Path</source>
-            <translation>Waylandソケットパス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1619" />
-            <source>Window ID</source>
-            <translation>ウィンドウID</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2135" />
-            <source>Unknown Device</source>
-            <translation>不明なデバイス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2204" />
-            <source>No ADB devices were found. Please check emulator or device connection.</source>
-            <translation>ADBデバイスが見つかりませんでした。エミュレーターまたはデバイスの接続を確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2208" />
-            <source>No desktop windows were found that match the filter.</source>
-            <translation>フィルターに一致するデスクトップウィンドウが見つかりませんでした。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2211" />
-            <source>No devices were found for current controller type.</source>
-            <translation>現在のコントローラータイプに対応するデバイスが見つかりませんでした。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DashboardInterface</name>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="669" />
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="673" />
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="678" />
-            <source>A More Modern Console Interface</source>
-            <translation>よりモダンなコンソールインターフェース</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="562" />
-            <source>Update Log</source>
-            <translation>更新ログ</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="514" />
-            <source>FrameWork Version</source>
-            <translation>フレームワーク バージョン</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="570" />
-            <source>No update log found locally.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1437"/>
+        <source>ADB Path</source>
+        <translation>ADBパス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1444"/>
+        <source>ADB Address</source>
+        <translation>ADBアドレス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1450"/>
+        <source>Emulator Path</source>
+        <translation>エミュレーターパス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1457"/>
+        <source>Emulator Params</source>
+        <translation>エミュレーターパラメータ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1463"/>
+        <source>Wait for Emulator StartUp Time</source>
+        <translation>エミュレーター起動待機時間</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1475"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1550"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1644"/>
+        <source>Screencap Method</source>
+        <translation>スクリーンキャプチャ方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1484"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1650"/>
+        <source>Input Method</source>
+        <translation>入力方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1493"/>
+        <source>Special Config</source>
+        <translation>特別設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1508"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1567"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1624"/>
+        <source>Program Path</source>
+        <translation>プログラムのパス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1515"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1574"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1630"/>
+        <source>Program Params</source>
+        <translation>プログラムパラメータ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1521"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1580"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1635"/>
+        <source>Wait for Launch Time</source>
+        <translation>起動待機時間</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1533"/>
+        <source>Mouse Input Method</source>
+        <translation>マウス入力方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1541"/>
+        <source>Keyboard Input Method</source>
+        <translation>キーボード入力方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1591"/>
+        <source>Gamepad Type</source>
+        <translation>ゲームパッドタイプ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1601"/>
+        <source>Address</source>
+        <translation>アドレス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1610"/>
+        <source>Wayland Socket Path</source>
+        <translation>Waylandソケットパス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1619"/>
+        <source>Window ID</source>
+        <translation>ウィンドウID</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2135"/>
+        <source>Unknown Device</source>
+        <translation>不明なデバイス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2204"/>
+        <source>No ADB devices were found. Please check emulator or device connection.</source>
+        <translation>ADBデバイスが見つかりませんでした。エミュレーターまたはデバイスの接続を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2208"/>
+        <source>No desktop windows were found that match the filter.</source>
+        <translation>フィルターに一致するデスクトップウィンドウが見つかりませんでした。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2211"/>
+        <source>No devices were found for current controller type.</source>
+        <translation>現在のコントローラータイプに対応するデバイスが見つかりませんでした。</translation>
+    </message>
+</context>
+<context>
+    <name>DashboardInterface</name>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="669"/>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="673"/>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="678"/>
+        <source>A More Modern Console Interface</source>
+        <translation>よりモダンなコンソールインターフェース</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="562"/>
+        <source>Update Log</source>
+        <translation>更新ログ</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="514"/>
+        <source>FrameWork Version</source>
+        <translation>フレームワーク バージョン</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="570"/>
+        <source>No update log found locally.
 
 Please check for updates first, or visit the GitHub releases page.</source>
-            <translation>ローカルに更新ログが見つかりません。
+        <translation>ローカルに更新ログが見つかりません。
 
 まず更新を確認するか、GitHubのリリースページをご覧ください。</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="593" />
-            <source>View full changelog in Settings &gt; Open update log.</source>
-            <translation>完全な変更履歴は「設定 &gt; 更新ログを開く」で確認できます。</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="609" />
-            <source>Task</source>
-            <translation>タスク</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="610" />
-            <source>Configure and execute automation tasks</source>
-            <translation>自動化タスクを設定して実行します</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="612" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="617" />
-            <source>Monitor</source>
-            <translation>モニター</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="618" />
-            <source>View real-time frames and runtime status</source>
-            <translation>リアルタイム画面と実行状態を確認します</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="625" />
-            <source>Schedule</source>
-            <translation>スケジュール</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="626" />
-            <source>Configure scheduled runs and force start</source>
-            <translation>定時実行と強制起動を設定します</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="633" />
-            <source>Setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="634" />
-            <source>Theme, update, and resource management</source>
-            <translation>テーマ、更新、リソース管理</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="662" />
-            <source>ChainFlow Assistant</source>
-            <translation>ChainFlowアシスタント</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="994" />
-            <source>No summary available</source>
-            <translation>要約はありません</translation>
-        </message>
-    </context>
-    <context>
-        <name>DescriptionWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/description_widget.py" line="32" />
-            <source>Function Description</source>
-            <translation>機能説明</translation>
-        </message>
-    </context>
-    <context>
-        <name>DingTalkNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="133" />
-            <source>DingTalk Webhook URL:</source>
-            <translation>DingTalk Webhook URL:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="134" />
-            <source>DingTalk Secret:</source>
-            <translation>DingTalk シークレット:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="135" />
-            <source>DingTalk Status:</source>
-            <translation>DingTalk ステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>DoubleButtonSettingCard</name>
-        <message>
-            <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="55" />
-            <source>stable</source>
-            <translation>安定版</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="56" />
-            <source>beta</source>
-            <translation>ベータ版</translation>
-        </message>
-    </context>
-    <context>
-        <name>GotifyNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="482" />
-            <source>Gotify Server URL:</source>
-            <translation>GotifyサーバーURL:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="483" />
-            <source>Gotify App Token:</source>
-            <translation>Gotifyアプリトークン:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="484" />
-            <source>Notification Priority (0-10):</source>
-            <translation>通知優先度 (0-10):</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="485" />
-            <source>Gotify Status:</source>
-            <translation>Gotifyステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImagePreviewDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/image_preview_dialog.py" line="29" />
-            <source>Image Preview</source>
-            <translation>画像プレビュー</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/image_preview_dialog.py" line="91" />
-            <source>Close</source>
-            <translation>閉じる</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/image_preview_dialog.py" line="121" />
-            <source>Failed to load image:
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="593"/>
+        <source>View full changelog in Settings &gt; Open update log.</source>
+        <translation>完全な変更履歴は「設定 &gt; 更新ログを開く」で確認できます。</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="609"/>
+        <source>Task</source>
+        <translation>タスク</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="610"/>
+        <source>Configure and execute automation tasks</source>
+        <translation>自動化タスクを設定して実行します</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="612"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="617"/>
+        <source>Monitor</source>
+        <translation>モニター</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="618"/>
+        <source>View real-time frames and runtime status</source>
+        <translation>リアルタイム画面と実行状態を確認します</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="625"/>
+        <source>Schedule</source>
+        <translation>スケジュール</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="626"/>
+        <source>Configure scheduled runs and force start</source>
+        <translation>定時実行と強制起動を設定します</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="633"/>
+        <source>Setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="634"/>
+        <source>Theme, update, and resource management</source>
+        <translation>テーマ、更新、リソース管理</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="662"/>
+        <source>ChainFlow Assistant</source>
+        <translation>ChainFlowアシスタント</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="994"/>
+        <source>No summary available</source>
+        <translation>要約はありません</translation>
+    </message>
+</context>
+<context>
+    <name>DescriptionWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/description_widget.py" line="32"/>
+        <source>Function Description</source>
+        <translation>機能説明</translation>
+    </message>
+</context>
+<context>
+    <name>DingTalkNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="133"/>
+        <source>DingTalk Webhook URL:</source>
+        <translation>DingTalk Webhook URL:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="134"/>
+        <source>DingTalk Secret:</source>
+        <translation>DingTalk シークレット:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="135"/>
+        <source>DingTalk Status:</source>
+        <translation>DingTalk ステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>DoubleButtonSettingCard</name>
+    <message>
+        <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="55"/>
+        <source>stable</source>
+        <translation>安定版</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="56"/>
+        <source>beta</source>
+        <translation>ベータ版</translation>
+    </message>
+</context>
+<context>
+    <name>GotifyNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="482"/>
+        <source>Gotify Server URL:</source>
+        <translation>GotifyサーバーURL:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="483"/>
+        <source>Gotify App Token:</source>
+        <translation>Gotifyアプリトークン:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="484"/>
+        <source>Notification Priority (0-10):</source>
+        <translation>通知優先度 (0-10):</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="485"/>
+        <source>Gotify Status:</source>
+        <translation>Gotifyステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>ImagePreviewDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/image_preview_dialog.py" line="29"/>
+        <source>Image Preview</source>
+        <translation>画像プレビュー</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/image_preview_dialog.py" line="91"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/image_preview_dialog.py" line="121"/>
+        <source>Failed to load image:
 {path}</source>
-            <translation>画像の読み込みに失敗しました:
+        <translation>画像の読み込みに失敗しました:
 {path}</translation>
-        </message>
-    </context>
-    <context>
-        <name>LarkNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="185" />
-            <source>Lark Webhook URL:</source>
-            <translation>Lark Webhook URL:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="186" />
-            <source>Lark App Key:</source>
-            <translation>Larkアプリキー:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="187" />
-            <source>Lark Status:</source>
-            <translation>Larkステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogItemWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/log_item_widget.py" line="147" />
-            <source>Click to view full image</source>
-            <translation>クリックで画像全体を表示</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/log_item_widget.py" line="163" />
-            <source>No image</source>
-            <translation>画像なし</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/log_item_widget.py" line="206" />
-            <source>Log Image</source>
-            <translation>ログ画像</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogZipDialog</name>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="103" />
-            <source>Select the content to include in the log package.</source>
-            <translation>ログパッケージに含める内容を選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="107" />
-            <source>Package logs</source>
-            <translation>ログをパッケージ化</translation>
-        </message>
-        <message>
-            <source>Choose the log files and image folders to include. Image items can be filtered by time range.</source>
-            <translation type="vanished">含めるログファイルと画像フォルダを選択してください。画像項目は時間範囲でフィルタリングできます。</translation>
-        </message>
-        <message>
-            <source>Select one or more run records to include in the log package.</source>
-            <translation type="vanished">ログパッケージに含める実行記録を1つ以上選択してください。</translation>
-        </message>
-        <message>
-            <source>Log contents will be grouped by run records (task flow start/stop). You can select multiple run records.</source>
-            <translation type="vanished">ログ内容は実行記録（タスクフローの開始/停止）ごとにグループ化されます。複数の実行記録を選択できます。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="160" />
-            <source>Start packaging</source>
-            <translation>パッケージ化を開始</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="161" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="412" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="428" />
-            <source>Close</source>
-            <translation>閉じる</translation>
-        </message>
-        <message>
-            <source>Run records</source>
-            <translation type="vanished">実行記録</translation>
-        </message>
-        <message>
-            <source>No run records found.</source>
-            <translation type="vanished">実行記録が見つかりませんでした。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="173" />
-            <source>Logs</source>
-            <translation>ログ</translation>
-        </message>
-        <message>
-            <source>maafw.log</source>
-            <translation type="vanished">maafw.log</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="189" />
-            <source>other .log/.txt</source>
-            <translation>その他 .log/.txt</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="222" />
-            <source>on_error (debug/on_error)</source>
-            <translation>on_error（デバッグ/on_error）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="225" />
-            <source>vision (debug/vision)</source>
-            <translation>vision（デバッグ/vision）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="228" />
-            <source>screenshot (debug/screenshot)</source>
-            <translation>screenshot（デバッグ/screenshot）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="231" />
-            <source>other .jpg/.png</source>
-            <translation>その他 .jpg/.png</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="255" />
-            <source>Other</source>
-            <translation>その他</translation>
-        </message>
-        <message>
-            <source>Run record </source>
-            <translation type="vanished">実行記録 </translation>
-        </message>
-        <message>
-            <source>Select at least one run record and one content category.</source>
-            <translation type="vanished">少なくとも1つの実行記録と1つのコンテンツカテゴリを選択してください。</translation>
-        </message>
-        <message>
-            <source>maa.log (including .bak)</source>
-            <translation type="vanished">maa.log (.bakを含む)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="186" />
-            <source>gui.log</source>
-            <translation>gui.log</translation>
-        </message>
-        <message>
-            <source>custom.log</source>
-            <translation type="vanished">custom.log</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="258" />
-            <source>other files</source>
-            <translation>その他のファイル</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="212" />
-            <source>Images</source>
-            <translation>画像</translation>
-        </message>
-        <message>
-            <source>Choose log files and image folders to include. Image items can be filtered by time range.</source>
-            <translation type="vanished">ログファイルと画像フォルダを含める選択。画像アイテムは時間範囲でフィルタリング可能</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="110" />
-            <source>Choose log files and image folders to include. Both logs and images can be filtered by time range.</source>
-            <translation>ログファイルと画像フォルダを含める選択。ログと画像の両方を時間範囲でフィルタリングできます。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="176" />
-            <source>Default is all log categories with time range set to all.</source>
-            <translation>デフォルトはすべてのログカテゴリで、時間範囲はすべてに設定されています。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="183" />
-            <source>maafw.log (including .bak)</source>
-            <translation>maafw.log（.bakを含む）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="215" />
-            <source>Default is all image categories with time range set to all.</source>
-            <translation>デフォルトはすべての画像カテゴリで、時間範囲はすべてに設定されています。</translation>
-        </message>
-        <message>
-            <source>on_error folder</source>
-            <translation type="vanished">on_errorフォルダ</translation>
-        </message>
-        <message>
-            <source>vision folder</source>
-            <translation type="vanished">visionフォルダ</translation>
-        </message>
-        <message>
-            <source>other images</source>
-            <translation type="vanished">他の画像</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="276" />
-            <source>all</source>
-            <translation>すべて</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="277" />
-            <source>within 1 hour</source>
-            <translation>1時間以内</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="278" />
-            <source>within 6 hours</source>
-            <translation>6時間以内</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="279" />
-            <source>within 12 hours</source>
-            <translation>12時間以内</translation>
-        </message>
-        <message>
-            <source>today</source>
-            <translation type="vanished">今日</translation>
-        </message>
-        <message>
-            <source>within 2 days</source>
-            <translation type="vanished">2日以内</translation>
-        </message>
-        <message>
-            <source>within 3 days</source>
-            <translation type="vanished">3日以内</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="280" />
-            <source>within 24 hours</source>
-            <translation>24時間以内</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="281" />
-            <source>within 48 hours</source>
-            <translation>48時間以内</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="282" />
-            <source>within 72 hours</source>
-            <translation>72時間以内</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="285" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="292" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="331" />
-            <source>Selected total size:</source>
-            <translation>選択された合計サイズ:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="285" />
-            <source> calculating...</source>
-            <translation> 計算中...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="412" />
-            <source>Cancel packaging</source>
-            <translation>パッケージ化をキャンセル</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="434" />
-            <source>Cancelling log packaging, please wait...</source>
-            <translation>ログのパッケージ化をキャンセル中、お待ちください...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="441" />
-            <source>Select at least one log or image category.</source>
-            <translation>少なくとも1つのログまたは画像カテゴリを選択してください。</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogoutputWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="110" />
-            <source>Monitor</source>
-            <translation>モニター</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="305" />
-            <source>Log Output</source>
-            <translation>ログ出力</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="311" />
-            <source>generate log zip</source>
-            <translation>ログZIPを生成</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="515" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="886" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="891" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="896" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="898" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="899" />
-            <source>System</source>
-            <translation>システム</translation>
-        </message>
-    </context>
-    <context>
-        <name>MainWindow</name>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="356" />
-            <source>Home</source>
-            <translation>ホーム</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="364" />
-            <source>Task</source>
-            <translation>タスク</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="369" />
-            <source>Monitor</source>
-            <translation>モニター</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="375" />
-            <source>Schedule</source>
-            <translation>スケジュール</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="383" />
-            <source>test_interface</source>
-            <translation>テストインターフェース</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="412" />
-            <location filename="../view/main_window/main_window.py" line="684" />
-            <location filename="../view/main_window/main_window.py" line="696" />
-            <source>Bundle</source>
-            <translation>バンドル</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="426" />
-            <source>Setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="541" />
-            <source>Show</source>
-            <translation>表示</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="542" />
-            <source>Hide</source>
-            <translation>非表示</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="543" />
-            <source>Quit</source>
-            <translation>終了</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="832" />
-            <source>Task flow is already running</source>
-            <translation>タスクフローは既に実行中です</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="844" />
-            <source>Failed to start task flow</source>
-            <translation>タスクフローの開始に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1168" />
-            <source>Config load failed, automatically reset to default. Backup of corrupted config file completed. Error details:</source>
-            <translation>設定の読み込みに失敗しました。自動的にデフォルトにリセットされました。破損した設定ファイルのバックアップが完了しました。エラーの詳細:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1172" />
-            <source>Config load failed, automatically reset to default. Backup of corrupted config file completed.</source>
-            <translation>設定の読み込みに失敗しました。自動的にデフォルトにリセットされました。破損した設定ファイルのバックアップが完了しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1179" />
-            <source>Config load failed, automatically reset to default. Failed to backup corrupted config file. Error details:</source>
-            <translation>設定ファイルの読み込みに失敗しました。自動的にデフォルト設定にリセットします。破損した設定ファイルのバックアップに失敗しました。エラーの詳細:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1183" />
-            <source>Config load failed, automatically reset to default. Failed to backup corrupted config file.</source>
-            <translation>設定ファイルの読み込みに失敗しました。自動的にデフォルト設定にリセットします。破損した設定ファイルのバックアップに失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1189" />
-            <source>Config load failed and error occurred while resetting config:</source>
-            <translation>設定ファイルの読み込みに失敗し、設定のリセット中にエラーが発生しました:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1193" />
-            <source>Config load failed and error occurred while resetting config.</source>
-            <translation>設定ファイルの読み込みに失敗し、設定のリセット中にエラーが発生しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1271" />
-            <source>(empty)</source>
-            <translation>(空)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1284" />
-            <source>(none)</source>
-            <translation>(なし)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1287" />
-            <source>Controller information is missing. Verify that {controller} is the expected controller.
+    </message>
+</context>
+<context>
+    <name>LarkNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="185"/>
+        <source>Lark Webhook URL:</source>
+        <translation>Lark Webhook URL:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="186"/>
+        <source>Lark App Key:</source>
+        <translation>Larkアプリキー:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="187"/>
+        <source>Lark Status:</source>
+        <translation>Larkステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>LogItemWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/log_item_widget.py" line="147"/>
+        <source>Click to view full image</source>
+        <translation>クリックで画像全体を表示</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/log_item_widget.py" line="163"/>
+        <source>No image</source>
+        <translation>画像なし</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/log_item_widget.py" line="206"/>
+        <source>Log Image</source>
+        <translation>ログ画像</translation>
+    </message>
+</context>
+<context>
+    <name>LogZipDialog</name>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="103"/>
+        <source>Select the content to include in the log package.</source>
+        <translation>ログパッケージに含める内容を選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="107"/>
+        <source>Package logs</source>
+        <translation>ログをパッケージ化</translation>
+    </message>
+    <message>
+        <source>Choose the log files and image folders to include. Image items can be filtered by time range.</source>
+        <translation type="vanished">含めるログファイルと画像フォルダを選択してください。画像項目は時間範囲でフィルタリングできます。</translation>
+    </message>
+    <message>
+        <source>Select one or more run records to include in the log package.</source>
+        <translation type="vanished">ログパッケージに含める実行記録を1つ以上選択してください。</translation>
+    </message>
+    <message>
+        <source>Log contents will be grouped by run records (task flow start/stop). You can select multiple run records.</source>
+        <translation type="vanished">ログ内容は実行記録（タスクフローの開始/停止）ごとにグループ化されます。複数の実行記録を選択できます。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="160"/>
+        <source>Start packaging</source>
+        <translation>パッケージ化を開始</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="161"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="412"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="428"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <source>Run records</source>
+        <translation type="vanished">実行記録</translation>
+    </message>
+    <message>
+        <source>No run records found.</source>
+        <translation type="vanished">実行記録が見つかりませんでした。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="173"/>
+        <source>Logs</source>
+        <translation>ログ</translation>
+    </message>
+    <message>
+        <source>maafw.log</source>
+        <translation type="vanished">maafw.log</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="189"/>
+        <source>other .log/.txt</source>
+        <translation>その他 .log/.txt</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="222"/>
+        <source>on_error (debug/on_error)</source>
+        <translation>on_error（デバッグ/on_error）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="225"/>
+        <source>vision (debug/vision)</source>
+        <translation>vision（デバッグ/vision）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="228"/>
+        <source>screenshot (debug/screenshot)</source>
+        <translation>screenshot（デバッグ/screenshot）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="231"/>
+        <source>other .jpg/.png</source>
+        <translation>その他 .jpg/.png</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="255"/>
+        <source>Other</source>
+        <translation>その他</translation>
+    </message>
+    <message>
+        <source>Run record </source>
+        <translation type="vanished">実行記録 </translation>
+    </message>
+    <message>
+        <source>Select at least one run record and one content category.</source>
+        <translation type="vanished">少なくとも1つの実行記録と1つのコンテンツカテゴリを選択してください。</translation>
+    </message>
+    <message>
+        <source>maa.log (including .bak)</source>
+        <translation type="vanished">maa.log (.bakを含む)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="186"/>
+        <source>gui.log</source>
+        <translation>gui.log</translation>
+    </message>
+    <message>
+        <source>custom.log</source>
+        <translation type="vanished">custom.log</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="258"/>
+        <source>other files</source>
+        <translation>その他のファイル</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="212"/>
+        <source>Images</source>
+        <translation>画像</translation>
+    </message>
+    <message>
+        <source>Choose log files and image folders to include. Image items can be filtered by time range.</source>
+        <translation type="vanished">ログファイルと画像フォルダを含める選択。画像アイテムは時間範囲でフィルタリング可能</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="110"/>
+        <source>Choose log files and image folders to include. Both logs and images can be filtered by time range.</source>
+        <translation>ログファイルと画像フォルダを含める選択。ログと画像の両方を時間範囲でフィルタリングできます。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="176"/>
+        <source>Default is all log categories with time range set to all.</source>
+        <translation>デフォルトはすべてのログカテゴリで、時間範囲はすべてに設定されています。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="183"/>
+        <source>maafw.log (including .bak)</source>
+        <translation>maafw.log（.bakを含む）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="215"/>
+        <source>Default is all image categories with time range set to all.</source>
+        <translation>デフォルトはすべての画像カテゴリで、時間範囲はすべてに設定されています。</translation>
+    </message>
+    <message>
+        <source>on_error folder</source>
+        <translation type="vanished">on_errorフォルダ</translation>
+    </message>
+    <message>
+        <source>vision folder</source>
+        <translation type="vanished">visionフォルダ</translation>
+    </message>
+    <message>
+        <source>other images</source>
+        <translation type="vanished">他の画像</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="276"/>
+        <source>all</source>
+        <translation>すべて</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="277"/>
+        <source>within 1 hour</source>
+        <translation>1時間以内</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="278"/>
+        <source>within 6 hours</source>
+        <translation>6時間以内</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="279"/>
+        <source>within 12 hours</source>
+        <translation>12時間以内</translation>
+    </message>
+    <message>
+        <source>today</source>
+        <translation type="vanished">今日</translation>
+    </message>
+    <message>
+        <source>within 2 days</source>
+        <translation type="vanished">2日以内</translation>
+    </message>
+    <message>
+        <source>within 3 days</source>
+        <translation type="vanished">3日以内</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="280"/>
+        <source>within 24 hours</source>
+        <translation>24時間以内</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="281"/>
+        <source>within 48 hours</source>
+        <translation>48時間以内</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="282"/>
+        <source>within 72 hours</source>
+        <translation>72時間以内</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="285"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="292"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="331"/>
+        <source>Selected total size:</source>
+        <translation>選択された合計サイズ:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="285"/>
+        <source> calculating...</source>
+        <translation> 計算中...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="412"/>
+        <source>Cancel packaging</source>
+        <translation>パッケージ化をキャンセル</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="434"/>
+        <source>Cancelling log packaging, please wait...</source>
+        <translation>ログのパッケージ化をキャンセル中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="441"/>
+        <source>Select at least one log or image category.</source>
+        <translation>少なくとも1つのログまたは画像カテゴリを選択してください。</translation>
+    </message>
+</context>
+<context>
+    <name>LogoutputWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="121"/>
+        <source>Monitor</source>
+        <translation>モニター</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="319"/>
+        <source>Log Output</source>
+        <translation>ログ出力</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="325"/>
+        <source>generate log zip</source>
+        <translation>ログZIPを生成</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="582"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="954"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="961"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="966"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="968"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="969"/>
+        <source>System</source>
+        <translation>システム</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="356"/>
+        <source>Home</source>
+        <translation>ホーム</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="364"/>
+        <source>Task</source>
+        <translation>タスク</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="369"/>
+        <source>Monitor</source>
+        <translation>モニター</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="375"/>
+        <source>Schedule</source>
+        <translation>スケジュール</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="383"/>
+        <source>test_interface</source>
+        <translation>テストインターフェース</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="412"/>
+        <location filename="../view/main_window/main_window.py" line="684"/>
+        <location filename="../view/main_window/main_window.py" line="696"/>
+        <source>Bundle</source>
+        <translation>バンドル</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="426"/>
+        <source>Setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="541"/>
+        <source>Show</source>
+        <translation>表示</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="542"/>
+        <source>Hide</source>
+        <translation>非表示</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="543"/>
+        <source>Quit</source>
+        <translation>終了</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="832"/>
+        <source>Task flow is already running</source>
+        <translation>タスクフローは既に実行中です</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="844"/>
+        <source>Failed to start task flow</source>
+        <translation>タスクフローの開始に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1168"/>
+        <source>Config load failed, automatically reset to default. Backup of corrupted config file completed. Error details:</source>
+        <translation>設定の読み込みに失敗しました。自動的にデフォルトにリセットされました。破損した設定ファイルのバックアップが完了しました。エラーの詳細:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1172"/>
+        <source>Config load failed, automatically reset to default. Backup of corrupted config file completed.</source>
+        <translation>設定の読み込みに失敗しました。自動的にデフォルトにリセットされました。破損した設定ファイルのバックアップが完了しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1179"/>
+        <source>Config load failed, automatically reset to default. Failed to backup corrupted config file. Error details:</source>
+        <translation>設定ファイルの読み込みに失敗しました。自動的にデフォルト設定にリセットします。破損した設定ファイルのバックアップに失敗しました。エラーの詳細:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1183"/>
+        <source>Config load failed, automatically reset to default. Failed to backup corrupted config file.</source>
+        <translation>設定ファイルの読み込みに失敗しました。自動的にデフォルト設定にリセットします。破損した設定ファイルのバックアップに失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1189"/>
+        <source>Config load failed and error occurred while resetting config:</source>
+        <translation>設定ファイルの読み込みに失敗し、設定のリセット中にエラーが発生しました:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1193"/>
+        <source>Config load failed and error occurred while resetting config.</source>
+        <translation>設定ファイルの読み込みに失敗し、設定のリセット中にエラーが発生しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1271"/>
+        <source>(empty)</source>
+        <translation>(空)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1284"/>
+        <source>(none)</source>
+        <translation>(なし)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1287"/>
+        <source>Controller information is missing. Verify that {controller} is the expected controller.
 Supported controllers in the current resource: {controllers}</source>
-            <translation>コントローラー情報がありません。{controller}が期待されるコントローラーであることを確認してください。
+        <translation>コントローラー情報がありません。{controller}が期待されるコントローラーであることを確認してください。
 現在のリソースでサポートされているコントローラー: {controllers}</translation>
-        </message>
-        <message>
-            <source>ADB path is not set. Tap Controller here and fill in the ADB executable path (usually next to your emulator).</source>
-            <translation type="vanished">ADBパスが設定されていません。ここでコントローラーをタップし、ADB実行ファイルのパス（通常はエミュレータの隣）を入力してください。</translation>
-        </message>
-        <message>
-            <source>ADB address is empty. Start the emulator so a device appears, or tap Controller here to pick a connection address.</source>
-            <translation type="vanished">ADBアドレスが空です。エミュレータを起動してデバイスを表示するか、ここでコントローラーをタップして接続アドレスを選択してください。</translation>
-        </message>
-        <message>
-            <source>ADB port is missing in the address. Use host:port (for example 127.0.0.1:5555), or tap Controller here to change settings.</source>
-            <translation type="vanished">アドレスにADBポートがありません。host:port（例：127.0.0.1:5555）を使用するか、ここでコントローラーをタップして設定を変更してください。</translation>
-        </message>
-        <message>
-            <source>Controller ADB settings are incomplete. Tap here to open the controller and fix path / address / port.</source>
-            <translation type="vanished">コントローラーのADB設定が不完全です。ここをタップしてコントローラーを開き、パス/アドレス/ポートを修正してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1362" />
-            <location filename="../view/main_window/main_window.py" line="1368" />
-            <source>hotkey disabled due to permission issue</source>
-            <translation>権限の問題によりホットキーが無効化されています</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1387" />
-            <source>Log is being packaged, please wait...</source>
-            <translation>ログをパッケージ化中です。お待ちください...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1408" />
-            <location filename="../view/main_window/main_window.py" line="1458" />
-            <source>Preparing files...</source>
-            <translation>ファイルを準備中...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1430" />
-            <location filename="../view/main_window/main_window.py" line="1434" />
-            <source>Debug directory not found, cannot package logs.</source>
-            <translation>デバッグディレクトリが見つかりません。ログをパッケージ化できません。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1449" />
-            <location filename="../view/main_window/main_window.py" line="1454" />
-            <source>No matching files were found for the selected options.</source>
-            <translation>選択されたオプションに一致するファイルが見つかりませんでした。</translation>
-        </message>
-        <message>
-            <source>No run records were selected.</source>
-            <translation type="vanished">実行記録が選択されていません。</translation>
-        </message>
-        <message>
-            <source>No matching files were found for the selected run records.</source>
-            <translation type="vanished">選択した実行記録に一致するファイルが見つかりませんでした。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1467" />
-            <location filename="../view/main_window/main_window.py" line="1482" />
-            <source>Packing:</source>
-            <translation>パッケージ化中:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1500" />
-            <location filename="../view/main_window/main_window.py" line="1501" />
-            <source>Log packaging cancelled.</source>
-            <translation>ログのパッケージ化がキャンセルされました。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1505" />
-            <location filename="../view/main_window/main_window.py" line="1509" />
-            <source>Log packaging failed:</source>
-            <translation>ログのパッケージ化に失敗しました:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2076" />
-            <source>, there are </source>
-            <translation>、</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2078" />
-            <source> files not added</source>
-            <translation> 個のファイルが追加されていません</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2082" />
-            <source>Log has been packaged, but some files failed to read:</source>
-            <translation>ログはパッケージ化されましたが、一部のファイルの読み込みに失敗しました:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2089" />
-            <source>Log has been packaged:</source>
-            <translation>ログはパッケージ化されました:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2094" />
-            <source>Packaging completed, but some files were skipped.</source>
-            <translation>パッケージ化は完了しましたが、一部のファイルはスキップされました。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2095" />
-            <source>Packaging completed:</source>
-            <translation>パッケージ化完了:</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2142" />
-            <location filename="../view/main_window/main_window.py" line="2309" />
-            <location filename="../view/main_window/main_window.py" line="2738" />
-            <source>Announcement</source>
-            <translation>お知らせ</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2145" />
-            <source>There is no announcement at the moment.</source>
-            <translation>現在、お知らせはありません。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2252" />
-            <location filename="../view/main_window/main_window.py" line="2262" />
-            <source>Welcome</source>
-            <translation>ようこそ</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2365" />
-            <source>This is the configuration area. Each configuration maps to different task sets.</source>
-            <translation>ここは設定エリアです。各設定は異なるタスクセットに対応しています。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2371" />
-            <source>This is the task area. Set the controller and resource configurations first; aside from those two, every task can be dragged to reorder before running.</source>
-            <translation>ここはタスクエリアです。まずコントローラーとリソース設定を設定してください。それら以外のすべてのタスクは、実行前にドラッグして順序を変更できます。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2377" />
-            <source>The monitor area displays live footage once tasks are running.</source>
-            <translation>モニターエリアは、タスク実行時にライブ映像を表示します。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2383" />
-            <source>When you encounter issues while running, click this button and send the generated log zip file in the report folder to the developers.</source>
-            <translation>実行中に問題が発生した場合は、このボタンをクリックし、report フォルダ内に生成されたログ ZIP を開発者に送信してください。</translation>
-        </message>
-        <message>
-            <source>Click this button to switch to special tasks; only tasks marked as special will execute.</source>
-            <translation type="vanished">このボタンをクリックして特殊タスクに切り替えます。特殊とマークされたタスクのみが実行されます。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2719" />
-            <source>Close</source>
-            <translation>閉じる</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2755" />
-            <source>Item </source>
-            <translation>項目 </translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2759" />
-            <source>Detail</source>
-            <translation>詳細</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2770" />
-            <location filename="../view/main_window/main_window.py" line="2773" />
-            <location filename="../view/main_window/main_window.py" line="2829" />
-            <source>Info</source>
-            <translation>情報</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2771" />
-            <source>Warning</source>
-            <translation>警告</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2772" />
-            <source>Error</source>
-            <translation>エラー</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2837" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2857" />
-            <source>ChainFlow Assistant</source>
-            <translation>ChainFlowアシスタント</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2878" />
-            <source>admin</source>
-            <translation>管理者</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2911" />
-            <source>Stopping task...</source>
-            <translation>タスクを停止中...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2919" />
-            <source>Please wait...</source>
-            <translation>お待ちください...</translation>
-        </message>
-    </context>
-    <context>
-        <name>MirrorCdkLineEditCard</name>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="123" />
-            <source>About Mirror</source>
-            <translation>Mirrorについて</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="158" />
-            <source>Remaining time: </source>
-            <translation>残り時間: </translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="162" />
-            <source>Unknown</source>
-            <translation>不明</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="168" />
-            <source>Expired</source>
-            <translation>期限切れ</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="179" />
-            <source>year</source>
-            <translation>年</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="180" />
-            <source>day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="181" />
-            <source>hour</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="182" />
-            <source>minute</source>
-            <translation>分</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="183" />
-            <source>second</source>
-            <translation>秒</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="189" />
-            <source>Less than a second</source>
-            <translation>1秒未満</translation>
-        </message>
-    </context>
-    <context>
-        <name>MonitorDialog</name>
-        <message>
-            <source>Monitor</source>
-            <translation type="vanished">モニター</translation>
-        </message>
-    </context>
-    <context>
-        <name>MonitorInterface</name>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="204" />
-            <source>Click to sync this frame to the device</source>
-            <translation>このフレームをデバイスに同期するにはクリックしてください</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="222" />
-            <source>FPS: --</source>
-            <translation>FPS: --</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="273" />
-            <source>Save Screenshot</source>
-            <translation>スクリーンショットを保存</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="279" />
-            <source>Capture the current preview and store it on disk</source>
-            <translation>現在のプレビューをキャプチャしてディスクに保存</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="263" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="616" />
-            <source>Start Monitoring</source>
-            <translation>監視を開始</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="154" />
-            <source>Monitor</source>
-            <translation>モニター</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="156" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="369" />
-            <source>Idle</source>
-            <translation>アイドル</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="164" />
-            <source>Live device preview via an independent controller connection. Click the preview to sync taps to the device.</source>
-            <translation>独立したコントローラー接続を介したライブデバイスプレビュー。プレビューをクリックしてタップをデバイスに同期します。</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="213" />
-            <source>Preview will appear when monitoring starts</source>
-            <translation>モニタリング開始時にプレビューが表示されます</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="244" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="386" />
-            <source>Resolution: --</source>
-            <translation>解像度: --</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="270" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="618" />
-            <source>Start monitoring task</source>
-            <translation>監視タスクを開始</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="283" />
-            <source>Monitoring starts automatically when a task runs</source>
-            <translation>タスク実行時にモニタリングが自動的に開始されます</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="363" />
-            <source>Connecting</source>
-            <translation>接続中</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="366" />
-            <source>Running</source>
-            <translation>実行中</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="375" />
-            <source>Capture rate: {} FPS</source>
-            <translation>キャプチャレート: {} FPS</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="381" />
-            <source>Resolution: {} × {}</source>
-            <translation>解像度: {} × {}</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="701" />
-            <source>Screenshot saved to </source>
-            <translation>スクリーンショットを保存しました: </translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="813" />
-            <source>Device connection failed, cannot start monitoring</source>
-            <translation>デバイス接続に失敗しました。監視を開始できません</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="612" />
-            <source>Stop Monitoring</source>
-            <translation>監視を停止</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="614" />
-            <source>Stop monitoring task</source>
-            <translation>監視タスクを停止</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="821" />
-            <source>Monitoring started</source>
-            <translation>監視を開始しました</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="827" />
-            <source>Failed to start monitoring: </source>
-            <translation>監視の開始に失敗しました: </translation>
-        </message>
-        <message>
-            <source>Monitoring stopped</source>
-            <translation type="vanished">監視を停止しました</translation>
-        </message>
-        <message>
-            <source>Failed to stop monitoring: </source>
-            <translation type="vanished">監視の停止に失敗しました: </translation>
-        </message>
-    </context>
-    <context>
-        <name>MonitorWidget</name>
-        <message>
-            <source>No screenshot available to save</source>
-            <translation type="vanished">保存可能なスクリーンショットがありません</translation>
-        </message>
-        <message>
-            <source>Screenshot saved to </source>
-            <translation type="vanished">スクリーンショットを保存しました: </translation>
-        </message>
-        <message>
-            <source>Failed to save screenshot: </source>
-            <translation type="vanished">スクリーンショットの保存に失敗しました: </translation>
-        </message>
-        <message>
-            <source>Controller not ready. Please ensure the device is connected.</source>
-            <translation type="vanished">コントローラーが準備できていません。デバイスが接続されていることを確認してください。</translation>
-        </message>
-        <message>
-            <source>Device connection failed, cannot start monitoring</source>
-            <translation type="vanished">デバイス接続に失敗しました。監視を開始できません。</translation>
-        </message>
-        <message>
-            <source>Failed to start monitoring loop</source>
-            <translation type="vanished">監視ループの開始に失敗しました</translation>
-        </message>
-        <message>
-            <source>Monitoring started</source>
-            <translation type="vanished">監視を開始しました</translation>
-        </message>
-        <message>
-            <source>Failed to start monitoring: </source>
-            <translation type="vanished">監視の開始に失敗しました: </translation>
-        </message>
-        <message>
-            <source>Monitoring stopped</source>
-            <translation type="vanished">監視を停止しました</translation>
-        </message>
-        <message>
-            <source>Failed to stop monitoring: </source>
-            <translation type="vanished">監視の停止に失敗しました: </translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/monitor_widget.py" line="97" />
-            <source>Click to open the monitor page</source>
-            <translation>クリックしてモニターページを開く</translation>
-        </message>
-    </context>
-    <context>
-        <name>MultiResourceUpdate</name>
-        <message>
-            <location filename="../utils/update.py" line="2630" />
-            <source>Checking for updates...</source>
-            <translation>更新を確認中...</translation>
-        </message>
-        <message>
-            <source>Already up to date</source>
-            <translation type="vanished">最新の状態です</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2665" />
-            <location filename="../utils/update.py" line="2688" />
-            <source>Download failed</source>
-            <translation>ダウンロードに失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2659" />
-            <source>Preparing to download update...</source>
-            <translation>更新のダウンロードを準備中...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2696" />
-            <source>Download complete</source>
-            <translation>ダウンロード完了</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2699" />
-            <source>Applying hotfix...</source>
-            <translation>ホットフィックス適用中...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2756" />
-            <source>Update applied successfully</source>
-            <translation>アップデートが正常に適用されました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2807" />
-            <source>Failed to update</source>
-            <translation>アップデートに失敗しました</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeIndexCard</name>
-        <message>
-            <location filename="../widget/notice_message.py" line="158" />
-            <source>No information available</source>
-            <translation>利用可能な情報はありません</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeMessageBox</name>
-        <message>
-            <location filename="../widget/notice_message.py" line="83" />
-            <source>Confirm and never show again</source>
-            <translation>確認して今後表示しない</translation>
-        </message>
-        <message>
-            <location filename="../widget/notice_message.py" line="84" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeSendThread</name>
-        <message>
-            <source> sent successfully.</source>
-            <translation type="vanished">送信成功。</translation>
-        </message>
-        <message>
-            <source> disabled.</source>
-            <translation type="vanished">無効化されました。</translation>
-        </message>
-        <message>
-            <source> param empty.</source>
-            <translation type="vanished">パラメータが空です。</translation>
-        </message>
-        <message>
-            <source> param invalid.</source>
-            <translation type="vanished">パラメータが無効です。</translation>
-        </message>
-        <message>
-            <source> network error.</source>
-            <translation type="vanished">ネットワークエラー。</translation>
-        </message>
-        <message>
-            <source> response error.</source>
-            <translation type="vanished">レスポンスエラー。</translation>
-        </message>
-        <message>
-            <source> unknown error.</source>
-            <translation type="vanished">不明なエラー。</translation>
-        </message>
-        <message>
-            <source> smtp port invalid.</source>
-            <translation type="vanished">SMTPポートが無効です。</translation>
-        </message>
-        <message>
-            <source> smtp connect failed.</source>
-            <translation type="vanished">SMTP接続に失敗しました。</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeTimingDialog</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="554" />
-            <source>Notification Timing Settings</source>
-            <translation>通知タイミング設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="569" />
-            <source>Notify when task flow starts</source>
-            <translation>タスクフロー開始時に通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="570" />
-            <source>Notify when device connects successfully</source>
-            <translation>デバイス接続成功時に通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="571" />
-            <source>Notify when device connection fails</source>
-            <translation>デバイス接続失敗時に通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="572" />
-            <source>Notify when task completes successfully</source>
-            <translation>タスク成功時に通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="573" />
-            <source>Notify when task fails</source>
-            <translation>タスク失敗時に通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="574" />
-            <source>Notify when task flow completes</source>
-            <translation>タスクフロー完了時に通知</translation>
-        </message>
-    </context>
-    <context>
-        <name>OptionWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget.py" line="250" />
-            <location filename="../view/task_interface/components/option_widget.py" line="323" />
-            <source>Options</source>
-            <translation>オプション</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget.py" line="324" />
-            <source>Conditions</source>
-            <translation>条件</translation>
-        </message>
-        <message>
-            <source>Speedrun</source>
-            <translation type="vanished">スピードラン</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget.py" line="340" />
-            <source>Function Description</source>
-            <translation>機能説明</translation>
-        </message>
-        <message>
-            <source>Program</source>
-            <translation type="vanished">プログラム</translation>
-        </message>
-        <message>
-            <source>Program Path</source>
-            <translation type="vanished">プログラムのパス</translation>
-        </message>
-        <message>
-            <source>Arguments</source>
-            <translation type="vanished">起動引数</translation>
-        </message>
-        <message>
-            <source>Wait for Process</source>
-            <translation type="vanished">プロセス終了を待機</translation>
-        </message>
-        <message>
-            <source>Wait</source>
-            <translation type="vanished">待機</translation>
-        </message>
-        <message>
-            <source>Seconds</source>
-            <translation type="vanished">秒数</translation>
-        </message>
-        <message>
-            <source>Target Time</source>
-            <translation type="vanished">対象時刻</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation type="vanished">時刻</translation>
-        </message>
-        <message>
-            <source>System Notification</source>
-            <translation type="vanished">システム通知</translation>
-        </message>
-        <message>
-            <source>Message</source>
-            <translation type="vanished">内容</translation>
-        </message>
-        <message>
-            <source>Play System Sound</source>
-            <translation type="vanished">システム音を再生</translation>
-        </message>
-        <message>
-            <source>External Notification</source>
-            <translation type="vanished">外部通知</translation>
-        </message>
-        <message>
-            <source>Title</source>
-            <translation type="vanished">タイトル</translation>
-        </message>
-        <message>
-            <source>Launch an external program and optionally wait for it to exit.</source>
-            <translation type="vanished">外部プログラムを起動し、必要に応じて終了を待機します。</translation>
-        </message>
-        <message>
-            <source>Wait for the specified number of seconds before continuing.</source>
-            <translation type="vanished">指定した秒数だけ待機してから後続タスクを続行します。</translation>
-        </message>
-        <message>
-            <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
-            <translation type="vanished">指定した時刻まで待機します。HH:MM または YYYY-MM-DD HH:MM に対応しています。</translation>
-        </message>
-        <message>
-            <source>Send a system notification and optionally play the system sound.</source>
-            <translation type="vanished">システム通知を送信し、必要に応じてシステム音を再生します。</translation>
-        </message>
-        <message>
-            <source>Send a message to all currently enabled external notification channels.</source>
-            <translation type="vanished">現在有効なすべての外部通知チャンネルにメッセージを送信します。</translation>
-        </message>
-        <message>
-            <source>Yes</source>
-            <translation type="vanished">はい</translation>
-        </message>
-        <message>
-            <source>No</source>
-            <translation type="vanished">いいえ</translation>
-        </message>
-    </context>
-    <context>
-        <name>PathLineEdit</name>
-        <message>
-            <location filename="../widget/path_line_edit.py" line="60" />
-            <source>Select File</source>
-            <translation>ファイルを選択</translation>
-        </message>
-    </context>
-    <context>
-        <name>PostActionSettingMixin</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="72" />
-            <source>Do nothing</source>
-            <translation>何もしない</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="73" />
-            <source>Shutdown</source>
-            <translation>シャットダウン</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="74" />
-            <source>Close controller</source>
-            <translation>コントローラーを閉じる</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="75" />
-            <source>Close software</source>
-            <translation>ソフトウェアを閉じる</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="76" />
-            <source>Run other configuration</source>
-            <translation>他の設定を実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="77" />
-            <source>Run other program</source>
-            <translation>他のプログラムを実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="87" />
-            <source>option_page_layout is not set, cannot render post action options</source>
-            <translation>option_page_layoutが設定されていないため、ポストアクションオプションをレンダリングできません</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="97" />
-            <source>Finish</source>
-            <translation>完了</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="102" />
-            <source>always run</source>
-            <translation>常に実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="106" />
-            <source>Whether to run the post-action regardless of success or failure</source>
-            <translation>成功または失敗に関わらずポストアクションを実行するかどうか</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="123" />
-            <source>Select the configuration to run</source>
-            <translation>実行する設定を選択</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="208" />
-            <source>Unknown config</source>
-            <translation>不明な設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="344" />
-            <source>Program path</source>
-            <translation>プログラムパス</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="349" />
-            <source>Select executable path</source>
-            <translation>実行可能パスを選択</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="355" />
-            <source>Program arguments</source>
-            <translation>プログラム引数</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="359" />
-            <source>Extra startup arguments</source>
-            <translation>追加起動引数</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="417" />
-            <source>Unnamed Configuration</source>
-            <translation>名前なし設定</translation>
-        </message>
-    </context>
-    <context>
-        <name>QYWXNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="431" />
-            <source>QYWXbot Key:</source>
-            <translation>QYWXbotキー:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="432" />
-            <source>QYWXbot Status:</source>
-            <translation>QYWXbotステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>QmsgNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="240" />
-            <source>Server:</source>
-            <translation>サーバー:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="241" />
-            <source>Key:</source>
-            <translation>キー:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="242" />
-            <source>User QQ:</source>
-            <translation>ユーザーQQ:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="243" />
-            <source>Robot QQ:</source>
-            <translation>ロボットQQ:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="244" />
-            <source>Qmsg Status:</source>
-            <translation>Qmsgステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>RenameConfigDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="915" />
-            <source>Rename config</source>
-            <translation>設定名変更</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="921" />
-            <source>Enter new config name:</source>
-            <translation>新しい設定名を入力:</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="924" />
-            <source>Enter the name of the config</source>
-            <translation>設定の名前を入力</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="939" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="940" />
-            <source>Cancel</source>
-            <translation>キャンセル</translation>
-        </message>
-    </context>
-    <context>
-        <name>ResourceSettingMixin</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="112" />
-            <source>Resource</source>
-            <translation>リソース</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="440" />
-            <source>Global Option</source>
-            <translation>グローバルオプション</translation>
-        </message>
-    </context>
-    <context>
-        <name>SMTPNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="304" />
-            <source>Use SSL</source>
-            <translation>SSLを使用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="310" />
-            <source>Server Address:</source>
-            <translation>サーバーアドレス:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="311" />
-            <source>Server Port:</source>
-            <translation>サーバーポート:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="312" />
-            <source>User Name:</source>
-            <translation>ユーザー名:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="313" />
-            <source>Password:</source>
-            <translation>パスワード:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="314" />
-            <source>Receive Mail:</source>
-            <translation>メール受信:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="315" />
-            <source>SMTP Status:</source>
-            <translation>SMTPステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScheduleInterface</name>
-        <message>
-            <source>Trigger</source>
-            <translation type="vanished">トリガー</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="155" />
-            <source>schedule_interface_info</source>
-            <translation>スケジュールインターフェース情報</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="150" />
-            <source>schedule_interface_info_windows</source>
-            <translation>schedule_interface_info_windows</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="152" />
-            <source>schedule_interface_info_macos</source>
-            <translation>schedule_interface_info_macos</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="154" />
-            <source>schedule_interface_info_linux</source>
-            <translation>schedule_interface_info_linux</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="172" />
-            <source>Select configuration</source>
-            <translation>設定選択</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="174" />
-            <source>Configuration</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="183" />
-            <source>Single</source>
-            <translation>単一</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="184" />
-            <source>Daily</source>
-            <translation>毎日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="185" />
-            <source>Weekly</source>
-            <translation>毎週</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="186" />
-            <source>Monthly</source>
-            <translation>毎月</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="177" />
-            <source>Trigger type</source>
-            <translation>トリガータイプ</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="197" />
-            <source>Timing</source>
-            <translation>タイミング</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="223" />
-            <source>Force start</source>
-            <translation>強制開始</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="224" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="464" />
-            <source>Enabled</source>
-            <translation>有効</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="162" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="231" />
-            <source>Add schedule</source>
-            <translation>スケジュール追加</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="251" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="275" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="301" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="319" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="269" />
-            <source>days</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="276" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="302" />
-            <source>Every</source>
-            <translation>毎</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="296" />
-            <source>weeks</source>
-            <translation>週</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="305" />
-            <source>Weekdays</source>
-            <translation>平日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="322" />
-            <source>Every month</source>
-            <translation>毎月</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="343" />
-            <source>Month</source>
-            <translation>月</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="348" />
-            <source>Day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="351" />
-            <source>Use ordinal weekday</source>
-            <translation>序数付き平日を使用</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="358" />
-            <source>First</source>
-            <translation>第1</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="359" />
-            <source>Second</source>
-            <translation>第2</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="360" />
-            <source>Third</source>
-            <translation>第3</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="361" />
-            <source>Fourth</source>
-            <translation>第4</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="362" />
-            <source>Last</source>
-            <translation>最終</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="368" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="401" />
-            <source>Monday</source>
-            <translation>月曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="369" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="402" />
-            <source>Tuesday</source>
-            <translation>火曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="370" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="403" />
-            <source>Wednesday</source>
-            <translation>水曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="371" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="404" />
-            <source>Thursday</source>
-            <translation>木曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="372" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="405" />
-            <source>Friday</source>
-            <translation>金曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="373" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="406" />
-            <source>Saturday</source>
-            <translation>土曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="374" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="407" />
-            <source>Sunday</source>
-            <translation>日曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="383" />
-            <source>Ordinal</source>
-            <translation>序数</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="384" />
-            <source>Weekday</source>
-            <translation>曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="449" />
-            <source>Scheduled tasks</source>
-            <translation>スケジュールされたタスク</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="459" />
-            <source>Config</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="460" />
-            <source>Type</source>
-            <translation>種類</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="461" />
-            <source>Pattern</source>
-            <translation>パターン</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="462" />
-            <source>Next run</source>
-            <translation>次回実行</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="463" />
-            <source>Force</source>
-            <translation>強制実行</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="465" />
-            <source>Action</source>
-            <translation>アクション</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="490" />
-            <source>No schedules yet.</source>
-            <translation>まだスケジュールはありません。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="563" />
-            <source>Unknown</source>
-            <translation>不明</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="579" />
-            <source>Pending</source>
-            <translation>保留中</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="586" />
-            <source>Yes</source>
-            <translation>はい</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="586" />
-            <source>No</source>
-            <translation>いいえ</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="605" />
-            <source>Delete schedule</source>
-            <translation>スケジュールを削除</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="633" />
-            <source>Please select a configuration to schedule.</source>
-            <translation>スケジュールする設定を選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="649" />
-            <source>Please choose a future date and time.</source>
-            <translation>将来の日時を選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="667" />
-            <source>Please select at least one weekday.</source>
-            <translation>少なくとも1つの曜日を選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="680" />
-            <source>Please select ordinal and weekday.</source>
-            <translation>序数と曜日を選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="704" />
-            <source>Failed to persist the schedule.</source>
-            <translation>スケジュールの保存に失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="708" />
-            <source>Schedule saved.</source>
-            <translation>スケジュールを保存しました。</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScheduleService</name>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="296" />
-            <source>Single</source>
-            <translation>単一</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="297" />
-            <source>Daily</source>
-            <translation>毎日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="298" />
-            <source>Weekly</source>
-            <translation>毎週</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="299" />
-            <source>Monthly</source>
-            <translation>毎月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="301" />
-            <location filename="../core/service/schedule_service.py" line="355" />
-            <source>Custom</source>
-            <translation>カスタム</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="314" />
-            <source>Once at {datetime}</source>
-            <translation>{datetime}に1回</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="319" />
-            <source>Every day at {time}</source>
-            <translation>毎日{time}に</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="320" />
-            <source>Every {n} days at {time}</source>
-            <translation>{n}日ごとに{time}に</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="329" />
-            <source>Every week on {weekdays} at {time}</source>
-            <translation>毎週{weekdays}の{time}に</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="332" />
-            <source>Every {n} weeks on {weekdays} at {time}</source>
-            <translation>{n}週ごとに{weekdays}の{time}に</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="343" />
-            <source>Every {month} on the {ordinal} {weekday} at {time}</source>
-            <translation>毎月{month}の第{ordinal}{weekday}の{time}に</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="351" />
-            <source>Every {month} on day {day} at {time}</source>
-            <translation>毎月{month}の{day}日の{time}に</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="365" />
-            <source>Monday</source>
-            <translation>月曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="366" />
-            <source>Tuesday</source>
-            <translation>火曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="367" />
-            <source>Wednesday</source>
-            <translation>水曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="368" />
-            <source>Thursday</source>
-            <translation>木曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="369" />
-            <source>Friday</source>
-            <translation>金曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="370" />
-            <source>Saturday</source>
-            <translation>土曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="371" />
-            <source>Sunday</source>
-            <translation>日曜日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="377" />
-            <source>Every month</source>
-            <translation>毎月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="379" />
-            <source>January</source>
-            <translation>1月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="380" />
-            <source>February</source>
-            <translation>2月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="381" />
-            <source>March</source>
-            <translation>3月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="382" />
-            <source>April</source>
-            <translation>4月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="383" />
-            <source>May</source>
-            <translation>5月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="384" />
-            <source>June</source>
-            <translation>6月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="385" />
-            <source>July</source>
-            <translation>7月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="386" />
-            <source>August</source>
-            <translation>8月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="387" />
-            <source>September</source>
-            <translation>9月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="388" />
-            <source>October</source>
-            <translation>10月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="389" />
-            <source>November</source>
-            <translation>11月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="390" />
-            <source>December</source>
-            <translation>12月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="396" />
-            <source>Last</source>
-            <translation>最終</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="398" />
-            <source>First</source>
-            <translation>第1</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="399" />
-            <source>Second</source>
-            <translation>第2</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="400" />
-            <source>Third</source>
-            <translation>第3</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="401" />
-            <source>Fourth</source>
-            <translation>第4</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="422" />
-            <source>Schedule: {name} ({describe}) added</source>
-            <translation>スケジュール: {name} ({describe}) を追加しました</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="439" />
-            <source>Schedule: {name} ({describe}) removed</source>
-            <translation>スケジュール: {name} ({describe}) を削除しました</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="460" />
-            <source>enabled</source>
-            <translation>有効</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="460" />
-            <source>disabled</source>
-            <translation>無効</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="462" />
-            <source>Schedule: {name} ({describe}) {status}</source>
-            <translation>スケジュール: {name} ({describe}) は {status} です</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} ({describe}) triggered</source>
-            <translation type="vanished">スケジュール: {name} ({describe}) がトリガーされました</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} queued, {count} task(s) remaining</source>
-            <translation type="vanished">スケジュール: {name} をキューに入れました。残り {count} タスク</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} ({describe}) started</source>
-            <translation type="vanished">スケジュール: {name} ({describe}) を開始しました</translation>
-        </message>
-        <message>
-            <source>Schedule: target config {config_id} not found, skipped</source>
-            <translation type="vanished">スケジュール: ターゲット設定 {config_id} が見つからないためスキップしました</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} failed: {error}</source>
-            <translation type="vanished">スケジュール: {name} が失敗しました: {error}</translation>
-        </message>
-    </context>
-    <context>
-        <name>SendSettingCard</name>
-        <message>
-            <location filename="../view/setting_interface/widget/send_setting_card.py" line="17" />
-            <source>When Connect Failed</source>
-            <translation>接続失敗時</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/send_setting_card.py" line="18" />
-            <source>When Post Task</source>
-            <translation>タスク投稿時</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/send_setting_card.py" line="19" />
-            <source>When Task Failed</source>
-            <translation>タスク失敗時</translation>
-        </message>
-    </context>
-    <context>
-        <name>SettingInterface</name>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="438" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1727" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1731" />
-            <source>ChainFlow Assistant</source>
-            <translation>ChainFlow アシスタント</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="511" />
-            <location filename="../view/setting_interface/setting_interface.py" line="600" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1756" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1806" />
-            <source>License</source>
-            <translation>ライセンス</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="514" />
-            <source>GitHub URL</source>
-            <translation>GitHub URL</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="516" />
-            <location filename="../view/setting_interface/setting_interface.py" line="715" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1412" />
-            <source>Update</source>
-            <translation>更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="518" />
-            <source>Open update log</source>
-            <translation>更新ログを開く</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="577" />
-            <source>Description: </source>
-            <translation>説明: </translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="662" />
-            <source>No update log</source>
-            <translation>更新ログなし</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="663" />
-            <source>No update log found locally.
+    </message>
+    <message>
+        <source>ADB path is not set. Tap Controller here and fill in the ADB executable path (usually next to your emulator).</source>
+        <translation type="vanished">ADBパスが設定されていません。ここでコントローラーをタップし、ADB実行ファイルのパス（通常はエミュレータの隣）を入力してください。</translation>
+    </message>
+    <message>
+        <source>ADB address is empty. Start the emulator so a device appears, or tap Controller here to pick a connection address.</source>
+        <translation type="vanished">ADBアドレスが空です。エミュレータを起動してデバイスを表示するか、ここでコントローラーをタップして接続アドレスを選択してください。</translation>
+    </message>
+    <message>
+        <source>ADB port is missing in the address. Use host:port (for example 127.0.0.1:5555), or tap Controller here to change settings.</source>
+        <translation type="vanished">アドレスにADBポートがありません。host:port（例：127.0.0.1:5555）を使用するか、ここでコントローラーをタップして設定を変更してください。</translation>
+    </message>
+    <message>
+        <source>Controller ADB settings are incomplete. Tap here to open the controller and fix path / address / port.</source>
+        <translation type="vanished">コントローラーのADB設定が不完全です。ここをタップしてコントローラーを開き、パス/アドレス/ポートを修正してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1362"/>
+        <location filename="../view/main_window/main_window.py" line="1368"/>
+        <source>hotkey disabled due to permission issue</source>
+        <translation>権限の問題によりホットキーが無効化されています</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1387"/>
+        <source>Log is being packaged, please wait...</source>
+        <translation>ログをパッケージ化中です。お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1408"/>
+        <location filename="../view/main_window/main_window.py" line="1458"/>
+        <source>Preparing files...</source>
+        <translation>ファイルを準備中...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1430"/>
+        <location filename="../view/main_window/main_window.py" line="1434"/>
+        <source>Debug directory not found, cannot package logs.</source>
+        <translation>デバッグディレクトリが見つかりません。ログをパッケージ化できません。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1449"/>
+        <location filename="../view/main_window/main_window.py" line="1454"/>
+        <source>No matching files were found for the selected options.</source>
+        <translation>選択されたオプションに一致するファイルが見つかりませんでした。</translation>
+    </message>
+    <message>
+        <source>No run records were selected.</source>
+        <translation type="vanished">実行記録が選択されていません。</translation>
+    </message>
+    <message>
+        <source>No matching files were found for the selected run records.</source>
+        <translation type="vanished">選択した実行記録に一致するファイルが見つかりませんでした。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1467"/>
+        <location filename="../view/main_window/main_window.py" line="1482"/>
+        <source>Packing:</source>
+        <translation>パッケージ化中:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1500"/>
+        <location filename="../view/main_window/main_window.py" line="1501"/>
+        <source>Log packaging cancelled.</source>
+        <translation>ログのパッケージ化がキャンセルされました。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1505"/>
+        <location filename="../view/main_window/main_window.py" line="1509"/>
+        <source>Log packaging failed:</source>
+        <translation>ログのパッケージ化に失敗しました:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2076"/>
+        <source>, there are </source>
+        <translation>、</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2078"/>
+        <source> files not added</source>
+        <translation> 個のファイルが追加されていません</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2082"/>
+        <source>Log has been packaged, but some files failed to read:</source>
+        <translation>ログはパッケージ化されましたが、一部のファイルの読み込みに失敗しました:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2089"/>
+        <source>Log has been packaged:</source>
+        <translation>ログはパッケージ化されました:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2094"/>
+        <source>Packaging completed, but some files were skipped.</source>
+        <translation>パッケージ化は完了しましたが、一部のファイルはスキップされました。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2095"/>
+        <source>Packaging completed:</source>
+        <translation>パッケージ化完了:</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2142"/>
+        <location filename="../view/main_window/main_window.py" line="2309"/>
+        <location filename="../view/main_window/main_window.py" line="2738"/>
+        <source>Announcement</source>
+        <translation>お知らせ</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2145"/>
+        <source>There is no announcement at the moment.</source>
+        <translation>現在、お知らせはありません。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2252"/>
+        <location filename="../view/main_window/main_window.py" line="2262"/>
+        <source>Welcome</source>
+        <translation>ようこそ</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2365"/>
+        <source>This is the configuration area. Each configuration maps to different task sets.</source>
+        <translation>ここは設定エリアです。各設定は異なるタスクセットに対応しています。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2371"/>
+        <source>This is the task area. Set the controller and resource configurations first; aside from those two, every task can be dragged to reorder before running.</source>
+        <translation>ここはタスクエリアです。まずコントローラーとリソース設定を設定してください。それら以外のすべてのタスクは、実行前にドラッグして順序を変更できます。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2377"/>
+        <source>The monitor area displays live footage once tasks are running.</source>
+        <translation>モニターエリアは、タスク実行時にライブ映像を表示します。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2383"/>
+        <source>When you encounter issues while running, click this button and send the generated log zip file in the report folder to the developers.</source>
+        <translation>実行中に問題が発生した場合は、このボタンをクリックし、report フォルダ内に生成されたログ ZIP を開発者に送信してください。</translation>
+    </message>
+    <message>
+        <source>Click this button to switch to special tasks; only tasks marked as special will execute.</source>
+        <translation type="vanished">このボタンをクリックして特殊タスクに切り替えます。特殊とマークされたタスクのみが実行されます。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2719"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2755"/>
+        <source>Item </source>
+        <translation>項目 </translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2759"/>
+        <source>Detail</source>
+        <translation>詳細</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2770"/>
+        <location filename="../view/main_window/main_window.py" line="2773"/>
+        <location filename="../view/main_window/main_window.py" line="2829"/>
+        <source>Info</source>
+        <translation>情報</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2771"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2772"/>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2837"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2857"/>
+        <source>ChainFlow Assistant</source>
+        <translation>ChainFlowアシスタント</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2878"/>
+        <source>admin</source>
+        <translation>管理者</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2911"/>
+        <source>Stopping task...</source>
+        <translation>タスクを停止中...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2919"/>
+        <source>Please wait...</source>
+        <translation>お待ちください...</translation>
+    </message>
+</context>
+<context>
+    <name>MirrorCdkLineEditCard</name>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="123"/>
+        <source>About Mirror</source>
+        <translation>Mirrorについて</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="158"/>
+        <source>Remaining time: </source>
+        <translation>残り時間: </translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="162"/>
+        <source>Unknown</source>
+        <translation>不明</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="168"/>
+        <source>Expired</source>
+        <translation>期限切れ</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="179"/>
+        <source>year</source>
+        <translation>年</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="180"/>
+        <source>day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="181"/>
+        <source>hour</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="182"/>
+        <source>minute</source>
+        <translation>分</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="183"/>
+        <source>second</source>
+        <translation>秒</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="189"/>
+        <source>Less than a second</source>
+        <translation>1秒未満</translation>
+    </message>
+</context>
+<context>
+    <name>MonitorDialog</name>
+    <message>
+        <source>Monitor</source>
+        <translation type="vanished">モニター</translation>
+    </message>
+</context>
+<context>
+    <name>MonitorInterface</name>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="385"/>
+        <source>Click to sync this frame to the device</source>
+        <translation>このフレームをデバイスに同期するにはクリックしてください</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="431"/>
+        <source>FPS: --</source>
+        <translation>FPS: --</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="482"/>
+        <source>Save Screenshot</source>
+        <translation>スクリーンショットを保存</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="488"/>
+        <source>Capture the current preview and store it on disk</source>
+        <translation>現在のプレビューをキャプチャしてディスクに保存</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="472"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1074"/>
+        <source>Start Monitoring</source>
+        <translation>監視を開始</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="341"/>
+        <source>Monitor</source>
+        <translation>モニター</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="343"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="654"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="672"/>
+        <source>Idle</source>
+        <translation>アイドル</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="412"/>
+        <source>Live device preview via an independent controller connection. Click the preview to sync taps to the device.</source>
+        <translation>独立したコントローラー接続を介したライブデバイスプレビュー。プレビューをクリックしてタップをデバイスに同期します。</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="416"/>
+        <source>Multi-instance mode: all configurations are shown below. Stopped configurations display a power-off indicator. Click a card to switch the active configuration.</source>
+        <translation>マルチインスタンスモード：以下にすべての設定が表示されます。停止中の設定には電源オフ表示が出ます。カードをクリックしてアクティブな設定を切り替えます。</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="422"/>
+        <source>Preview will appear when monitoring starts</source>
+        <translation>モニタリング開始時にプレビューが表示されます</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="453"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="689"/>
+        <source>Resolution: --</source>
+        <translation>解像度: --</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="479"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1076"/>
+        <source>Start monitoring task</source>
+        <translation>監視タスクを開始</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="492"/>
+        <source>Monitoring starts automatically when a task runs</source>
+        <translation>タスク実行時にモニタリングが自動的に開始されます</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="650"/>
+        <source>{0} / {1} running</source>
+        <translation>{0} / {1} 実行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="666"/>
+        <source>Connecting</source>
+        <translation>接続中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="669"/>
+        <source>Running</source>
+        <translation>実行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="678"/>
+        <source>Capture rate: {} FPS</source>
+        <translation>キャプチャレート: {} FPS</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="684"/>
+        <source>Resolution: {} × {}</source>
+        <translation>解像度: {} × {}</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1206"/>
+        <source>Screenshot saved to </source>
+        <translation>スクリーンショットを保存しました: </translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1333"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1378"/>
+        <source>Device connection failed, cannot start monitoring</source>
+        <translation>デバイス接続に失敗しました。監視を開始できません</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1070"/>
+        <source>Stop Monitoring</source>
+        <translation>監視を停止</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1072"/>
+        <source>Stop monitoring task</source>
+        <translation>監視タスクを停止</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1340"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1386"/>
+        <source>Monitoring started</source>
+        <translation>監視を開始しました</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1347"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1392"/>
+        <source>Failed to start monitoring: </source>
+        <translation>監視の開始に失敗しました: </translation>
+    </message>
+    <message>
+        <source>Monitoring stopped</source>
+        <translation type="vanished">監視を停止しました</translation>
+    </message>
+    <message>
+        <source>Failed to stop monitoring: </source>
+        <translation type="vanished">監視の停止に失敗しました: </translation>
+    </message>
+</context>
+<context>
+    <name>MonitorWidget</name>
+    <message>
+        <source>No screenshot available to save</source>
+        <translation type="vanished">保存可能なスクリーンショットがありません</translation>
+    </message>
+    <message>
+        <source>Screenshot saved to </source>
+        <translation type="vanished">スクリーンショットを保存しました: </translation>
+    </message>
+    <message>
+        <source>Failed to save screenshot: </source>
+        <translation type="vanished">スクリーンショットの保存に失敗しました: </translation>
+    </message>
+    <message>
+        <source>Controller not ready. Please ensure the device is connected.</source>
+        <translation type="vanished">コントローラーが準備できていません。デバイスが接続されていることを確認してください。</translation>
+    </message>
+    <message>
+        <source>Device connection failed, cannot start monitoring</source>
+        <translation type="vanished">デバイス接続に失敗しました。監視を開始できません。</translation>
+    </message>
+    <message>
+        <source>Failed to start monitoring loop</source>
+        <translation type="vanished">監視ループの開始に失敗しました</translation>
+    </message>
+    <message>
+        <source>Monitoring started</source>
+        <translation type="vanished">監視を開始しました</translation>
+    </message>
+    <message>
+        <source>Failed to start monitoring: </source>
+        <translation type="vanished">監視の開始に失敗しました: </translation>
+    </message>
+    <message>
+        <source>Monitoring stopped</source>
+        <translation type="vanished">監視を停止しました</translation>
+    </message>
+    <message>
+        <source>Failed to stop monitoring: </source>
+        <translation type="vanished">監視の停止に失敗しました: </translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/monitor_widget.py" line="97"/>
+        <source>Click to open the monitor page</source>
+        <translation>クリックしてモニターページを開く</translation>
+    </message>
+</context>
+<context>
+    <name>MultiResourceUpdate</name>
+    <message>
+        <location filename="../utils/update.py" line="2630"/>
+        <source>Checking for updates...</source>
+        <translation>更新を確認中...</translation>
+    </message>
+    <message>
+        <source>Already up to date</source>
+        <translation type="vanished">最新の状態です</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2665"/>
+        <location filename="../utils/update.py" line="2688"/>
+        <source>Download failed</source>
+        <translation>ダウンロードに失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2659"/>
+        <source>Preparing to download update...</source>
+        <translation>更新のダウンロードを準備中...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2696"/>
+        <source>Download complete</source>
+        <translation>ダウンロード完了</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2699"/>
+        <source>Applying hotfix...</source>
+        <translation>ホットフィックス適用中...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2756"/>
+        <source>Update applied successfully</source>
+        <translation>アップデートが正常に適用されました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2807"/>
+        <source>Failed to update</source>
+        <translation>アップデートに失敗しました</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeIndexCard</name>
+    <message>
+        <location filename="../widget/notice_message.py" line="158"/>
+        <source>No information available</source>
+        <translation>利用可能な情報はありません</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeMessageBox</name>
+    <message>
+        <location filename="../widget/notice_message.py" line="83"/>
+        <source>Confirm and never show again</source>
+        <translation>確認して今後表示しない</translation>
+    </message>
+    <message>
+        <location filename="../widget/notice_message.py" line="84"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeSendThread</name>
+    <message>
+        <source> sent successfully.</source>
+        <translation type="vanished">送信成功。</translation>
+    </message>
+    <message>
+        <source> disabled.</source>
+        <translation type="vanished">無効化されました。</translation>
+    </message>
+    <message>
+        <source> param empty.</source>
+        <translation type="vanished">パラメータが空です。</translation>
+    </message>
+    <message>
+        <source> param invalid.</source>
+        <translation type="vanished">パラメータが無効です。</translation>
+    </message>
+    <message>
+        <source> network error.</source>
+        <translation type="vanished">ネットワークエラー。</translation>
+    </message>
+    <message>
+        <source> response error.</source>
+        <translation type="vanished">レスポンスエラー。</translation>
+    </message>
+    <message>
+        <source> unknown error.</source>
+        <translation type="vanished">不明なエラー。</translation>
+    </message>
+    <message>
+        <source> smtp port invalid.</source>
+        <translation type="vanished">SMTPポートが無効です。</translation>
+    </message>
+    <message>
+        <source> smtp connect failed.</source>
+        <translation type="vanished">SMTP接続に失敗しました。</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeTimingDialog</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="554"/>
+        <source>Notification Timing Settings</source>
+        <translation>通知タイミング設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="569"/>
+        <source>Notify when task flow starts</source>
+        <translation>タスクフロー開始時に通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="570"/>
+        <source>Notify when device connects successfully</source>
+        <translation>デバイス接続成功時に通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="571"/>
+        <source>Notify when device connection fails</source>
+        <translation>デバイス接続失敗時に通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="572"/>
+        <source>Notify when task completes successfully</source>
+        <translation>タスク成功時に通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="573"/>
+        <source>Notify when task fails</source>
+        <translation>タスク失敗時に通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="574"/>
+        <source>Notify when task flow completes</source>
+        <translation>タスクフロー完了時に通知</translation>
+    </message>
+</context>
+<context>
+    <name>OptionWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget.py" line="250"/>
+        <location filename="../view/task_interface/components/option_widget.py" line="323"/>
+        <source>Options</source>
+        <translation>オプション</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget.py" line="324"/>
+        <source>Conditions</source>
+        <translation>条件</translation>
+    </message>
+    <message>
+        <source>Speedrun</source>
+        <translation type="vanished">スピードラン</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget.py" line="340"/>
+        <source>Function Description</source>
+        <translation>機能説明</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation type="vanished">プログラム</translation>
+    </message>
+    <message>
+        <source>Program Path</source>
+        <translation type="vanished">プログラムのパス</translation>
+    </message>
+    <message>
+        <source>Arguments</source>
+        <translation type="vanished">起動引数</translation>
+    </message>
+    <message>
+        <source>Wait for Process</source>
+        <translation type="vanished">プロセス終了を待機</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation type="vanished">待機</translation>
+    </message>
+    <message>
+        <source>Seconds</source>
+        <translation type="vanished">秒数</translation>
+    </message>
+    <message>
+        <source>Target Time</source>
+        <translation type="vanished">対象時刻</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="vanished">時刻</translation>
+    </message>
+    <message>
+        <source>System Notification</source>
+        <translation type="vanished">システム通知</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="vanished">内容</translation>
+    </message>
+    <message>
+        <source>Play System Sound</source>
+        <translation type="vanished">システム音を再生</translation>
+    </message>
+    <message>
+        <source>External Notification</source>
+        <translation type="vanished">外部通知</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="vanished">タイトル</translation>
+    </message>
+    <message>
+        <source>Launch an external program and optionally wait for it to exit.</source>
+        <translation type="vanished">外部プログラムを起動し、必要に応じて終了を待機します。</translation>
+    </message>
+    <message>
+        <source>Wait for the specified number of seconds before continuing.</source>
+        <translation type="vanished">指定した秒数だけ待機してから後続タスクを続行します。</translation>
+    </message>
+    <message>
+        <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
+        <translation type="vanished">指定した時刻まで待機します。HH:MM または YYYY-MM-DD HH:MM に対応しています。</translation>
+    </message>
+    <message>
+        <source>Send a system notification and optionally play the system sound.</source>
+        <translation type="vanished">システム通知を送信し、必要に応じてシステム音を再生します。</translation>
+    </message>
+    <message>
+        <source>Send a message to all currently enabled external notification channels.</source>
+        <translation type="vanished">現在有効なすべての外部通知チャンネルにメッセージを送信します。</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="vanished">はい</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="vanished">いいえ</translation>
+    </message>
+</context>
+<context>
+    <name>PathLineEdit</name>
+    <message>
+        <location filename="../widget/path_line_edit.py" line="60"/>
+        <source>Select File</source>
+        <translation>ファイルを選択</translation>
+    </message>
+</context>
+<context>
+    <name>PostActionSettingMixin</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="72"/>
+        <source>Do nothing</source>
+        <translation>何もしない</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="73"/>
+        <source>Shutdown</source>
+        <translation>シャットダウン</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="74"/>
+        <source>Close controller</source>
+        <translation>コントローラーを閉じる</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="75"/>
+        <source>Close software</source>
+        <translation>ソフトウェアを閉じる</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="76"/>
+        <source>Run other configuration</source>
+        <translation>他の設定を実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="77"/>
+        <source>Run other program</source>
+        <translation>他のプログラムを実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="87"/>
+        <source>option_page_layout is not set, cannot render post action options</source>
+        <translation>option_page_layoutが設定されていないため、ポストアクションオプションをレンダリングできません</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="97"/>
+        <source>Finish</source>
+        <translation>完了</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="102"/>
+        <source>always run</source>
+        <translation>常に実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="106"/>
+        <source>Whether to run the post-action regardless of success or failure</source>
+        <translation>成功または失敗に関わらずポストアクションを実行するかどうか</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="123"/>
+        <source>Select the configuration to run</source>
+        <translation>実行する設定を選択</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="208"/>
+        <source>Unknown config</source>
+        <translation>不明な設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="344"/>
+        <source>Program path</source>
+        <translation>プログラムパス</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="349"/>
+        <source>Select executable path</source>
+        <translation>実行可能パスを選択</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="355"/>
+        <source>Program arguments</source>
+        <translation>プログラム引数</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="359"/>
+        <source>Extra startup arguments</source>
+        <translation>追加起動引数</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="417"/>
+        <source>Unnamed Configuration</source>
+        <translation>名前なし設定</translation>
+    </message>
+</context>
+<context>
+    <name>QYWXNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="431"/>
+        <source>QYWXbot Key:</source>
+        <translation>QYWXbotキー:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="432"/>
+        <source>QYWXbot Status:</source>
+        <translation>QYWXbotステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>QmsgNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="240"/>
+        <source>Server:</source>
+        <translation>サーバー:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="241"/>
+        <source>Key:</source>
+        <translation>キー:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="242"/>
+        <source>User QQ:</source>
+        <translation>ユーザーQQ:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="243"/>
+        <source>Robot QQ:</source>
+        <translation>ロボットQQ:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="244"/>
+        <source>Qmsg Status:</source>
+        <translation>Qmsgステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>RenameConfigDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="915"/>
+        <source>Rename config</source>
+        <translation>設定名変更</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="921"/>
+        <source>Enter new config name:</source>
+        <translation>新しい設定名を入力:</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="924"/>
+        <source>Enter the name of the config</source>
+        <translation>設定の名前を入力</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="939"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="940"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+</context>
+<context>
+    <name>ResourceSettingMixin</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="112"/>
+        <source>Resource</source>
+        <translation>リソース</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="440"/>
+        <source>Global Option</source>
+        <translation>グローバルオプション</translation>
+    </message>
+</context>
+<context>
+    <name>SMTPNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="304"/>
+        <source>Use SSL</source>
+        <translation>SSLを使用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="310"/>
+        <source>Server Address:</source>
+        <translation>サーバーアドレス:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="311"/>
+        <source>Server Port:</source>
+        <translation>サーバーポート:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="312"/>
+        <source>User Name:</source>
+        <translation>ユーザー名:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="313"/>
+        <source>Password:</source>
+        <translation>パスワード:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="314"/>
+        <source>Receive Mail:</source>
+        <translation>メール受信:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="315"/>
+        <source>SMTP Status:</source>
+        <translation>SMTPステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduleInterface</name>
+    <message>
+        <source>Trigger</source>
+        <translation type="vanished">トリガー</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="155"/>
+        <source>schedule_interface_info</source>
+        <translation>スケジュールインターフェース情報</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="150"/>
+        <source>schedule_interface_info_windows</source>
+        <translation>schedule_interface_info_windows</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="152"/>
+        <source>schedule_interface_info_macos</source>
+        <translation>schedule_interface_info_macos</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="154"/>
+        <source>schedule_interface_info_linux</source>
+        <translation>schedule_interface_info_linux</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="172"/>
+        <source>Select configuration</source>
+        <translation>設定選択</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="174"/>
+        <source>Configuration</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="183"/>
+        <source>Single</source>
+        <translation>単一</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="184"/>
+        <source>Daily</source>
+        <translation>毎日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="185"/>
+        <source>Weekly</source>
+        <translation>毎週</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="186"/>
+        <source>Monthly</source>
+        <translation>毎月</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="177"/>
+        <source>Trigger type</source>
+        <translation>トリガータイプ</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="197"/>
+        <source>Timing</source>
+        <translation>タイミング</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="223"/>
+        <source>Force start</source>
+        <translation>強制開始</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="224"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="464"/>
+        <source>Enabled</source>
+        <translation>有効</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="162"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="231"/>
+        <source>Add schedule</source>
+        <translation>スケジュール追加</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="251"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="275"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="301"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="319"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="269"/>
+        <source>days</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="276"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="302"/>
+        <source>Every</source>
+        <translation>毎</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="296"/>
+        <source>weeks</source>
+        <translation>週</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="305"/>
+        <source>Weekdays</source>
+        <translation>平日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="322"/>
+        <source>Every month</source>
+        <translation>毎月</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="343"/>
+        <source>Month</source>
+        <translation>月</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="348"/>
+        <source>Day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="351"/>
+        <source>Use ordinal weekday</source>
+        <translation>序数付き平日を使用</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="358"/>
+        <source>First</source>
+        <translation>第1</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="359"/>
+        <source>Second</source>
+        <translation>第2</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="360"/>
+        <source>Third</source>
+        <translation>第3</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="361"/>
+        <source>Fourth</source>
+        <translation>第4</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="362"/>
+        <source>Last</source>
+        <translation>最終</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="368"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="401"/>
+        <source>Monday</source>
+        <translation>月曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="369"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="402"/>
+        <source>Tuesday</source>
+        <translation>火曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="370"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="403"/>
+        <source>Wednesday</source>
+        <translation>水曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="371"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="404"/>
+        <source>Thursday</source>
+        <translation>木曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="372"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="405"/>
+        <source>Friday</source>
+        <translation>金曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="373"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="406"/>
+        <source>Saturday</source>
+        <translation>土曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="374"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="407"/>
+        <source>Sunday</source>
+        <translation>日曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="383"/>
+        <source>Ordinal</source>
+        <translation>序数</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="384"/>
+        <source>Weekday</source>
+        <translation>曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="449"/>
+        <source>Scheduled tasks</source>
+        <translation>スケジュールされたタスク</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="459"/>
+        <source>Config</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="460"/>
+        <source>Type</source>
+        <translation>種類</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="461"/>
+        <source>Pattern</source>
+        <translation>パターン</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="462"/>
+        <source>Next run</source>
+        <translation>次回実行</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="463"/>
+        <source>Force</source>
+        <translation>強制実行</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="465"/>
+        <source>Action</source>
+        <translation>アクション</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="490"/>
+        <source>No schedules yet.</source>
+        <translation>まだスケジュールはありません。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="563"/>
+        <source>Unknown</source>
+        <translation>不明</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="579"/>
+        <source>Pending</source>
+        <translation>保留中</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="586"/>
+        <source>Yes</source>
+        <translation>はい</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="586"/>
+        <source>No</source>
+        <translation>いいえ</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="605"/>
+        <source>Delete schedule</source>
+        <translation>スケジュールを削除</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="633"/>
+        <source>Please select a configuration to schedule.</source>
+        <translation>スケジュールする設定を選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="649"/>
+        <source>Please choose a future date and time.</source>
+        <translation>将来の日時を選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="667"/>
+        <source>Please select at least one weekday.</source>
+        <translation>少なくとも1つの曜日を選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="680"/>
+        <source>Please select ordinal and weekday.</source>
+        <translation>序数と曜日を選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="704"/>
+        <source>Failed to persist the schedule.</source>
+        <translation>スケジュールの保存に失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="708"/>
+        <source>Schedule saved.</source>
+        <translation>スケジュールを保存しました。</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduleService</name>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="296"/>
+        <source>Single</source>
+        <translation>単一</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="297"/>
+        <source>Daily</source>
+        <translation>毎日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="298"/>
+        <source>Weekly</source>
+        <translation>毎週</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="299"/>
+        <source>Monthly</source>
+        <translation>毎月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="301"/>
+        <location filename="../core/service/schedule_service.py" line="355"/>
+        <source>Custom</source>
+        <translation>カスタム</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="314"/>
+        <source>Once at {datetime}</source>
+        <translation>{datetime}に1回</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="319"/>
+        <source>Every day at {time}</source>
+        <translation>毎日{time}に</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="320"/>
+        <source>Every {n} days at {time}</source>
+        <translation>{n}日ごとに{time}に</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="329"/>
+        <source>Every week on {weekdays} at {time}</source>
+        <translation>毎週{weekdays}の{time}に</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="332"/>
+        <source>Every {n} weeks on {weekdays} at {time}</source>
+        <translation>{n}週ごとに{weekdays}の{time}に</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="343"/>
+        <source>Every {month} on the {ordinal} {weekday} at {time}</source>
+        <translation>毎月{month}の第{ordinal}{weekday}の{time}に</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="351"/>
+        <source>Every {month} on day {day} at {time}</source>
+        <translation>毎月{month}の{day}日の{time}に</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="365"/>
+        <source>Monday</source>
+        <translation>月曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="366"/>
+        <source>Tuesday</source>
+        <translation>火曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="367"/>
+        <source>Wednesday</source>
+        <translation>水曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="368"/>
+        <source>Thursday</source>
+        <translation>木曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="369"/>
+        <source>Friday</source>
+        <translation>金曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="370"/>
+        <source>Saturday</source>
+        <translation>土曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="371"/>
+        <source>Sunday</source>
+        <translation>日曜日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="377"/>
+        <source>Every month</source>
+        <translation>毎月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="379"/>
+        <source>January</source>
+        <translation>1月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="380"/>
+        <source>February</source>
+        <translation>2月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="381"/>
+        <source>March</source>
+        <translation>3月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="382"/>
+        <source>April</source>
+        <translation>4月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="383"/>
+        <source>May</source>
+        <translation>5月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="384"/>
+        <source>June</source>
+        <translation>6月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="385"/>
+        <source>July</source>
+        <translation>7月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="386"/>
+        <source>August</source>
+        <translation>8月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="387"/>
+        <source>September</source>
+        <translation>9月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="388"/>
+        <source>October</source>
+        <translation>10月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="389"/>
+        <source>November</source>
+        <translation>11月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="390"/>
+        <source>December</source>
+        <translation>12月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="396"/>
+        <source>Last</source>
+        <translation>最終</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="398"/>
+        <source>First</source>
+        <translation>第1</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="399"/>
+        <source>Second</source>
+        <translation>第2</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="400"/>
+        <source>Third</source>
+        <translation>第3</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="401"/>
+        <source>Fourth</source>
+        <translation>第4</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="422"/>
+        <source>Schedule: {name} ({describe}) added</source>
+        <translation>スケジュール: {name} ({describe}) を追加しました</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="439"/>
+        <source>Schedule: {name} ({describe}) removed</source>
+        <translation>スケジュール: {name} ({describe}) を削除しました</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="460"/>
+        <source>enabled</source>
+        <translation>有効</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="460"/>
+        <source>disabled</source>
+        <translation>無効</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="462"/>
+        <source>Schedule: {name} ({describe}) {status}</source>
+        <translation>スケジュール: {name} ({describe}) は {status} です</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} ({describe}) triggered</source>
+        <translation type="vanished">スケジュール: {name} ({describe}) がトリガーされました</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} queued, {count} task(s) remaining</source>
+        <translation type="vanished">スケジュール: {name} をキューに入れました。残り {count} タスク</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} ({describe}) started</source>
+        <translation type="vanished">スケジュール: {name} ({describe}) を開始しました</translation>
+    </message>
+    <message>
+        <source>Schedule: target config {config_id} not found, skipped</source>
+        <translation type="vanished">スケジュール: ターゲット設定 {config_id} が見つからないためスキップしました</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} failed: {error}</source>
+        <translation type="vanished">スケジュール: {name} が失敗しました: {error}</translation>
+    </message>
+</context>
+<context>
+    <name>SendSettingCard</name>
+    <message>
+        <location filename="../view/setting_interface/widget/send_setting_card.py" line="17"/>
+        <source>When Connect Failed</source>
+        <translation>接続失敗時</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/send_setting_card.py" line="18"/>
+        <source>When Post Task</source>
+        <translation>タスク投稿時</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/send_setting_card.py" line="19"/>
+        <source>When Task Failed</source>
+        <translation>タスク失敗時</translation>
+    </message>
+</context>
+<context>
+    <name>SettingInterface</name>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="438"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1739"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1743"/>
+        <source>ChainFlow Assistant</source>
+        <translation>ChainFlow アシスタント</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="511"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="600"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1768"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1818"/>
+        <source>License</source>
+        <translation>ライセンス</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="514"/>
+        <source>GitHub URL</source>
+        <translation>GitHub URL</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="516"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="715"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1412"/>
+        <source>Update</source>
+        <translation>更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="518"/>
+        <source>Open update log</source>
+        <translation>更新ログを開く</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="577"/>
+        <source>Description: </source>
+        <translation>説明: </translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="662"/>
+        <source>No update log</source>
+        <translation>更新ログなし</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="663"/>
+        <source>No update log found locally.
 
 Please check for updates first, or visit the GitHub releases page.</source>
-            <translation>ローカルに更新ログが見つかりません。
+        <translation>ローカルに更新ログが見つかりません。
 
 まず更新を確認するか、GitHubのリリースページをご覧ください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="671" />
-            <source>Update Log</source>
-            <translation>更新ログ</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="729" />
-            <source>Update Now</source>
-            <translation>今すぐ更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="824" />
-            <source>Custom Startup</source>
-            <translation>カスタム起動</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="828" />
-            <source>run after startup</source>
-            <translation>起動後に実行</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="829" />
-            <source>Launch the task immediately after starting the GUI program</source>
-            <translation>GUIプログラム起動後、すぐにタスクを開始する</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="835" />
-            <source>Start minimized</source>
-            <translation>最小化で起動</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="836" />
-            <source>Automatically minimize the window right after launch</source>
-            <translation>起動後すぐにウィンドウを自動的に最小化する</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="842" />
-            <source>Minimize to tray (Windows)</source>
-            <translation>トレイに最小化 (Windows)</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="844" />
-            <source>When enabled, minimizing the window will hide it to the system tray</source>
-            <translation>有効にすると、ウィンドウを最小化するとシステムトレイに隠れます</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="855" />
-            <source>Initial Page</source>
-            <translation>初期ページ</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="856" />
-            <source>Choose which page to show after launch</source>
-            <translation>起動後に表示するページを選択</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="858" />
-            <source>Last visited</source>
-            <translation>最後に訪問したページ</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="859" />
-            <source>Home</source>
-            <translation>ホーム</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="860" />
-            <source>Task</source>
-            <translation>タスク</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="861" />
-            <source>Monitor</source>
-            <translation>モニター</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="862" />
-            <source>Schedule</source>
-            <translation>スケジュール</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="863" />
-            <source>Setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="876" />
-            <source>Personalization</source>
-            <translation>個人設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="881" />
-            <source>Mica Effect</source>
-            <translation>マイカ効果</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="882" />
-            <source>Apply semi transparent to windows and surfaces</source>
-            <translation>ウィンドウと表面に半透明を適用する</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="889" />
-            <source>Application Theme</source>
-            <translation>アプリケーションテーマ</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="890" />
-            <source>Change the appearance of your application</source>
-            <translation>アプリケーションの外観を変更する</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="891" />
-            <source>Light</source>
-            <translation>ライト</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="891" />
-            <source>Dark</source>
-            <translation>ダーク</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="891" />
-            <location filename="../view/setting_interface/setting_interface.py" line="912" />
-            <source>Use system setting</source>
-            <translation>システム設定を使用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="897" />
-            <source>Theme Color</source>
-            <translation>テーマカラー</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="898" />
-            <source>Change the theme color of your application</source>
-            <translation>アプリケーションのテーマカラーを変更します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="904" />
-            <source>Interface Zoom</source>
-            <translation>インターフェースズーム</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="905" />
-            <source>Change the size of widgets and fonts</source>
-            <translation>ウィジェットとフォントのサイズを変更します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="919" />
-            <source>Language</source>
-            <translation>言語</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="920" />
-            <source>Set your preferred language for UI</source>
-            <translation>UIの優先言語を設定します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="927" />
-            <source>Restore window position</source>
-            <translation>ウィンドウ位置を復元</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="929" />
-            <source>When enabled, the application reopens at the last recorded size and position</source>
-            <translation>有効にすると、アプリケーションは最後に記録されたサイズと位置で再開します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="936" />
-            <source>Advanced Settings</source>
-            <translation>詳細設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="937" />
-            <source>Enable to show more options in Pre-configuration</source>
-            <translation>事前設定でより多くのオプションを表示するには有効にします</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="945" />
-            <source>Background Image</source>
-            <translation>背景画像</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="947" />
-            <source>Select an image as application background</source>
-            <translation>アプリケーションの背景として画像を選択します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="953" />
-            <location filename="../view/setting_interface/setting_interface.py" line="994" />
-            <source>Choose an image file (png/jpg/webp/bmp)</source>
-            <translation>画像ファイルを選択 (png/jpg/webp/bmp)</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="960" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1001" />
-            <source>Browse image file</source>
-            <translation>画像ファイルを参照</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="974" />
-            <source>Clear background image</source>
-            <translation>背景画像をクリア</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="986" />
-            <source>Home Cover Image</source>
-            <translation>ホームカバー画像</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="988" />
-            <source>Select an image as Home hero cover</source>
-            <translation>ホームのヒーローカバーとして画像を選択</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1011" />
-            <source>Clear home cover image</source>
-            <translation>ホームカバー画像をクリア</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1022" />
-            <source>Background Opacity</source>
-            <translation>背景の不透明度</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1023" />
-            <source>Adjust transparency of the background image</source>
-            <translation>背景画像の透明度を調整します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1048" />
-            <source>Global Shortcuts</source>
-            <translation>グローバルショートカット</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1056" />
-            <source>Start task shortcut</source>
-            <translation>タスク開始ショートカット</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1059" />
-            <source>Default Ctrl+F1, can also trigger when focus is not on the main window</source>
-            <translation>デフォルトはCtrl+F1、メインウィンドウにフォーカスがない場合もトリガーできます</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1064" />
-            <source>Ctrl+</source>
-            <translation>Ctrl+</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1067" />
-            <source>Format: Modifier+[Key], e.g. Ctrl+F1</source>
-            <translation>形式: 修飾キー+[キー]、例: Ctrl+F1</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1079" />
-            <source>Stop task shortcut</source>
-            <translation>タスク停止ショートカット</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1081" />
-            <source>Default Alt+F1, used to interrupt tasks in advance</source>
-            <translation>デフォルトはAlt+F1、タスクを事前に中断するために使用します</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1085" />
-            <source>Alt+</source>
-            <translation>Alt+</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1088" />
-            <source>Format: Modifier+[Key], e.g. Alt+F1</source>
-            <translation>形式：修飾キー+[キー]、例：Alt+F1</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1126" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1129" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1137" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1140" />
-            <source>Permission denied, shortcuts disabled</source>
-            <translation>権限がありません、ショートカットは無効です</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1156" />
-            <source>Key cannot be empty</source>
-            <translation>キーは空にできません</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1165" />
-            <source>Key format is invalid, restored to previous configuration.</source>
-            <translation>キーの形式が無効です、前の設定に戻しました。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1174" />
-            <source>Ctrl</source>
-            <translation>Ctrl</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1174" />
-            <source>Alt</source>
-            <translation>Alt</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1177" />
-            <source>Start task</source>
-            <translation>タスクを開始</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1179" />
-            <source>Stop task</source>
-            <translation>タスクを停止</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1183" />
-            <source>Shortcut must start with %1+, used for %2.</source>
-            <translation>ショートカットは%1+で始める必要があります、%2に使用されます。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1232" />
-            <source>Notice</source>
-            <translation>通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1235" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2445" />
-            <source>DingTalk Notification Enabled</source>
-            <translation>DingTalk通知が有効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1237" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2447" />
-            <source>DingTalk Notification Disabled</source>
-            <translation>DingTalk通知が無効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1240" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1251" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1262" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1274" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1286" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1299" />
-            <source>Modify</source>
-            <translation>変更</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1242" />
-            <source>DingTalk</source>
-            <translation>DingTalk</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1247" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2451" />
-            <source>Lark Notification Enabled</source>
-            <translation>Lark通知が有効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1249" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2453" />
-            <source>Lark Notification Disabled</source>
-            <translation>Lark通知が無効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1253" />
-            <source>Lark</source>
-            <translation>Lark</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1258" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2457" />
-            <source>SMTP Notification Enabled</source>
-            <translation>SMTP通知が有効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1260" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2459" />
-            <source>SMTP Notification Disabled</source>
-            <translation>SMTP通知が無効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1264" />
-            <source>SMTP</source>
-            <translation>SMTP</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1269" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2463" />
-            <source>WxPusher Notification Enabled</source>
-            <translation>WxPusher通知が有効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1271" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2465" />
-            <source>WxPusher Notification Disabled</source>
-            <translation>WxPusher通知が無効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1276" />
-            <source>WxPusher</source>
-            <translation>WxPusher</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1281" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2469" />
-            <source>QYWX Notification Enabled</source>
-            <translation>QYWX通知有効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1283" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2471" />
-            <source>QYWX Notification Disabled</source>
-            <translation>QYWX通知無効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1288" />
-            <source>QYWX</source>
-            <translation>QYWX</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1294" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2475" />
-            <source>Gotify Notification Enabled</source>
-            <translation>Gotify通知有効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1296" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2477" />
-            <source>Gotify Notification Disabled</source>
-            <translation>Gotify通知無効</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1301" />
-            <source>Gotify</source>
-            <translation>Gotify</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1317" />
-            <source>Send Format</source>
-            <translation>送信形式</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1318" />
-            <source>Plain text or HTML for external notifications (e.g. email body)</source>
-            <translation>外部通知用のプレーンテキストまたはHTML（例：メール本文）</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1319" />
-            <source>Plain text</source>
-            <translation>プレーンテキスト</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1319" />
-            <source>HTML</source>
-            <translation>HTML</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1327" />
-            <source>Attach screenshot to notice</source>
-            <translation>通知にスクリーンショットを添付</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1329" />
-            <source>When enabled, a screenshot is captured and sent with notifications (e.g. as email attachment) if controller is available</source>
-            <translation>有効時、コントローラーが利用可能な場合、スクリーンショットを撮影して通知と共に送信します（例：メール添付）</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1338" />
-            <source>Configure</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1340" />
-            <source>Notification Timing</source>
-            <translation>通知タイミング</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1341" />
-            <source>Configure when to send notifications</source>
-            <translation>通知を送信するタイミングを設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1351" />
-            <source>Task Settings</source>
-            <translation>タスク設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1356" />
-            <source>Monitor capture rate</source>
-            <translation>監視キャプチャレート</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1358" />
-            <source>Screenshot frames per second for the monitoring preview (uses a separate controller connection based on your controller settings)</source>
-            <translation>監視プレビューの秒間スクリーンショット枚数（メイン設定のコントローラー種別で独立接続）</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1373" />
-            <source>Recognition ROI overlay</source>
-            <translation>認識枠オーバーレイ</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1375" />
-            <source>Draw recognition hit boxes on the monitoring preview during tasks. This feature consumes significant system resources.</source>
-            <translation>タスク実行中に監視プレビューへ認識ヒット枠を描画します。この機能は大量のシステムリソースを消費します。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1385" />
-            <source>GPU Acceleration</source>
-            <translation>GPUアクセラレーション</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1386" />
-            <source>Enable GPU hardware acceleration for resource inference</source>
-            <translation>リソース推論にGPUハードウェアアクセラレーションを有効化</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1396" />
-            <source>Reset task page layout</source>
-            <translation>タスクページのレイアウトをリセット</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1398" />
-            <source>Restore the task, option, and log columns to equal width (1:1:1)</source>
-            <translation>タスク、オプション、ログの列を均等幅（1:1:1）に戻す</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1417" />
-            <source>mirrorchyan CDK</source>
-            <translation>mirrorchyan CDK</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1418" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1599" />
-            <source>Enter mirrorchyan CDK for stable update path</source>
-            <translation>安定した更新パスのためのmirrorchyan CDKを入力</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1420" />
-            <source>About Mirror</source>
-            <translation>Mirrorについて</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1426" />
-            <source>Automatically update after startup</source>
-            <translation>起動後自動更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1427" />
-            <source>Automatically download and apply updates once available</source>
-            <translation>利用可能になると自動的にダウンロードして適用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1436" />
-            <source>select update channel for resource</source>
-            <translation>リソースの更新チャンネルを選択</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1437" />
-            <source>select the update channel for the resource</source>
-            <translation>リソースの更新チャンネルを選択</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1444" />
-            <source>Force use GitHub</source>
-            <translation>GitHubを強制使用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1445" />
-            <source>Force use GitHub for resource update</source>
-            <translation>リソース更新にGitHubを強制使用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1394" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1451" />
-            <source>Reset</source>
-            <translation>リセット</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1453" />
-            <source>Reset resource</source>
-            <translation>リソースをリセット</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1454" />
-            <source>Redownload resource package without version/tag check</source>
-            <translation>バージョン/タグチェックなしでリソースパッケージを再ダウンロード</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1460" />
-            <source>GitHub API Key</source>
-            <translation>GitHub APIキー</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1462" />
-            <source>Personal access tokens increase GitHub API rate limits for update checks.</source>
-            <translation>個人アクセストークンは、更新チェックのGitHub APIレート制限を増やします。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1469" />
-            <source>Optional token for authenticated GitHub requests</source>
-            <translation>認証済みGitHubリクエスト用のオプショナルトークン</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1478" />
-            <source>Use Proxy</source>
-            <translation>プロキシを使用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1480" />
-            <source>After filling in the proxy settings, all traffic except that to the Mirror will be proxied.</source>
-            <translation>プロキシ設定を入力後、ミラーへのトラフィックを除くすべてのトラフィックがプロキシされます。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1504" />
-            <source>Experimental / Compatibility</source>
-            <translation>実験的 / 互換性</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1508" />
-            <source>Multi-resource adaptation</source>
-            <translation>マルチリソース適応</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1510" />
-            <source>Experimental. Enable loading multiple resource bundles; may impact stability.</source>
-            <translation>実験的。複数のリソースバンドルの読み込みを有効化；安定性に影響する可能性があります。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1518" />
-            <source>Save screenshot</source>
-            <translation>スクリーンショットを保存</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1519" />
-            <source>Save a screenshot when experimental features run</source>
-            <translation>実験的機能実行時にスクリーンショットを保存</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1526" />
-            <source>Include images in log zip</source>
-            <translation>ログZIPに画像を含める</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1528" />
-            <source>Include log images when generating log zip package. The number of images included equals the number displayed in the log interface.</source>
-            <translation>ログZIPパッケージ生成時にログ画像を含める。含まれる画像数は、ログインターフェースに表示される数と等しいです。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1546" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2431" />
-            <source>Set cache image count, current cache usage: {}</source>
-            <translation>キャッシュ画像数を設定、現在のキャッシュ使用量: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1551" />
-            <source>Max log images</source>
-            <translation>最大ログ画像数</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1605" />
-            <source>Resource does not support Mirrorchyan, right-click about mirror to unlock input</source>
-            <translation>リソースはMirrorchyanをサポートしていません、ミラーについて右クリックで入力を解除</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1628" />
-            <source>decrypt Mirror CDK failed, please fill in again and save.</source>
-            <translation>Mirror CDKの復号に失敗しました、再度入力して保存してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1659" />
-            <source>Failed to save Mirror CDK: {}</source>
-            <translation>Mirror CDKの保存に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1678" />
-            <source>Failed to read GitHub token, please save it again.</source>
-            <translation>GitHubトークンの読み込みに失敗しました。もう一度保存してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1703" />
-            <source>Failed to save GitHub token: {}.</source>
-            <translation>GitHubトークンの保存に失敗しました: {}。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1738" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1794" />
-            <source>Current version: </source>
-            <translation>現在のバージョン: </translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1741" />
-            <source>Latest version: </source>
-            <translation>最新バージョン：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1744" />
-            <source>UI version: </source>
-            <translation>UIバージョン：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1747" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1797" />
-            <source>MaaFW version: </source>
-            <translation>MaaFWバージョン：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1764" />
-            <source>MFW-ChainFlow Assistant</source>
-            <translation>MFW-ChainFlow アシスタント</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1777" />
-            <source>MFW-ChainFlow Assistant provides a visual orchestrator for MaaFramework users, covering configuration management, scheduling, notifications and custom extensions.</source>
-            <translation>MFW-ChainFlow アシスタントは、MaaFrameworkユーザー向けの視覚的オーケストレーターを提供し、設定管理、スケジューリング、通知、カスタム拡張機能をカバーします。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1871" />
-            <source>Select background image</source>
-            <translation>背景画像を選択</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1873" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1891" />
-            <source>Images (*.png *.jpg *.jpeg *.bmp *.webp)</source>
-            <translation>画像ファイル (*.png *.jpg *.jpeg *.bmp *.webp)</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1889" />
-            <source>Select home cover image</source>
-            <translation>ホームカバー画像を選択</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1908" />
-            <source>UI update feature is not implemented yet.</source>
-            <translation>UI更新機能はまだ実装されていません。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2280" />
-            <source>Enable multi-resource adaptation?</source>
-            <translation>マルチリソース適応を有効にしますか？</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2284" />
-            <source>After enabling the multi-configuration feature, the resource directories will be reconfigured. This operation is irreversible; please proceed with caution.</source>
-            <translation>マルチ設定機能を有効にすると、リソースディレクトリが再構成されます。この操作は元に戻せませんので、ご注意ください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2297" />
-            <source>Enable</source>
-            <translation>有効にする</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2299" />
-            <location filename="../view/setting_interface/setting_interface.py" line="3066" />
-            <source>Cancel</source>
-            <translation>キャンセル</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2346" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2365" />
-            <source>Image file does not exist</source>
-            <translation>画像ファイルが存在しません</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2532" />
-            <source>Configuration takes effect after restart</source>
-            <translation>設定は再起動後に有効になります</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2634" />
-            <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
-            <translation>CI/Alphaリソースバージョンでは自動更新が無効です。手動で更新してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2718" />
-            <source>Update failed too many times, local update package has been cleared.</source>
-            <translation>更新失敗が多すぎるため、ローカルの更新パッケージがクリアされました。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2794" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2837" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2887" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2938" />
-            <source>Stop update</source>
-            <translation>更新を停止</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2858" />
-            <source>New version available: </source>
-            <translation>新しいバージョンが利用可能：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2919" />
-            <source>Task page layout has been reset</source>
-            <translation>タスクページのレイアウトがリセットされました</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2926" />
-            <source>Update is already running</source>
-            <translation>更新は既に実行中です</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2932" />
-            <source>Service is not ready, cannot reset resource</source>
-            <translation>サービスが準備できていないため、リソースをリセットできません</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2943" />
-            <source>Starting Reset Resource</source>
-            <translation>リソースリセットを開始中</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2993" />
-            <source>Failed to rename updater: {}</source>
-            <translation>アップデータの名前変更に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3005" />
-            <location filename="../view/setting_interface/setting_interface.py" line="3138" />
-            <source>Failed to start updater: {}</source>
-            <translation>アップデータの起動に失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3048" />
-            <source>Update package not found, please try updating again.</source>
-            <translation>更新パッケージが見つかりません。再度更新をお試しください。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3065" />
-            <source>Update now</source>
-            <translation>今すぐ更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3069" />
-            <source>Restart required to update</source>
-            <translation>更新には再起動が必要です</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3071" />
-            <source>Update package detected</source>
-            <translation>更新パッケージを検出しました</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3074" />
-            <source>Hot update is unavailable. A restart update is required. Proceed?</source>
-            <translation>ホットアップデートは利用できません。再起動によるアップデートが必要です。実行しますか？</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3077" />
-            <source>Found a downloaded update package. Do you want to launch the updater now?</source>
-            <translation>ダウンロード済みのアップデートパッケージが見つかりました。アップデータを今すぐ起動しますか？</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3100" />
-            <source>Auto updating in %1 s</source>
-            <translation>%1 秒後に自動アップデート</translation>
-        </message>
-    </context>
-    <context>
-        <name>SpeedrunConfigWidget</name>
-        <message>
-            <source>Speedrun Configuration</source>
-            <translation type="vanished">スピードラン設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="80" />
-            <source>Daily</source>
-            <translation>日次</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="81" />
-            <source>Weekly</source>
-            <translation>週次</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="82" />
-            <source>Monthly</source>
-            <translation>月次</translation>
-        </message>
-        <message>
-            <source>Mode</source>
-            <translation type="vanished">モード</translation>
-        </message>
-        <message>
-            <source>Refresh Hour</source>
-            <translation type="vanished">更新時刻</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="169" />
-            <source>Monday</source>
-            <translation>月曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="170" />
-            <source>Tuesday</source>
-            <translation>火曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="171" />
-            <source>Wednesday</source>
-            <translation>水曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="172" />
-            <source>Thursday</source>
-            <translation>木曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="173" />
-            <source>Friday</source>
-            <translation>金曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="174" />
-            <source>Saturday</source>
-            <translation>土曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="175" />
-            <source>Sunday</source>
-            <translation>日曜日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="64" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="86" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="107" />
-            <source>Weekday</source>
-            <translation>平日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="37" />
-            <source>Condition Execution</source>
-            <translation>条件実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="53" />
-            <source>Condition</source>
-            <translation>条件</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="62" />
-            <source>Always</source>
-            <translation>常に</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="63" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="97" />
-            <source>Run Count</source>
-            <translation>実行回数</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="65" />
-            <source>Month Day</source>
-            <translation>月日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="66" />
-            <source>After Time</source>
-            <translation>時間後</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="67" />
-            <source>Condition Type</source>
-            <translation>条件タイプ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="70" />
-            <source>Condition Configuration</source>
-            <translation>条件設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="83" />
-            <source>Period</source>
-            <translation>期間</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="92" />
-            <source>Refresh Timeline</source>
-            <translation>タイムラインを更新</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="89" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="115" />
-            <source>Day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="123" />
-            <source>Hour</source>
-            <translation>時</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="130" />
-            <source>Execution</source>
-            <translation>実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="139" />
-            <source>Run</source>
-            <translation>実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="140" />
-            <source>Skip</source>
-            <translation>スキップ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="141" />
-            <source>Execution Type</source>
-            <translation>実行タイプ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="144" />
-            <source>Execution Configuration</source>
-            <translation>実行設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="152" />
-            <source>Notify</source>
-            <translation>通知</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="157" />
-            <source>External Notify</source>
-            <translation>外部通知</translation>
-        </message>
-        <message>
-            <source>General</source>
-            <translation type="vanished">一般</translation>
-        </message>
-        <message>
-            <source>Refresh Count</source>
-            <translation type="vanished">更新回数</translation>
-        </message>
-        <message>
-            <source>Min Interval (hours)</source>
-            <translation type="vanished">最小間隔（時間）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="150" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="155" />
-            <source>Enabled</source>
-            <translation>有効</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="151" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="156" />
-            <source>Disabled</source>
-            <translation>無効</translation>
-        </message>
-        <message>
-            <source>Enable Speedrun</source>
-            <translation type="vanished">スピードランを有効にする</translation>
-        </message>
-        <message>
-            <source>N/A</source>
-            <translation type="vanished">該当なし</translation>
-        </message>
-        <message>
-            <source>Current Count</source>
-            <translation type="vanished">現在のカウント</translation>
-        </message>
-        <message>
-            <source>Last Run Time</source>
-            <translation type="vanished">最終実行時刻</translation>
-        </message>
-    </context>
-    <context>
-        <name>StartBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/start_bar_widget.py" line="30" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-    </context>
-    <context>
-        <name>StartupDialogManager</name>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="303" />
-            <source>Missing Runtime Library</source>
-            <translation>ランタイムライブラリが不足しています</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="305" />
-            <source>Failed to load MAA framework library.
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="671"/>
+        <source>Update Log</source>
+        <translation>更新ログ</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="729"/>
+        <source>Update Now</source>
+        <translation>今すぐ更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="824"/>
+        <source>Custom Startup</source>
+        <translation>カスタム起動</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="828"/>
+        <source>run after startup</source>
+        <translation>起動後に実行</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="829"/>
+        <source>Launch the task immediately after starting the GUI program</source>
+        <translation>GUIプログラム起動後、すぐにタスクを開始する</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="835"/>
+        <source>Start minimized</source>
+        <translation>最小化で起動</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="836"/>
+        <source>Automatically minimize the window right after launch</source>
+        <translation>起動後すぐにウィンドウを自動的に最小化する</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="842"/>
+        <source>Minimize to tray (Windows)</source>
+        <translation>トレイに最小化 (Windows)</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="844"/>
+        <source>When enabled, minimizing the window will hide it to the system tray</source>
+        <translation>有効にすると、ウィンドウを最小化するとシステムトレイに隠れます</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="855"/>
+        <source>Initial Page</source>
+        <translation>初期ページ</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="856"/>
+        <source>Choose which page to show after launch</source>
+        <translation>起動後に表示するページを選択</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="858"/>
+        <source>Last visited</source>
+        <translation>最後に訪問したページ</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="859"/>
+        <source>Home</source>
+        <translation>ホーム</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="860"/>
+        <source>Task</source>
+        <translation>タスク</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="861"/>
+        <source>Monitor</source>
+        <translation>モニター</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="862"/>
+        <source>Schedule</source>
+        <translation>スケジュール</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="863"/>
+        <source>Setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="876"/>
+        <source>Personalization</source>
+        <translation>個人設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="881"/>
+        <source>Mica Effect</source>
+        <translation>マイカ効果</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="882"/>
+        <source>Apply semi transparent to windows and surfaces</source>
+        <translation>ウィンドウと表面に半透明を適用する</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="889"/>
+        <source>Application Theme</source>
+        <translation>アプリケーションテーマ</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="890"/>
+        <source>Change the appearance of your application</source>
+        <translation>アプリケーションの外観を変更する</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="891"/>
+        <source>Light</source>
+        <translation>ライト</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="891"/>
+        <source>Dark</source>
+        <translation>ダーク</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="891"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="912"/>
+        <source>Use system setting</source>
+        <translation>システム設定を使用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="897"/>
+        <source>Theme Color</source>
+        <translation>テーマカラー</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="898"/>
+        <source>Change the theme color of your application</source>
+        <translation>アプリケーションのテーマカラーを変更します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="904"/>
+        <source>Interface Zoom</source>
+        <translation>インターフェースズーム</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="905"/>
+        <source>Change the size of widgets and fonts</source>
+        <translation>ウィジェットとフォントのサイズを変更します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="919"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="920"/>
+        <source>Set your preferred language for UI</source>
+        <translation>UIの優先言語を設定します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="927"/>
+        <source>Restore window position</source>
+        <translation>ウィンドウ位置を復元</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="929"/>
+        <source>When enabled, the application reopens at the last recorded size and position</source>
+        <translation>有効にすると、アプリケーションは最後に記録されたサイズと位置で再開します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="936"/>
+        <source>Advanced Settings</source>
+        <translation>詳細設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="937"/>
+        <source>Enable to show more options in Pre-configuration</source>
+        <translation>事前設定でより多くのオプションを表示するには有効にします</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="945"/>
+        <source>Background Image</source>
+        <translation>背景画像</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="947"/>
+        <source>Select an image as application background</source>
+        <translation>アプリケーションの背景として画像を選択します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="953"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="994"/>
+        <source>Choose an image file (png/jpg/webp/bmp)</source>
+        <translation>画像ファイルを選択 (png/jpg/webp/bmp)</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="960"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1001"/>
+        <source>Browse image file</source>
+        <translation>画像ファイルを参照</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="974"/>
+        <source>Clear background image</source>
+        <translation>背景画像をクリア</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="986"/>
+        <source>Home Cover Image</source>
+        <translation>ホームカバー画像</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="988"/>
+        <source>Select an image as Home hero cover</source>
+        <translation>ホームのヒーローカバーとして画像を選択</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1011"/>
+        <source>Clear home cover image</source>
+        <translation>ホームカバー画像をクリア</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1022"/>
+        <source>Background Opacity</source>
+        <translation>背景の不透明度</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1023"/>
+        <source>Adjust transparency of the background image</source>
+        <translation>背景画像の透明度を調整します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1048"/>
+        <source>Global Shortcuts</source>
+        <translation>グローバルショートカット</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1056"/>
+        <source>Start task shortcut</source>
+        <translation>タスク開始ショートカット</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1059"/>
+        <source>Default Ctrl+F1, can also trigger when focus is not on the main window</source>
+        <translation>デフォルトはCtrl+F1、メインウィンドウにフォーカスがない場合もトリガーできます</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1064"/>
+        <source>Ctrl+</source>
+        <translation>Ctrl+</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1067"/>
+        <source>Format: Modifier+[Key], e.g. Ctrl+F1</source>
+        <translation>形式: 修飾キー+[キー]、例: Ctrl+F1</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1079"/>
+        <source>Stop task shortcut</source>
+        <translation>タスク停止ショートカット</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1081"/>
+        <source>Default Alt+F1, used to interrupt tasks in advance</source>
+        <translation>デフォルトはAlt+F1、タスクを事前に中断するために使用します</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1085"/>
+        <source>Alt+</source>
+        <translation>Alt+</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1088"/>
+        <source>Format: Modifier+[Key], e.g. Alt+F1</source>
+        <translation>形式：修飾キー+[キー]、例：Alt+F1</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1126"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1129"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1137"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1140"/>
+        <source>Permission denied, shortcuts disabled</source>
+        <translation>権限がありません、ショートカットは無効です</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1156"/>
+        <source>Key cannot be empty</source>
+        <translation>キーは空にできません</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1165"/>
+        <source>Key format is invalid, restored to previous configuration.</source>
+        <translation>キーの形式が無効です、前の設定に戻しました。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1174"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1174"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1177"/>
+        <source>Start task</source>
+        <translation>タスクを開始</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1179"/>
+        <source>Stop task</source>
+        <translation>タスクを停止</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1183"/>
+        <source>Shortcut must start with %1+, used for %2.</source>
+        <translation>ショートカットは%1+で始める必要があります、%2に使用されます。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1232"/>
+        <source>Notice</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1235"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2457"/>
+        <source>DingTalk Notification Enabled</source>
+        <translation>DingTalk通知が有効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1237"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2459"/>
+        <source>DingTalk Notification Disabled</source>
+        <translation>DingTalk通知が無効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1240"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1251"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1262"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1274"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1286"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1299"/>
+        <source>Modify</source>
+        <translation>変更</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1242"/>
+        <source>DingTalk</source>
+        <translation>DingTalk</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1247"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2463"/>
+        <source>Lark Notification Enabled</source>
+        <translation>Lark通知が有効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1249"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2465"/>
+        <source>Lark Notification Disabled</source>
+        <translation>Lark通知が無効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1253"/>
+        <source>Lark</source>
+        <translation>Lark</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1258"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2469"/>
+        <source>SMTP Notification Enabled</source>
+        <translation>SMTP通知が有効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1260"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2471"/>
+        <source>SMTP Notification Disabled</source>
+        <translation>SMTP通知が無効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1264"/>
+        <source>SMTP</source>
+        <translation>SMTP</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1269"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2475"/>
+        <source>WxPusher Notification Enabled</source>
+        <translation>WxPusher通知が有効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1271"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2477"/>
+        <source>WxPusher Notification Disabled</source>
+        <translation>WxPusher通知が無効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1276"/>
+        <source>WxPusher</source>
+        <translation>WxPusher</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1281"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2481"/>
+        <source>QYWX Notification Enabled</source>
+        <translation>QYWX通知有効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1283"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2483"/>
+        <source>QYWX Notification Disabled</source>
+        <translation>QYWX通知無効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1288"/>
+        <source>QYWX</source>
+        <translation>QYWX</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1294"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2487"/>
+        <source>Gotify Notification Enabled</source>
+        <translation>Gotify通知有効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1296"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2489"/>
+        <source>Gotify Notification Disabled</source>
+        <translation>Gotify通知無効</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1301"/>
+        <source>Gotify</source>
+        <translation>Gotify</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1317"/>
+        <source>Send Format</source>
+        <translation>送信形式</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1318"/>
+        <source>Plain text or HTML for external notifications (e.g. email body)</source>
+        <translation>外部通知用のプレーンテキストまたはHTML（例：メール本文）</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1319"/>
+        <source>Plain text</source>
+        <translation>プレーンテキスト</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1319"/>
+        <source>HTML</source>
+        <translation>HTML</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1327"/>
+        <source>Attach screenshot to notice</source>
+        <translation>通知にスクリーンショットを添付</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1329"/>
+        <source>When enabled, a screenshot is captured and sent with notifications (e.g. as email attachment) if controller is available</source>
+        <translation>有効時、コントローラーが利用可能な場合、スクリーンショットを撮影して通知と共に送信します（例：メール添付）</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1338"/>
+        <source>Configure</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1340"/>
+        <source>Notification Timing</source>
+        <translation>通知タイミング</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1341"/>
+        <source>Configure when to send notifications</source>
+        <translation>通知を送信するタイミングを設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1351"/>
+        <source>Task Settings</source>
+        <translation>タスク設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1356"/>
+        <source>Monitor capture rate</source>
+        <translation>監視キャプチャレート</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1358"/>
+        <source>Screenshot frames per second for the monitoring preview (uses a separate controller connection based on your controller settings)</source>
+        <translation>監視プレビューの秒間スクリーンショット枚数（メイン設定のコントローラー種別で独立接続）</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1373"/>
+        <source>Recognition ROI overlay</source>
+        <translation>認識枠オーバーレイ</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1375"/>
+        <source>Draw recognition hit boxes on the monitoring preview during tasks. This feature consumes significant system resources.</source>
+        <translation>タスク実行中に監視プレビューへ認識ヒット枠を描画します。この機能は大量のシステムリソースを消費します。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1385"/>
+        <source>GPU Acceleration</source>
+        <translation>GPUアクセラレーション</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1386"/>
+        <source>Enable GPU hardware acceleration for resource inference</source>
+        <translation>リソース推論にGPUハードウェアアクセラレーションを有効化</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1396"/>
+        <source>Reset task page layout</source>
+        <translation>タスクページのレイアウトをリセット</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1398"/>
+        <source>Restore the task, option, and log columns to equal width (1:1:1)</source>
+        <translation>タスク、オプション、ログの列を均等幅（1:1:1）に戻す</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1417"/>
+        <source>mirrorchyan CDK</source>
+        <translation>mirrorchyan CDK</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1418"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1611"/>
+        <source>Enter mirrorchyan CDK for stable update path</source>
+        <translation>安定した更新パスのためのmirrorchyan CDKを入力</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1420"/>
+        <source>About Mirror</source>
+        <translation>Mirrorについて</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1426"/>
+        <source>Automatically update after startup</source>
+        <translation>起動後自動更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1427"/>
+        <source>Automatically download and apply updates once available</source>
+        <translation>利用可能になると自動的にダウンロードして適用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1436"/>
+        <source>select update channel for resource</source>
+        <translation>リソースの更新チャンネルを選択</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1437"/>
+        <source>select the update channel for the resource</source>
+        <translation>リソースの更新チャンネルを選択</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1444"/>
+        <source>Force use GitHub</source>
+        <translation>GitHubを強制使用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1445"/>
+        <source>Force use GitHub for resource update</source>
+        <translation>リソース更新にGitHubを強制使用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1394"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1451"/>
+        <source>Reset</source>
+        <translation>リセット</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1453"/>
+        <source>Reset resource</source>
+        <translation>リソースをリセット</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1454"/>
+        <source>Redownload resource package without version/tag check</source>
+        <translation>バージョン/タグチェックなしでリソースパッケージを再ダウンロード</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1460"/>
+        <source>GitHub API Key</source>
+        <translation>GitHub APIキー</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1462"/>
+        <source>Personal access tokens increase GitHub API rate limits for update checks.</source>
+        <translation>個人アクセストークンは、更新チェックのGitHub APIレート制限を増やします。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1469"/>
+        <source>Optional token for authenticated GitHub requests</source>
+        <translation>認証済みGitHubリクエスト用のオプショナルトークン</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1478"/>
+        <source>Use Proxy</source>
+        <translation>プロキシを使用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1480"/>
+        <source>After filling in the proxy settings, all traffic except that to the Mirror will be proxied.</source>
+        <translation>プロキシ設定を入力後、ミラーへのトラフィックを除くすべてのトラフィックがプロキシされます。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1504"/>
+        <source>Experimental / Compatibility</source>
+        <translation>実験的 / 互換性</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1508"/>
+        <source>Multi-instance mode</source>
+        <translation>マルチインスタンスモード</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1510"/>
+        <source>Experimental. Allow multiple configurations to run at the same time, each with its own start/stop control, log, and monitor. When off, switching the active configuration is blocked while a task is running.</source>
+        <translation>実験的。複数の設定を同時に実行でき、各設定に独立した開始/停止、ログ、モニターがあります。オフの場合、タスク実行中はアクティブ設定の切り替えがロックされます。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1519"/>
+        <source>Multi-resource adaptation</source>
+        <translation>マルチリソース適応</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1521"/>
+        <source>Experimental. Enable loading multiple resource bundles; may impact stability.</source>
+        <translation>実験的。複数のリソースバンドルの読み込みを有効化；安定性に影響する可能性があります。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1529"/>
+        <source>Save screenshot</source>
+        <translation>スクリーンショットを保存</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1530"/>
+        <source>Save a screenshot when experimental features run</source>
+        <translation>実験的機能実行時にスクリーンショットを保存</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1537"/>
+        <source>Include images in log zip</source>
+        <translation>ログZIPに画像を含める</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1539"/>
+        <source>Include log images when generating log zip package. The number of images included equals the number displayed in the log interface.</source>
+        <translation>ログZIPパッケージ生成時にログ画像を含める。含まれる画像数は、ログインターフェースに表示される数と等しいです。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1557"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2443"/>
+        <source>Set cache image count, current cache usage: {}</source>
+        <translation>キャッシュ画像数を設定、現在のキャッシュ使用量: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1562"/>
+        <source>Max log images</source>
+        <translation>最大ログ画像数</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1617"/>
+        <source>Resource does not support Mirrorchyan, right-click about mirror to unlock input</source>
+        <translation>リソースはMirrorchyanをサポートしていません、ミラーについて右クリックで入力を解除</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1640"/>
+        <source>decrypt Mirror CDK failed, please fill in again and save.</source>
+        <translation>Mirror CDKの復号に失敗しました、再度入力して保存してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1671"/>
+        <source>Failed to save Mirror CDK: {}</source>
+        <translation>Mirror CDKの保存に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1690"/>
+        <source>Failed to read GitHub token, please save it again.</source>
+        <translation>GitHubトークンの読み込みに失敗しました。もう一度保存してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1715"/>
+        <source>Failed to save GitHub token: {}.</source>
+        <translation>GitHubトークンの保存に失敗しました: {}。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1750"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1806"/>
+        <source>Current version: </source>
+        <translation>現在のバージョン: </translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1753"/>
+        <source>Latest version: </source>
+        <translation>最新バージョン：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1756"/>
+        <source>UI version: </source>
+        <translation>UIバージョン：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1759"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1809"/>
+        <source>MaaFW version: </source>
+        <translation>MaaFWバージョン：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1776"/>
+        <source>MFW-ChainFlow Assistant</source>
+        <translation>MFW-ChainFlow アシスタント</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1789"/>
+        <source>MFW-ChainFlow Assistant provides a visual orchestrator for MaaFramework users, covering configuration management, scheduling, notifications and custom extensions.</source>
+        <translation>MFW-ChainFlow アシスタントは、MaaFrameworkユーザー向けの視覚的オーケストレーターを提供し、設定管理、スケジューリング、通知、カスタム拡張機能をカバーします。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1883"/>
+        <source>Select background image</source>
+        <translation>背景画像を選択</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1885"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1903"/>
+        <source>Images (*.png *.jpg *.jpeg *.bmp *.webp)</source>
+        <translation>画像ファイル (*.png *.jpg *.jpeg *.bmp *.webp)</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1901"/>
+        <source>Select home cover image</source>
+        <translation>ホームカバー画像を選択</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1920"/>
+        <source>UI update feature is not implemented yet.</source>
+        <translation>UI更新機能はまだ実装されていません。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2292"/>
+        <source>Enable multi-resource adaptation?</source>
+        <translation>マルチリソース適応を有効にしますか？</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2296"/>
+        <source>After enabling the multi-configuration feature, the resource directories will be reconfigured. This operation is irreversible; please proceed with caution.</source>
+        <translation>マルチ設定機能を有効にすると、リソースディレクトリが再構成されます。この操作は元に戻せませんので、ご注意ください。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2309"/>
+        <source>Enable</source>
+        <translation>有効にする</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2311"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3089"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2358"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2377"/>
+        <source>Image file does not exist</source>
+        <translation>画像ファイルが存在しません</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2544"/>
+        <source>Configuration takes effect after restart</source>
+        <translation>設定は再起動後に有効になります</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2657"/>
+        <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
+        <translation>CI/Alphaリソースバージョンでは自動更新が無効です。手動で更新してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2741"/>
+        <source>Update failed too many times, local update package has been cleared.</source>
+        <translation>更新失敗が多すぎるため、ローカルの更新パッケージがクリアされました。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2817"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2860"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2910"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2961"/>
+        <source>Stop update</source>
+        <translation>更新を停止</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2881"/>
+        <source>New version available: </source>
+        <translation>新しいバージョンが利用可能：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2942"/>
+        <source>Task page layout has been reset</source>
+        <translation>タスクページのレイアウトがリセットされました</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2949"/>
+        <source>Update is already running</source>
+        <translation>更新は既に実行中です</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2955"/>
+        <source>Service is not ready, cannot reset resource</source>
+        <translation>サービスが準備できていないため、リソースをリセットできません</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2966"/>
+        <source>Starting Reset Resource</source>
+        <translation>リソースリセットを開始中</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3016"/>
+        <source>Failed to rename updater: {}</source>
+        <translation>アップデータの名前変更に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3028"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3161"/>
+        <source>Failed to start updater: {}</source>
+        <translation>アップデータの起動に失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3071"/>
+        <source>Update package not found, please try updating again.</source>
+        <translation>更新パッケージが見つかりません。再度更新をお試しください。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3088"/>
+        <source>Update now</source>
+        <translation>今すぐ更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3092"/>
+        <source>Restart required to update</source>
+        <translation>更新には再起動が必要です</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3094"/>
+        <source>Update package detected</source>
+        <translation>更新パッケージを検出しました</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3097"/>
+        <source>Hot update is unavailable. A restart update is required. Proceed?</source>
+        <translation>ホットアップデートは利用できません。再起動によるアップデートが必要です。実行しますか？</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3100"/>
+        <source>Found a downloaded update package. Do you want to launch the updater now?</source>
+        <translation>ダウンロード済みのアップデートパッケージが見つかりました。アップデータを今すぐ起動しますか？</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3123"/>
+        <source>Auto updating in %1 s</source>
+        <translation>%1 秒後に自動アップデート</translation>
+    </message>
+</context>
+<context>
+    <name>SpeedrunConfigWidget</name>
+    <message>
+        <source>Speedrun Configuration</source>
+        <translation type="vanished">スピードラン設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="80"/>
+        <source>Daily</source>
+        <translation>日次</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="81"/>
+        <source>Weekly</source>
+        <translation>週次</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="82"/>
+        <source>Monthly</source>
+        <translation>月次</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation type="vanished">モード</translation>
+    </message>
+    <message>
+        <source>Refresh Hour</source>
+        <translation type="vanished">更新時刻</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="169"/>
+        <source>Monday</source>
+        <translation>月曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="170"/>
+        <source>Tuesday</source>
+        <translation>火曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="171"/>
+        <source>Wednesday</source>
+        <translation>水曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="172"/>
+        <source>Thursday</source>
+        <translation>木曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="173"/>
+        <source>Friday</source>
+        <translation>金曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="174"/>
+        <source>Saturday</source>
+        <translation>土曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="175"/>
+        <source>Sunday</source>
+        <translation>日曜日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="64"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="86"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="107"/>
+        <source>Weekday</source>
+        <translation>平日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="37"/>
+        <source>Condition Execution</source>
+        <translation>条件実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="53"/>
+        <source>Condition</source>
+        <translation>条件</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="62"/>
+        <source>Always</source>
+        <translation>常に</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="63"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="97"/>
+        <source>Run Count</source>
+        <translation>実行回数</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="65"/>
+        <source>Month Day</source>
+        <translation>月日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="66"/>
+        <source>After Time</source>
+        <translation>時間後</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="67"/>
+        <source>Condition Type</source>
+        <translation>条件タイプ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="70"/>
+        <source>Condition Configuration</source>
+        <translation>条件設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="83"/>
+        <source>Period</source>
+        <translation>期間</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="92"/>
+        <source>Refresh Timeline</source>
+        <translation>タイムラインを更新</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="89"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="115"/>
+        <source>Day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="123"/>
+        <source>Hour</source>
+        <translation>時</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="130"/>
+        <source>Execution</source>
+        <translation>実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="139"/>
+        <source>Run</source>
+        <translation>実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="140"/>
+        <source>Skip</source>
+        <translation>スキップ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="141"/>
+        <source>Execution Type</source>
+        <translation>実行タイプ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="144"/>
+        <source>Execution Configuration</source>
+        <translation>実行設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="152"/>
+        <source>Notify</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="157"/>
+        <source>External Notify</source>
+        <translation>外部通知</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="vanished">一般</translation>
+    </message>
+    <message>
+        <source>Refresh Count</source>
+        <translation type="vanished">更新回数</translation>
+    </message>
+    <message>
+        <source>Min Interval (hours)</source>
+        <translation type="vanished">最小間隔（時間）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="150"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="155"/>
+        <source>Enabled</source>
+        <translation>有効</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="151"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="156"/>
+        <source>Disabled</source>
+        <translation>無効</translation>
+    </message>
+    <message>
+        <source>Enable Speedrun</source>
+        <translation type="vanished">スピードランを有効にする</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="vanished">該当なし</translation>
+    </message>
+    <message>
+        <source>Current Count</source>
+        <translation type="vanished">現在のカウント</translation>
+    </message>
+    <message>
+        <source>Last Run Time</source>
+        <translation type="vanished">最終実行時刻</translation>
+    </message>
+</context>
+<context>
+    <name>StartBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/start_bar_widget.py" line="30"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+</context>
+<context>
+    <name>StartupDialogManager</name>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="303"/>
+        <source>Missing Runtime Library</source>
+        <translation>ランタイムライブラリが不足しています</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="305"/>
+        <source>Failed to load MAA framework library.
 
 Microsoft Visual C++ Redistributable runtime library is missing.
 
 Current system: {platform}
 
 Please download and install Visual C++ Redistributable, then restart the program.</source>
-            <translation>MAAフレームワークライブラリの読み込みに失敗しました。
+        <translation>MAAフレームワークライブラリの読み込みに失敗しました。
 
 Microsoft Visual C++ Redistributable ランタイムライブラリが不足しています。
 
 現在のシステム: {platform}
 
 Visual C++ Redistributable をダウンロードしてインストールし、プログラムを再起動してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="312" />
-            <source>Open Download Page</source>
-            <translation>ダウンロードページを開く</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="317" />
-            <location filename="../utils/startup_dialog.py" line="539" />
-            <source>Exit</source>
-            <translation>終了</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="336" />
-            <source>Program Already Running</source>
-            <translation>プログラムは既に実行中です</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="338" />
-            <source>The program is already running.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="312"/>
+        <source>Open Download Page</source>
+        <translation>ダウンロードページを開く</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="317"/>
+        <location filename="../utils/startup_dialog.py" line="539"/>
+        <source>Exit</source>
+        <translation>終了</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="336"/>
+        <source>Program Already Running</source>
+        <translation>プログラムは既に実行中です</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="338"/>
+        <source>The program is already running.
 
 Please close the existing window or terminate the process in Task Manager before starting again.</source>
-            <translation>プログラムは既に実行中です。
+        <translation>プログラムは既に実行中です。
 
 既存のウィンドウを閉じるか、タスクマネージャーでプロセスを終了してから再起動してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="343" />
-            <location filename="../utils/startup_dialog.py" line="373" />
-            <location filename="../utils/startup_dialog.py" line="388" />
-            <location filename="../utils/startup_dialog.py" line="581" />
-            <source>OK</source>
-            <translation>OK</translation>
-        </message>
-        <message>
-            <source>关闭失败</source>
-            <translation type="vanished">閉じるのに失敗しました</translation>
-        </message>
-        <message>
-            <source>无法在 30 秒内关闭正在运行的实例，请手动关闭后重试。</source>
-            <translation type="vanished">30秒以内に実行中のインスタンスを閉じられませんでした。手動で閉じてから再試行してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="368" />
-            <source>The existing instance did not respond and could not be closed automatically.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="343"/>
+        <location filename="../utils/startup_dialog.py" line="373"/>
+        <location filename="../utils/startup_dialog.py" line="388"/>
+        <location filename="../utils/startup_dialog.py" line="581"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>关闭失败</source>
+        <translation type="vanished">閉じるのに失敗しました</translation>
+    </message>
+    <message>
+        <source>无法在 30 秒内关闭正在运行的实例，请手动关闭后重试。</source>
+        <translation type="vanished">30秒以内に実行中のインスタンスを閉じられませんでした。手動で閉じてから再試行してください。</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="368"/>
+        <source>The existing instance did not respond and could not be closed automatically.
 
 Please end the process in Task Manager, then start the program again.</source>
-            <translation>既存のインスタンスが応答せず、自動的に閉じることができませんでした。
+        <translation>既存のインスタンスが応答せず、自動的に閉じることができませんでした。
 
 タスクマネージャーでプロセスを終了してから、プログラムを再度起動してください。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="379" />
-            <source>The existing instance did not respond and could not be closed automatically.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="379"/>
+        <source>The existing instance did not respond and could not be closed automatically.
 
 Please try one of the following:
 • End the process in Task Manager
-• Right-click the program and choose "Run as administrator"
+• Right-click the program and choose &quot;Run as administrator&quot;
 
 If the existing instance was started with administrator privileges, you must also run as administrator to replace it.</source>
-            <translation>既存のインスタンスが応答せず、自動的に閉じることができませんでした。
+        <translation>既存のインスタンスが応答せず、自動的に閉じることができませんでした。
 
 次のいずれかを試してください：
 • タスクマネージャーでプロセスを終了する
 • プログラムを右クリックして「管理者として実行」を選択する
 
 既存のインスタンスが管理者権限で起動された場合、置き換えるには管理者として実行する必要があります。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="395" />
-            <source>Run as administrator</source>
-            <translation>管理者として実行</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="403" />
-            <source>Unable to Start Program</source>
-            <translation>プログラムを起動できません</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="433" />
-            <source>正在关闭</source>
-            <translation>閉じています</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="434" />
-            <source>检测到其他任务正在运行，正在关闭中...</source>
-            <translation>他のタスクが実行中です。閉じています...</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="485" />
-            <source>Program Error</source>
-            <translation>プログラムエラー</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="487" />
-            <source>The program encountered an unhandled exception.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="395"/>
+        <source>Run as administrator</source>
+        <translation>管理者として実行</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="403"/>
+        <source>Unable to Start Program</source>
+        <translation>プログラムを起動できません</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="433"/>
+        <source>正在关闭</source>
+        <translation>閉じています</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="434"/>
+        <source>检测到其他任务正在运行，正在关闭中...</source>
+        <translation>他のタスクが実行中です。閉じています...</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="485"/>
+        <source>Program Error</source>
+        <translation>プログラムエラー</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="487"/>
+        <source>The program encountered an unhandled exception.
 
 Error type: {exc_type}
 Error message: {exc_value}
 
 Below is the detailed stack trace. You can copy it and report to the developer:</source>
-            <translation>プログラムで未処理の例外が発生しました。
+        <translation>プログラムで未処理の例外が発生しました。
 
 エラータイプ: {exc_type}
 エラーメッセージ: {exc_value}
 
 以下は詳細なスタックトレースです。開発者に報告するためにコピーできます:</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="495" />
-            <location filename="../utils/startup_dialog.py" line="534" />
-            <source>Copy Error Info</source>
-            <translation>エラー情報をコピー</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="500" />
-            <source>Continue</source>
-            <translation>続行</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="524" />
-            <source>Program Failed to Start</source>
-            <translation>プログラムの起動に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="526" />
-            <source>The program failed during startup and could not continue.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="495"/>
+        <location filename="../utils/startup_dialog.py" line="534"/>
+        <source>Copy Error Info</source>
+        <translation>エラー情報をコピー</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="500"/>
+        <source>Continue</source>
+        <translation>続行</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="524"/>
+        <source>Program Failed to Start</source>
+        <translation>プログラムの起動に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="526"/>
+        <source>The program failed during startup and could not continue.
 
 Error type: {exc_type}
 Error message: {exc_value}
 
 You can copy the detailed stack trace below and report it to the developer.</source>
-            <translation>プログラムの起動中に失敗し、続行できませんでした。
+        <translation>プログラムの起動中に失敗し、続行できませんでした。
 
 エラータイプ: {exc_type}
 エラーメッセージ: {exc_value}
 
 詳細なスタックトレースを以下からコピーして、開発者に報告できます。</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskDragListWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_widget.py" line="724" />
-            <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
-            <translation>ベースタスク（リソース、ポストタスク）は削除できません（ID: {id}）</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskFlowRunner</name>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="346" />
-            <source>Resource or controller not initialized</source>
-            <translation>リソースまたはコントローラーが初期化されていません</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="348" />
-            <source>Agent connection failed</source>
-            <translation>エージェント接続に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="355" />
-            <source>Agent connection timed out ({}s)</source>
-            <translation>MAA Agent 接続がタイムアウトしました（{} 秒）</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="357" />
-            <source>Agent configuration is missing</source>
-            <translation>Agent 設定がありません</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="359" />
-            <source>Agent configuration list is empty</source>
-            <translation>Agent 設定リストが空です</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="361" />
-            <source>Agent configuration is invalid</source>
-            <translation>Agent 設定が無効です</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="363" />
-            <source>Agent child_exec is missing</source>
-            <translation>Agent の child_exec 設定がありません</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="365" />
-            <source>Failed to start agent process</source>
-            <translation>Agent プロセスの起動に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="367" />
-            <source>Tasker not initialized</source>
-            <translation>タスカーが初期化されていません</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="369" />
-            <location filename="../core/runner/task_flow.py" line="374" />
-            <source>Unknown MaaFW error code: {}</source>
-            <translation>不明なMaaFWエラーコード: {}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="422" />
-            <source>Task Flow Started</source>
-            <translation>タスクフローを開始しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="423" />
-            <source>Task flow has been started.</source>
-            <translation>タスクフローが開始されました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="517" />
-            <source>Controller or resource in current config does not exist in interface. They have been reset to default. Please check and run again.</source>
-            <translation>現在の設定のコントローラーまたはリソースがインターフェースに存在しません。デフォルトにリセットされました。確認して再実行してください。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="526" />
-            <source>Starting to load resources...</source>
-            <translation>リソースの読み込みを開始しています...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="577" />
-            <source>Embedded Agent prepare failed: </source>
-            <translation>埋め込みエージェントの準備に失敗しました: </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="578" />
-            <source>Unknown reason</source>
-            <translation>不明な理由</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="597" />
-            <source>Agent Service Start</source>
-            <translation>エージェントサービスを開始</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="606" />
-            <source>Starting to load custom components...</source>
-            <translation>カスタムコンポーネントの読み込みを開始しています...</translation>
-        </message>
-        <message>
-            <source>Custom components loading failed, the flow is terminated: </source>
-            <translation type="vanished">カスタムコンポーネントの読み込みに失敗しました。フローは終了しました: </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="657" />
-            <location filename="../core/runner/task_flow.py" line="1505" />
-            <location filename="../core/runner/task_flow.py" line="1536" />
-            <source>please try to reset resource in setting</source>
-            <translation>設定でリソースをリセットしてください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="667" />
-            <source>Embedded aspect ratio checker failed to load, the flow is terminated.</source>
-            <translation>埋め込みアスペクト比チェッカーの読み込みに失敗したため、フローを終了します。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="698" />
-            <source>Starting to connect device...</source>
-            <translation>デバイスの接続を開始しています...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="713" />
-            <source>Device Connection Failed</source>
-            <translation>デバイス接続失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="715" />
-            <source>Failed to connect to the device.</source>
-            <translation>デバイスへの接続に失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="718" />
-            <location filename="../core/runner/task_flow.py" line="2953" />
-            <location filename="../core/runner/task_flow.py" line="2965" />
-            <source>Device connected successfully</source>
-            <translation>デバイスが正常に接続されました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="723" />
-            <source>Device Connected Successfully</source>
-            <translation>デバイス接続成功</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="724" />
-            <source>Device has been connected successfully.</source>
-            <translation>デバイスは正常に接続されました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="775" />
-            <location filename="../core/runner/task_flow.py" line="798" />
-            <location filename="../core/runner/task_flow.py" line="827" />
-            <location filename="../core/runner/task_flow.py" line="1638" />
-            <source>Task Failed</source>
-            <translation>タスク失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="777" />
-            <source>Task '{}' failed and the flow was terminated.</source>
-            <translation>タスク「{}」が失敗し、フローは終了しました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="799" />
-            <source>Task '{}' was aborted.</source>
-            <translation>タスク「{}」は中止されました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="811" />
-            <source>Task Completed</source>
-            <translation>タスク完了</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="813" />
-            <source>Task '{}' has been completed successfully.</source>
-            <translation>タスク「{}」は正常に完了しました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="828" />
-            <source>Task '{}' failed with error: {}</source>
-            <translation>タスク「{}」はエラーで失敗しました: {}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="844" />
-            <source>All tasks have been completed</source>
-            <translation>すべてのタスクが完了しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="849" />
-            <source>Task flow error: </source>
-            <translation>タスクフローエラー: </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="901" />
-            <source>Task Flow Completed</source>
-            <translation>タスクフロー完了</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1015" />
-            <source>INFO</source>
-            <translation>情報</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1016" />
-            <source>WARNING</source>
-            <translation>警告</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1017" />
-            <source>ERROR</source>
-            <translation>エラー</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1018" />
-            <source>CRITICAL</source>
-            <translation>致命的</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1039" />
-            <source>Base controller/resource task is missing.</source>
-            <translation>基本コントローラー/リソースタスクがありません。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1060" />
-            <source>Current controller does not exist in interface: {}</source>
-            <translation>現在のコントローラーはインターフェースに存在しません: {}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1061" />
-            <location filename="../core/runner/task_flow.py" line="1066" />
-            <location filename="../core/runner/task_flow.py" line="1077" />
-            <location filename="../core/runner/task_flow.py" line="1078" />
-            <source>(empty)</source>
-            <translation>（空）</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1065" />
-            <source>Current resource does not exist in interface: {}</source>
-            <translation>現在のリソースはインターフェースに存在しません: {}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1075" />
-            <source>Current resource is not enabled for current controller: {} -&gt; {}</source>
-            <translation>現在のリソースは現在のコントローラーで有効ではありません: {} -&gt; {}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1274" />
-            <source>Controller name is empty, please configure controller in settings</source>
-            <translation>コントローラー名が空です。設定でコントローラーを構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1293" />
-            <location filename="../core/runner/task_flow.py" line="1466" />
-            <source>Controller '{}' not found, please reset controller in settings</source>
-            <translation>コントローラー '{}' が見つかりません。設定でコントローラーをリセットしてください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1373" />
-            <source>this Controller requires admin permission to run</source>
-            <translation>このコントローラーは管理者権限が必要です</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1388" />
-            <source>Controller configuration is invalid, please reset controller in settings</source>
-            <translation>コントローラー構成が無効です。設定でコントローラーをリセットしてください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1456" />
-            <source>Controller config not found, please configure controller first</source>
-            <translation>コントローラー構成が見つかりません。まずコントローラーを構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1482" />
-            <source>Resource target is empty, please configure resource in settings</source>
-            <translation>リソースターゲットが空です。設定でリソースを構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1500" />
-            <source>Resource '{}' not found, please reset resource in settings</source>
-            <translation>リソース '{}' が見つかりません。設定でリソースをリセットしてください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1530" />
-            <source>Resource </source>
-            <translation>リソース </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1532" />
-            <source> not found in bundle: </source>
-            <translation> はバンドル内に見つかりません: </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1599" />
-            <source>Task </source>
-            <translation>タスク </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1601" />
-            <source> follows speedrun limit, skipping this run: </source>
-            <translation> はスピードラン制限に従います。この実行をスキップします: </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1639" />
-            <source>Task '{}' execution failed.</source>
-            <translation>タスク '{}' の実行に失敗しました。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1665" />
-            <source>Builtin task failed: </source>
-            <translation>組み込みタスクが失敗しました: </translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1752" />
-            <source>Stopping task...</source>
-            <translation>タスクを停止中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1779" />
-            <location filename="../core/runner/task_flow.py" line="1862" />
-            <source>Unknown Task Entry</source>
-            <translation>不明なタスクエントリ</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1868" />
-            <source>{} hours {} minutes</source>
-            <translation>{} 時間 {} 分</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1870" />
-            <source>{} minutes</source>
-            <translation>{} 分</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1873" />
-            <source>Task entry '{}' has been running for {}. This may indicate a problem. Please check the task status.</source>
-            <translation>タスクエントリ '{}' は {} 実行中です。問題が発生している可能性があります。タスクステータスを確認してください。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1887" />
-            <source>Task running time too long</source>
-            <translation>タスクの実行時間が長すぎます</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1941" />
-            <source>Auto searching ADB devices...</source>
-            <translation>ADB デバイスを自動検索中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2395" />
-            <source>WlRoots controller is only supported on Linux</source>
-            <translation>WlRootsコントローラーはLinuxでのみサポートされています</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2426" />
-            <source>WlRoots Wayland socket path is empty, please configure it in settings</source>
-            <translation>WlRoots Waylandソケットパスが空です。設定で構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2443" />
-            <source>Connecting to WlRoots: {socket}</source>
-            <translation>WlRootsに接続中: {socket}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2448" />
-            <source>WlRoots connected successfully</source>
-            <translation>WlRootsに正常に接続しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2452" />
-            <source>Failed to connect to WlRoots</source>
-            <translation>WlRootsへの接続に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2458" />
-            <source>MacOS controller is only supported on macOS</source>
-            <translation>MacOSコントローラーはmacOSでのみサポートされています</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2521" />
-            <source>Auto searching MacOS windows...</source>
-            <translation>MacOSウィンドウを自動検索中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2532" />
-            <source>Window ID is empty, please configure window connection in settings</source>
-            <translation>ウィンドウIDが空です。設定でウィンドウ接続を構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2687" />
-            <source>ADB path is empty, please configure ADB path in settings</source>
-            <translation>ADB パスが空です。設定で ADB パスを構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2706" />
-            <source>ADB connection address is empty, please configure device connection in settings</source>
-            <translation>ADB 接続アドレスが空です。設定でデバイス接続を構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1957" />
-            <source>try to start emulator</source>
-            <translation>エミュレータを起動してみる</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="653" />
-            <source>Custom components loading failed, the flow is terminated.</source>
-            <translation>カスタムコンポーネントの読み込みに失敗したため、フローを終了します。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1967" />
-            <source>waiting for emulator start...</source>
-            <translation>エミュレータの起動を待機中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1997" />
-            <location filename="../core/runner/task_flow.py" line="2111" />
-            <location filename="../core/runner/task_flow.py" line="2118" />
-            <location filename="../core/runner/task_flow.py" line="2166" />
-            <location filename="../core/runner/task_flow.py" line="2254" />
-            <location filename="../core/runner/task_flow.py" line="2261" />
-            <location filename="../core/runner/task_flow.py" line="2304" />
-            <location filename="../core/runner/task_flow.py" line="2546" />
-            <location filename="../core/runner/task_flow.py" line="2552" />
-            <location filename="../core/runner/task_flow.py" line="2597" />
-            <source>Device connection failed</source>
-            <translation>デバイス接続に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2004" />
-            <source>Win32 controller is only supported on Windows</source>
-            <translation>Win32コントローラーはWindowsでのみサポートされています</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2080" />
-            <source>Auto searching Win32 windows...</source>
-            <translation>Win32ウィンドウを自動検索中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2093" />
-            <location filename="../core/runner/task_flow.py" line="2240" />
-            <source>Window handle (hwnd) is empty, please configure window connection in settings</source>
-            <translation>ウィンドウハンドル（hwnd）が空です。設定でウィンドウ接続を構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2126" />
-            <location filename="../core/runner/task_flow.py" line="2268" />
-            <location filename="../core/runner/task_flow.py" line="2559" />
-            <source>try to start program</source>
-            <translation>プログラムを起動してみる</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2154" />
-            <location filename="../core/runner/task_flow.py" line="2292" />
-            <location filename="../core/runner/task_flow.py" line="2585" />
-            <source>waiting for program start...</source>
-            <translation>プログラムの起動を待機中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2173" />
-            <source>Gamepad controller is only supported on Windows</source>
-            <translation>ゲームパッドコントローラーはWindowsでのみサポートされています</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2230" />
-            <source>Auto searching desktop windows...</source>
-            <translation>デスクトップウィンドウを自動検索中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2311" />
-            <source>PlayCover controller is only supported on macOS</source>
-            <translation>PlayCoverコントローラーはmacOSでのみサポートされています</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2349" />
-            <source>PlayCover UUID is empty, please configure UUID in settings</source>
-            <translation>PlayCover UUIDが空です。設定でUUIDを構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2361" />
-            <source>PlayCover connection address is empty, please configure address in settings</source>
-            <translation>PlayCover接続アドレスが空です。設定でアドレスを構成してください</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2374" />
-            <source>Connecting to PlayCover: {address} (UUID: {uuid})</source>
-            <translation>PlayCoverに接続中: {address} (UUID: {uuid})</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2383" />
-            <source>PlayCover connected successfully</source>
-            <translation>PlayCoverへの接続に成功しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2387" />
-            <source>Failed to connect to PlayCover</source>
-            <translation>PlayCoverへの接続に失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2715" />
-            <source>ADB connection port is empty; use host:port (for example 127.0.0.1:5555) or pick a device after starting the emulator.</source>
-            <translation>ADB接続ポートが空です。host:port（例：127.0.0.1:5555）を使用するか、エミュレータ起動後にデバイスを選択してください。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2942" />
-            <location filename="../core/runner/task_flow.py" line="2989" />
-            <source> seconds</source>
-            <translation> 秒</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="3386" />
-            <source>Notifications are being sent, please wait up to {} seconds</source>
-            <translation>通知を送信中です。最大 {} 秒お待ちください</translation>
-        </message>
-        <message>
-            <source>This period's remaining execution count is 0</source>
-            <translation type="vanished">今月の残り実行回数は0です</translation>
-        </message>
-        <message>
-            <source>Not enough time passed since last run. Minimum interval is </source>
-            <translation type="vanished">前回の実行から十分な時間が経過していません。最小間隔は </translation>
-        </message>
-        <message>
-            <source> hours.</source>
-            <translation type="vanished"> 時間です。</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskInterface</name>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="28" />
-            <source>Task Information</source>
-            <translation>タスク情報</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="29" />
-            <source>Configuration Selection</source>
-            <translation>構成選択</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="112" />
-            <location filename="../view/task_interface/task_interface_logic.py" line="147" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-        <message>
-            <source>Please select a special task to run.</source>
-            <translation type="vanished">特殊タスクを選択して実行してください。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="142" />
-            <source>Stop</source>
-            <translation>停止</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskListItem</name>
-        <message>
-            <source>Launch Program</source>
-            <translation type="vanished">プログラムを起動</translation>
-        </message>
-        <message>
-            <source>Wait</source>
-            <translation type="vanished">待機</translation>
-        </message>
-        <message>
-            <source>Wait Until</source>
-            <translation type="vanished">時刻まで待機</translation>
-        </message>
-        <message>
-            <source>System Notification</source>
-            <translation type="vanished">システム通知</translation>
-        </message>
-        <message>
-            <source>External Notification</source>
-            <translation type="vanished">外部通知</translation>
-        </message>
-        <message>
-            <source>Yes</source>
-            <translation type="vanished">はい</translation>
-        </message>
-        <message>
-            <source>No</source>
-            <translation type="vanished">いいえ</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="409" />
-            <source>Resource</source>
-            <translation>リソース</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="411" />
-            <source>Controller</source>
-            <translation>コントローラー</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="413" />
-            <source>Post-Action</source>
-            <translation>後処理</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="677" />
-            <source>Run this task</source>
-            <translation>このタスクを実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="685" />
-            <source>Run from here</source>
-            <translation>ここから実行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="693" />
-            <source>Insert task</source>
-            <translation>タスクを挿入</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="734" />
-            <source>No available tasks to add.</source>
-            <translation>追加可能なタスクがありません。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="871" />
-            <source>Delete task</source>
-            <translation>タスクを削除</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="888" />
-            <source>Delete Task</source>
-            <translation>タスクを削除</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="889" />
-            <source>Are you sure you want to delete task '{}'?</source>
-            <translation>タスク '{}' を削除してもよろしいですか？</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskListToolBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="303" />
-            <source>Tasks</source>
-            <translation>タスク</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="335" />
-            <source>No available tasks to add.</source>
-            <translation>追加可能なタスクがありません。</translation>
-        </message>
-        <message>
-            <source>Switch to Normal Tasks</source>
-            <translation type="vanished">通常タスクに切り替え</translation>
-        </message>
-        <message>
-            <source>Special Tasks</source>
-            <translation type="vanished">特殊タスク</translation>
-        </message>
-        <message>
-            <source>Switch to Special Tasks</source>
-            <translation type="vanished">特殊タスクに切り替え</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="455" />
-            <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
-            <translation>基本タスク（リソース、後処理）は削除できません（ID: {id}）</translation>
-        </message>
-    </context>
-    <context>
-        <name>Update</name>
-        <message>
-            <location filename="../utils/update.py" line="1415" />
-            <location filename="../utils/update.py" line="1508" />
-            <source>Checking for updates...</source>
-            <translation>更新を確認中...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1233" />
-            <source>Already up to date</source>
-            <translation>最新の状態です</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1238" />
-            <location filename="../utils/update.py" line="1446" />
-            <location filename="../utils/update.py" line="1467" />
-            <location filename="../utils/update.py" line="1581" />
-            <location filename="../utils/update.py" line="1604" />
-            <source>Download failed</source>
-            <translation>ダウンロードに失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1440" />
-            <location filename="../utils/update.py" line="1575" />
-            <source>Preparing to download update...</source>
-            <translation>更新のダウンロード準備中...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1475" />
-            <location filename="../utils/update.py" line="1612" />
-            <source>Download complete</source>
-            <translation>ダウンロード完了</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1634" />
-            <source>Applying hotfix...</source>
-            <translation>ホットフィックスを適用中...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1689" />
-            <source>Update applied successfully</source>
-            <translation>アップデートが正常に適用されました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1740" />
-            <source>Failed to update</source>
-            <translation>アップデートに失敗しました</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1832" />
-            <location filename="../utils/update.py" line="1855" />
-            <location filename="../utils/update.py" line="1941" />
-            <location filename="../utils/update.py" line="1974" />
-            <location filename="../utils/update.py" line="2335" />
-            <location filename="../utils/update.py" line="2358" />
-            <location filename="../utils/update.py" line="2435" />
-            <location filename="../utils/update.py" line="2472" />
-            <source>Found update: </source>
-            <translation>アップデートが見つかりました: </translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1885" />
-            <location filename="../utils/update.py" line="1896" />
-            <location filename="../utils/update.py" line="1908" />
-            <location filename="../utils/update.py" line="1919" />
-            <location filename="../utils/update.py" line="1956" />
-            <location filename="../utils/update.py" line="1963" />
-            <location filename="../utils/update.py" line="2381" />
-            <location filename="../utils/update.py" line="2390" />
-            <location filename="../utils/update.py" line="2402" />
-            <location filename="../utils/update.py" line="2413" />
-            <location filename="../utils/update.py" line="2454" />
-            <location filename="../utils/update.py" line="2461" />
-            <source>GitHub update check failed</source>
-            <translation>GitHub アップデートチェックに失敗しました</translation>
-        </message>
-    </context>
-    <context>
-        <name>WxPusherNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="385" />
-            <source>WxPusher Spt:</source>
-            <translation>WxPusher Spt:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="386" />
-            <source>WxPusher Status:</source>
-            <translation>WxPusher ステータス:</translation>
-        </message>
-    </context>
-    <context>
-        <name>context</name>
-        <message>
-            <source>Builtin launch program path is empty, skipped.</source>
-            <translation type="vanished">組み込みタスクの起動プログラムのパスが空のため、スキップしました。</translation>
-        </message>
-        <message>
-            <source>Builtin task waits {seconds} second(s).</source>
-            <translation type="vanished">組み込みタスクは {seconds} 秒待機します。</translation>
-        </message>
-        <message>
-            <source>Builtin wait-until target time is empty, skipped.</source>
-            <translation type="vanished">組み込みの時刻待機タスクの対象時刻が空のため、スキップしました。</translation>
-        </message>
-        <message>
-            <source>Failed to parse builtin wait-until target time: {time}</source>
-            <translation type="vanished">時刻待機の対象時刻を解析できませんでした: {time}</translation>
-        </message>
-        <message>
-            <source>Builtin task waits until {time}.</source>
-            <translation type="vanished">組み込みタスクは {time} まで待機します。</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="46" />
-            <source>$builtin_log_launch_program_path_empty</source>
-            <translation>$builtin_log_launch_program_path_empty</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="62" />
-            <source>$builtin_log_wait_duration</source>
-            <translation>$builtin_log_wait_duration</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="70" />
-            <source>$builtin_log_wait_until_empty</source>
-            <translation>$builtin_log_wait_until_empty</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="77" />
-            <source>$builtin_log_wait_until_invalid</source>
-            <translation>$builtin_log_wait_until_invalid</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="84" />
-            <source>$builtin_log_wait_until_target</source>
-            <translation>$builtin_log_wait_until_target</translation>
-        </message>
-    </context>
-    <context>
-        <name>manager</name>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="704" />
-            <source>启动参数已弃用</source>
-            <translation>起動パラメータは非推奨です</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="706" />
-            <source>检测到旧版命令行参数。程序已按新规则继续启动，但请尽快改用下列写法：</source>
-            <translation>旧バージョンのコマンドライン引数を検出しました。プログラムは新しいルールで起動を続行しますが、できるだけ早く以下の記法に切り替えてください：</translation>
-        </message>
-    </context>
+    </message>
+</context>
+<context>
+    <name>TaskDragListWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_widget.py" line="724"/>
+        <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
+        <translation>ベースタスク（リソース、ポストタスク）は削除できません（ID: {id}）</translation>
+    </message>
+</context>
+<context>
+    <name>TaskFlowRunner</name>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="379"/>
+        <source>Resource or controller not initialized</source>
+        <translation>リソースまたはコントローラーが初期化されていません</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="381"/>
+        <source>Agent connection failed</source>
+        <translation>エージェント接続に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="388"/>
+        <source>Agent connection timed out ({}s)</source>
+        <translation>MAA Agent 接続がタイムアウトしました（{} 秒）</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="390"/>
+        <source>Agent configuration is missing</source>
+        <translation>Agent 設定がありません</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="392"/>
+        <source>Agent configuration list is empty</source>
+        <translation>Agent 設定リストが空です</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="394"/>
+        <source>Agent configuration is invalid</source>
+        <translation>Agent 設定が無効です</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="396"/>
+        <source>Agent child_exec is missing</source>
+        <translation>Agent の child_exec 設定がありません</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="398"/>
+        <source>Failed to start agent process</source>
+        <translation>Agent プロセスの起動に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="400"/>
+        <source>Tasker not initialized</source>
+        <translation>タスカーが初期化されていません</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="402"/>
+        <location filename="../core/runner/task_flow.py" line="407"/>
+        <source>Unknown MaaFW error code: {}</source>
+        <translation>不明なMaaFWエラーコード: {}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="455"/>
+        <source>Task Flow Started</source>
+        <translation>タスクフローを開始しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="456"/>
+        <source>Task flow has been started.</source>
+        <translation>タスクフローが開始されました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="550"/>
+        <source>Controller or resource in current config does not exist in interface. They have been reset to default. Please check and run again.</source>
+        <translation>現在の設定のコントローラーまたはリソースがインターフェースに存在しません。デフォルトにリセットされました。確認して再実行してください。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="559"/>
+        <source>Starting to load resources...</source>
+        <translation>リソースの読み込みを開始しています...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="610"/>
+        <source>Embedded Agent prepare failed: </source>
+        <translation>埋め込みエージェントの準備に失敗しました: </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="611"/>
+        <source>Unknown reason</source>
+        <translation>不明な理由</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="630"/>
+        <source>Agent Service Start</source>
+        <translation>エージェントサービスを開始</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="639"/>
+        <source>Starting to load custom components...</source>
+        <translation>カスタムコンポーネントの読み込みを開始しています...</translation>
+    </message>
+    <message>
+        <source>Custom components loading failed, the flow is terminated: </source>
+        <translation type="vanished">カスタムコンポーネントの読み込みに失敗しました。フローは終了しました: </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="697"/>
+        <location filename="../core/runner/task_flow.py" line="1522"/>
+        <location filename="../core/runner/task_flow.py" line="1553"/>
+        <source>please try to reset resource in setting</source>
+        <translation>設定でリソースをリセットしてください</translation>
+    </message>
+    <message>
+        <source>Embedded aspect ratio checker failed to load, the flow is terminated.</source>
+        <translation type="vanished">埋め込みアスペクト比チェッカーの読み込みに失敗したため、フローを終了します。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="715"/>
+        <source>Starting to connect device...</source>
+        <translation>デバイスの接続を開始しています...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="730"/>
+        <source>Device Connection Failed</source>
+        <translation>デバイス接続失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="732"/>
+        <source>Failed to connect to the device.</source>
+        <translation>デバイスへの接続に失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="735"/>
+        <location filename="../core/runner/task_flow.py" line="2970"/>
+        <location filename="../core/runner/task_flow.py" line="2982"/>
+        <source>Device connected successfully</source>
+        <translation>デバイスが正常に接続されました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="740"/>
+        <source>Device Connected Successfully</source>
+        <translation>デバイス接続成功</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="741"/>
+        <source>Device has been connected successfully.</source>
+        <translation>デバイスは正常に接続されました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="792"/>
+        <location filename="../core/runner/task_flow.py" line="815"/>
+        <location filename="../core/runner/task_flow.py" line="844"/>
+        <location filename="../core/runner/task_flow.py" line="1655"/>
+        <source>Task Failed</source>
+        <translation>タスク失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="794"/>
+        <source>Task &apos;{}&apos; failed and the flow was terminated.</source>
+        <translation>タスク「{}」が失敗し、フローは終了しました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="816"/>
+        <source>Task &apos;{}&apos; was aborted.</source>
+        <translation>タスク「{}」は中止されました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="828"/>
+        <source>Task Completed</source>
+        <translation>タスク完了</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="830"/>
+        <source>Task &apos;{}&apos; has been completed successfully.</source>
+        <translation>タスク「{}」は正常に完了しました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="845"/>
+        <source>Task &apos;{}&apos; failed with error: {}</source>
+        <translation>タスク「{}」はエラーで失敗しました: {}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="861"/>
+        <source>All tasks have been completed</source>
+        <translation>すべてのタスクが完了しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="866"/>
+        <source>Task flow error: </source>
+        <translation>タスクフローエラー: </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="918"/>
+        <source>Task Flow Completed</source>
+        <translation>タスクフロー完了</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1032"/>
+        <source>INFO</source>
+        <translation>情報</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1033"/>
+        <source>WARNING</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1034"/>
+        <source>ERROR</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1035"/>
+        <source>CRITICAL</source>
+        <translation>致命的</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1056"/>
+        <source>Base controller/resource task is missing.</source>
+        <translation>基本コントローラー/リソースタスクがありません。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1077"/>
+        <source>Current controller does not exist in interface: {}</source>
+        <translation>現在のコントローラーはインターフェースに存在しません: {}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1078"/>
+        <location filename="../core/runner/task_flow.py" line="1083"/>
+        <location filename="../core/runner/task_flow.py" line="1094"/>
+        <location filename="../core/runner/task_flow.py" line="1095"/>
+        <source>(empty)</source>
+        <translation>（空）</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1082"/>
+        <source>Current resource does not exist in interface: {}</source>
+        <translation>現在のリソースはインターフェースに存在しません: {}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1092"/>
+        <source>Current resource is not enabled for current controller: {} -&gt; {}</source>
+        <translation>現在のリソースは現在のコントローラーで有効ではありません: {} -&gt; {}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1291"/>
+        <source>Controller name is empty, please configure controller in settings</source>
+        <translation>コントローラー名が空です。設定でコントローラーを構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1310"/>
+        <location filename="../core/runner/task_flow.py" line="1483"/>
+        <source>Controller &apos;{}&apos; not found, please reset controller in settings</source>
+        <translation>コントローラー &apos;{}&apos; が見つかりません。設定でコントローラーをリセットしてください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1390"/>
+        <source>this Controller requires admin permission to run</source>
+        <translation>このコントローラーは管理者権限が必要です</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1405"/>
+        <source>Controller configuration is invalid, please reset controller in settings</source>
+        <translation>コントローラー構成が無効です。設定でコントローラーをリセットしてください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1473"/>
+        <source>Controller config not found, please configure controller first</source>
+        <translation>コントローラー構成が見つかりません。まずコントローラーを構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1499"/>
+        <source>Resource target is empty, please configure resource in settings</source>
+        <translation>リソースターゲットが空です。設定でリソースを構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1517"/>
+        <source>Resource &apos;{}&apos; not found, please reset resource in settings</source>
+        <translation>リソース &apos;{}&apos; が見つかりません。設定でリソースをリセットしてください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1547"/>
+        <source>Resource </source>
+        <translation>リソース </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1549"/>
+        <source> not found in bundle: </source>
+        <translation> はバンドル内に見つかりません: </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1616"/>
+        <source>Task </source>
+        <translation>タスク </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1618"/>
+        <source> follows speedrun limit, skipping this run: </source>
+        <translation> はスピードラン制限に従います。この実行をスキップします: </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1656"/>
+        <source>Task &apos;{}&apos; execution failed.</source>
+        <translation>タスク &apos;{}&apos; の実行に失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1682"/>
+        <source>Builtin task failed: </source>
+        <translation>組み込みタスクが失敗しました: </translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1769"/>
+        <source>Stopping task...</source>
+        <translation>タスクを停止中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1796"/>
+        <location filename="../core/runner/task_flow.py" line="1879"/>
+        <source>Unknown Task Entry</source>
+        <translation>不明なタスクエントリ</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1885"/>
+        <source>{} hours {} minutes</source>
+        <translation>{} 時間 {} 分</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1887"/>
+        <source>{} minutes</source>
+        <translation>{} 分</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1890"/>
+        <source>Task entry &apos;{}&apos; has been running for {}. This may indicate a problem. Please check the task status.</source>
+        <translation>タスクエントリ &apos;{}&apos; は {} 実行中です。問題が発生している可能性があります。タスクステータスを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1904"/>
+        <source>Task running time too long</source>
+        <translation>タスクの実行時間が長すぎます</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1958"/>
+        <source>Auto searching ADB devices...</source>
+        <translation>ADB デバイスを自動検索中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2412"/>
+        <source>WlRoots controller is only supported on Linux</source>
+        <translation>WlRootsコントローラーはLinuxでのみサポートされています</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2443"/>
+        <source>WlRoots Wayland socket path is empty, please configure it in settings</source>
+        <translation>WlRoots Waylandソケットパスが空です。設定で構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2460"/>
+        <source>Connecting to WlRoots: {socket}</source>
+        <translation>WlRootsに接続中: {socket}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2465"/>
+        <source>WlRoots connected successfully</source>
+        <translation>WlRootsに正常に接続しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2469"/>
+        <source>Failed to connect to WlRoots</source>
+        <translation>WlRootsへの接続に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2475"/>
+        <source>MacOS controller is only supported on macOS</source>
+        <translation>MacOSコントローラーはmacOSでのみサポートされています</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2538"/>
+        <source>Auto searching MacOS windows...</source>
+        <translation>MacOSウィンドウを自動検索中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2549"/>
+        <source>Window ID is empty, please configure window connection in settings</source>
+        <translation>ウィンドウIDが空です。設定でウィンドウ接続を構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2704"/>
+        <source>ADB path is empty, please configure ADB path in settings</source>
+        <translation>ADB パスが空です。設定で ADB パスを構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2723"/>
+        <source>ADB connection address is empty, please configure device connection in settings</source>
+        <translation>ADB 接続アドレスが空です。設定でデバイス接続を構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1974"/>
+        <source>try to start emulator</source>
+        <translation>エミュレータを起動してみる</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="693"/>
+        <source>Custom components loading failed, the flow is terminated.</source>
+        <translation>カスタムコンポーネントの読み込みに失敗したため、フローを終了します。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1984"/>
+        <source>waiting for emulator start...</source>
+        <translation>エミュレータの起動を待機中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2014"/>
+        <location filename="../core/runner/task_flow.py" line="2128"/>
+        <location filename="../core/runner/task_flow.py" line="2135"/>
+        <location filename="../core/runner/task_flow.py" line="2183"/>
+        <location filename="../core/runner/task_flow.py" line="2271"/>
+        <location filename="../core/runner/task_flow.py" line="2278"/>
+        <location filename="../core/runner/task_flow.py" line="2321"/>
+        <location filename="../core/runner/task_flow.py" line="2563"/>
+        <location filename="../core/runner/task_flow.py" line="2569"/>
+        <location filename="../core/runner/task_flow.py" line="2614"/>
+        <source>Device connection failed</source>
+        <translation>デバイス接続に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2021"/>
+        <source>Win32 controller is only supported on Windows</source>
+        <translation>Win32コントローラーはWindowsでのみサポートされています</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2097"/>
+        <source>Auto searching Win32 windows...</source>
+        <translation>Win32ウィンドウを自動検索中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2110"/>
+        <location filename="../core/runner/task_flow.py" line="2257"/>
+        <source>Window handle (hwnd) is empty, please configure window connection in settings</source>
+        <translation>ウィンドウハンドル（hwnd）が空です。設定でウィンドウ接続を構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2143"/>
+        <location filename="../core/runner/task_flow.py" line="2285"/>
+        <location filename="../core/runner/task_flow.py" line="2576"/>
+        <source>try to start program</source>
+        <translation>プログラムを起動してみる</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2171"/>
+        <location filename="../core/runner/task_flow.py" line="2309"/>
+        <location filename="../core/runner/task_flow.py" line="2602"/>
+        <source>waiting for program start...</source>
+        <translation>プログラムの起動を待機中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2190"/>
+        <source>Gamepad controller is only supported on Windows</source>
+        <translation>ゲームパッドコントローラーはWindowsでのみサポートされています</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2247"/>
+        <source>Auto searching desktop windows...</source>
+        <translation>デスクトップウィンドウを自動検索中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2328"/>
+        <source>PlayCover controller is only supported on macOS</source>
+        <translation>PlayCoverコントローラーはmacOSでのみサポートされています</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2366"/>
+        <source>PlayCover UUID is empty, please configure UUID in settings</source>
+        <translation>PlayCover UUIDが空です。設定でUUIDを構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2378"/>
+        <source>PlayCover connection address is empty, please configure address in settings</source>
+        <translation>PlayCover接続アドレスが空です。設定でアドレスを構成してください</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2391"/>
+        <source>Connecting to PlayCover: {address} (UUID: {uuid})</source>
+        <translation>PlayCoverに接続中: {address} (UUID: {uuid})</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2400"/>
+        <source>PlayCover connected successfully</source>
+        <translation>PlayCoverへの接続に成功しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2404"/>
+        <source>Failed to connect to PlayCover</source>
+        <translation>PlayCoverへの接続に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2732"/>
+        <source>ADB connection port is empty; use host:port (for example 127.0.0.1:5555) or pick a device after starting the emulator.</source>
+        <translation>ADB接続ポートが空です。host:port（例：127.0.0.1:5555）を使用するか、エミュレータ起動後にデバイスを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2959"/>
+        <location filename="../core/runner/task_flow.py" line="3006"/>
+        <source> seconds</source>
+        <translation> 秒</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="3411"/>
+        <source>Notifications are being sent, please wait up to {} seconds</source>
+        <translation>通知を送信中です。最大 {} 秒お待ちください</translation>
+    </message>
+    <message>
+        <source>This period&apos;s remaining execution count is 0</source>
+        <translation type="vanished">今月の残り実行回数は0です</translation>
+    </message>
+    <message>
+        <source>Not enough time passed since last run. Minimum interval is </source>
+        <translation type="vanished">前回の実行から十分な時間が経過していません。最小間隔は </translation>
+    </message>
+    <message>
+        <source> hours.</source>
+        <translation type="vanished"> 時間です。</translation>
+    </message>
+</context>
+<context>
+    <name>TaskInterface</name>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="28"/>
+        <source>Task Information</source>
+        <translation>タスク情報</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="29"/>
+        <source>Configuration Selection</source>
+        <translation>構成選択</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="112"/>
+        <location filename="../view/task_interface/task_interface_logic.py" line="147"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <source>Please select a special task to run.</source>
+        <translation type="vanished">特殊タスクを選択して実行してください。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="142"/>
+        <source>Stop</source>
+        <translation>停止</translation>
+    </message>
+</context>
+<context>
+    <name>TaskListItem</name>
+    <message>
+        <source>Launch Program</source>
+        <translation type="vanished">プログラムを起動</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation type="vanished">待機</translation>
+    </message>
+    <message>
+        <source>Wait Until</source>
+        <translation type="vanished">時刻まで待機</translation>
+    </message>
+    <message>
+        <source>System Notification</source>
+        <translation type="vanished">システム通知</translation>
+    </message>
+    <message>
+        <source>External Notification</source>
+        <translation type="vanished">外部通知</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="vanished">はい</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="vanished">いいえ</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="409"/>
+        <source>Resource</source>
+        <translation>リソース</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="411"/>
+        <source>Controller</source>
+        <translation>コントローラー</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="413"/>
+        <source>Post-Action</source>
+        <translation>後処理</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="677"/>
+        <source>Run this task</source>
+        <translation>このタスクを実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="685"/>
+        <source>Run from here</source>
+        <translation>ここから実行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="693"/>
+        <source>Insert task</source>
+        <translation>タスクを挿入</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="734"/>
+        <source>No available tasks to add.</source>
+        <translation>追加可能なタスクがありません。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="871"/>
+        <source>Delete task</source>
+        <translation>タスクを削除</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="888"/>
+        <source>Delete Task</source>
+        <translation>タスクを削除</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="889"/>
+        <source>Are you sure you want to delete task &apos;{}&apos;?</source>
+        <translation>タスク &apos;{}&apos; を削除してもよろしいですか？</translation>
+    </message>
+</context>
+<context>
+    <name>TaskListToolBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="322"/>
+        <source>Tasks</source>
+        <translation>タスク</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="354"/>
+        <source>No available tasks to add.</source>
+        <translation>追加可能なタスクがありません。</translation>
+    </message>
+    <message>
+        <source>Switch to Normal Tasks</source>
+        <translation type="vanished">通常タスクに切り替え</translation>
+    </message>
+    <message>
+        <source>Special Tasks</source>
+        <translation type="vanished">特殊タスク</translation>
+    </message>
+    <message>
+        <source>Switch to Special Tasks</source>
+        <translation type="vanished">特殊タスクに切り替え</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="474"/>
+        <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
+        <translation>基本タスク（リソース、後処理）は削除できません（ID: {id}）</translation>
+    </message>
+</context>
+<context>
+    <name>Update</name>
+    <message>
+        <location filename="../utils/update.py" line="1415"/>
+        <location filename="../utils/update.py" line="1508"/>
+        <source>Checking for updates...</source>
+        <translation>更新を確認中...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1233"/>
+        <source>Already up to date</source>
+        <translation>最新の状態です</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1238"/>
+        <location filename="../utils/update.py" line="1446"/>
+        <location filename="../utils/update.py" line="1467"/>
+        <location filename="../utils/update.py" line="1581"/>
+        <location filename="../utils/update.py" line="1604"/>
+        <source>Download failed</source>
+        <translation>ダウンロードに失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1440"/>
+        <location filename="../utils/update.py" line="1575"/>
+        <source>Preparing to download update...</source>
+        <translation>更新のダウンロード準備中...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1475"/>
+        <location filename="../utils/update.py" line="1612"/>
+        <source>Download complete</source>
+        <translation>ダウンロード完了</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1634"/>
+        <source>Applying hotfix...</source>
+        <translation>ホットフィックスを適用中...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1689"/>
+        <source>Update applied successfully</source>
+        <translation>アップデートが正常に適用されました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1740"/>
+        <source>Failed to update</source>
+        <translation>アップデートに失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1832"/>
+        <location filename="../utils/update.py" line="1855"/>
+        <location filename="../utils/update.py" line="1941"/>
+        <location filename="../utils/update.py" line="1974"/>
+        <location filename="../utils/update.py" line="2335"/>
+        <location filename="../utils/update.py" line="2358"/>
+        <location filename="../utils/update.py" line="2435"/>
+        <location filename="../utils/update.py" line="2472"/>
+        <source>Found update: </source>
+        <translation>アップデートが見つかりました: </translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1885"/>
+        <location filename="../utils/update.py" line="1896"/>
+        <location filename="../utils/update.py" line="1908"/>
+        <location filename="../utils/update.py" line="1919"/>
+        <location filename="../utils/update.py" line="1956"/>
+        <location filename="../utils/update.py" line="1963"/>
+        <location filename="../utils/update.py" line="2381"/>
+        <location filename="../utils/update.py" line="2390"/>
+        <location filename="../utils/update.py" line="2402"/>
+        <location filename="../utils/update.py" line="2413"/>
+        <location filename="../utils/update.py" line="2454"/>
+        <location filename="../utils/update.py" line="2461"/>
+        <source>GitHub update check failed</source>
+        <translation>GitHub アップデートチェックに失敗しました</translation>
+    </message>
+</context>
+<context>
+    <name>WxPusherNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="385"/>
+        <source>WxPusher Spt:</source>
+        <translation>WxPusher Spt:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="386"/>
+        <source>WxPusher Status:</source>
+        <translation>WxPusher ステータス:</translation>
+    </message>
+</context>
+<context>
+    <name>context</name>
+    <message>
+        <source>Builtin launch program path is empty, skipped.</source>
+        <translation type="vanished">組み込みタスクの起動プログラムのパスが空のため、スキップしました。</translation>
+    </message>
+    <message>
+        <source>Builtin task waits {seconds} second(s).</source>
+        <translation type="vanished">組み込みタスクは {seconds} 秒待機します。</translation>
+    </message>
+    <message>
+        <source>Builtin wait-until target time is empty, skipped.</source>
+        <translation type="vanished">組み込みの時刻待機タスクの対象時刻が空のため、スキップしました。</translation>
+    </message>
+    <message>
+        <source>Failed to parse builtin wait-until target time: {time}</source>
+        <translation type="vanished">時刻待機の対象時刻を解析できませんでした: {time}</translation>
+    </message>
+    <message>
+        <source>Builtin task waits until {time}.</source>
+        <translation type="vanished">組み込みタスクは {time} まで待機します。</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="46"/>
+        <source>$builtin_log_launch_program_path_empty</source>
+        <translation>$builtin_log_launch_program_path_empty</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="62"/>
+        <source>$builtin_log_wait_duration</source>
+        <translation>$builtin_log_wait_duration</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="70"/>
+        <source>$builtin_log_wait_until_empty</source>
+        <translation>$builtin_log_wait_until_empty</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="77"/>
+        <source>$builtin_log_wait_until_invalid</source>
+        <translation>$builtin_log_wait_until_invalid</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="84"/>
+        <source>$builtin_log_wait_until_target</source>
+        <translation>$builtin_log_wait_until_target</translation>
+    </message>
+</context>
+<context>
+    <name>manager</name>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="704"/>
+        <source>启动参数已弃用</source>
+        <translation>起動パラメータは非推奨です</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="706"/>
+        <source>检测到旧版命令行参数。程序已按新规则继续启动，但请尽快改用下列写法：</source>
+        <translation>旧バージョンのコマンドライン引数を検出しました。プログラムは新しいルールで起動を続行しますが、できるだけ早く以下の記法に切り替えてください：</translation>
+    </message>
+</context>
 </TS>

--- a/app/i18n/i18n.zh_CN.ts
+++ b/app/i18n/i18n.zh_CN.ts
@@ -1215,38 +1215,43 @@ The following configurations using this bundle will also be deleted:
 <context>
     <name>ConfigListItem</name>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1103"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1016"/>
+        <source>Running</source>
+        <translation>运行中</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1124"/>
         <source>Rename config</source>
         <translation>重命名配置</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1108"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1129"/>
         <source>Copy config ID</source>
         <translation>复制配置ID</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1113"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1134"/>
         <source>Share config</source>
         <translation>分享配置</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1188"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1209"/>
         <source>Failed to load config for sharing.</source>
         <translation>加载配置以共享失败。</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1195"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1216"/>
         <source>Config has no resource bundle, cannot share.</source>
         <translation>配置没有资源包，无法共享。</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1211"/>
-        <location filename="../view/task_interface/components/list_item.py" line="1216"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1232"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1237"/>
         <source>Failed to encode config for sharing.</source>
         <translation>编码配置以共享失败。</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_item.py" line="1222"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1243"/>
         <source>Config copied to clipboard.</source>
         <translation>配置已复制到剪贴板。</translation>
     </message>
@@ -1259,25 +1264,25 @@ The following configurations using this bundle will also be deleted:
         <translation>配置</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="184"/>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="253"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="203"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="272"/>
         <source>Task is running, configurations are locked.</source>
         <translation>任务正在运行，配置已锁定。</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="239"/>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="240"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="258"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="259"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="244"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="263"/>
         <source>Shared config version ({0}) differs from current resource version ({1}); imported anyway.</source>
         <translation>共享配置版本({0})与当前资源版本({1})不同；已强制导入。</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="259"/>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="262"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="278"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="281"/>
         <source>Cannot delete the last configuration!</source>
         <translation>无法删除最后一项配置</translation>
     </message>
@@ -1295,6 +1300,19 @@ The following configurations using this bundle will also be deleted:
     <message>
         <source>Stop</source>
         <translation type="vanished">停止</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigMonitorTile</name>
+    <message>
+        <location filename="../view/monitor_interface/multi_config_monitor_grid.py" line="99"/>
+        <source>Running</source>
+        <translation>运行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/multi_config_monitor_grid.py" line="129"/>
+        <source>Not running</source>
+        <translation>未运行</translation>
     </message>
 </context>
 <context>
@@ -2366,22 +2384,22 @@ Please check for updates first, or visit the GitHub releases page.</source>
 <context>
     <name>LogoutputWidget</name>
     <message>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="110"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="121"/>
         <source>Monitor</source>
         <translation>监控</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="305"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="319"/>
         <source>Log Output</source>
         <translation>日志输出</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="515"/>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="886"/>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="891"/>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="896"/>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="898"/>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="899"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="582"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="954"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="961"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="966"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="968"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="969"/>
         <source>System</source>
         <translation>System</translation>
     </message>
@@ -2390,7 +2408,7 @@ Please check for updates first, or visit the GitHub releases page.</source>
         <translation type="vanished">启动监控任务</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/logoutput_widget.py" line="311"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="325"/>
         <source>generate log zip</source>
         <translation>生成日志压缩包</translation>
     </message>
@@ -2778,116 +2796,130 @@ Supported controllers in the current resource: {controllers}</source>
 <context>
     <name>MonitorInterface</name>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="204"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="385"/>
         <source>Click to sync this frame to the device</source>
         <translation>点击以同步操作到设备</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="222"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="431"/>
         <source>FPS: --</source>
         <translation>FPS:--</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="273"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="482"/>
         <source>Save Screenshot</source>
         <translation>保存截图</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="279"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="488"/>
         <source>Capture the current preview and store it on disk</source>
         <translation>保存截图到设备</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="263"/>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="616"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="472"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1074"/>
         <source>Start Monitoring</source>
         <translation>开始监控</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="154"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="341"/>
         <source>Monitor</source>
         <translation>显示器</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="156"/>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="369"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="343"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="654"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="672"/>
         <source>Idle</source>
         <translation>空闲</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="164"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="412"/>
         <source>Live device preview via an independent controller connection. Click the preview to sync taps to the device.</source>
         <translation>通过独立控制器连接进行实时设备预览。点击预览可将点击同步到设备。</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="213"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="416"/>
+        <source>Multi-instance mode: all configurations are shown below. Stopped configurations display a power-off indicator. Click a card to switch the active configuration.</source>
+        <translation>多实例模式：下方显示所有配置。已停止的配置显示电源关闭图标。点击卡片可切换当前激活配置。</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="422"/>
         <source>Preview will appear when monitoring starts</source>
         <translation>监控开始时将显示预览</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="244"/>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="386"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="453"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="689"/>
         <source>Resolution: --</source>
         <translation>分辨率：--</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="270"/>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="618"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="479"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1076"/>
         <source>Start monitoring task</source>
         <translation>启动监控任务</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="283"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="492"/>
         <source>Monitoring starts automatically when a task runs</source>
         <translation>任务运行时自动开始监控</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="363"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="650"/>
+        <source>{0} / {1} running</source>
+        <translation>{0} / {1} 个运行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="666"/>
         <source>Connecting</source>
         <translation>连接中</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="366"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="669"/>
         <source>Running</source>
         <translation>运行中</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="375"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="678"/>
         <source>Capture rate: {} FPS</source>
         <translation>采集帧率：{} FPS</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="381"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="684"/>
         <source>Resolution: {} × {}</source>
         <translation>分辨率：{} × {}</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="701"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1206"/>
         <source>Screenshot saved to </source>
         <translation>截图保存到: </translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="813"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1333"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1378"/>
         <source>Device connection failed, cannot start monitoring</source>
         <translation>设备连接失败，无法开始监控</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="612"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1070"/>
         <source>Stop Monitoring</source>
         <translation>停止监控</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="614"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1072"/>
         <source>Stop monitoring task</source>
         <translation>停止监控任务</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="821"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1340"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1386"/>
         <source>Monitoring started</source>
         <translation>监控开始</translation>
     </message>
     <message>
-        <location filename="../view/monitor_interface/monitor_interface.py" line="827"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1347"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1392"/>
         <source>Failed to start monitoring: </source>
         <translation>启动监控失败：</translation>
     </message>
@@ -4223,16 +4255,16 @@ Supported controllers in the current resource: {controllers}</source>
     <name>SettingInterface</name>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="438"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1727"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1731"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1739"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1743"/>
         <source>ChainFlow Assistant</source>
         <translation>链程助手</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="511"/>
         <location filename="../view/setting_interface/setting_interface.py" line="600"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1756"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1806"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1768"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1818"/>
         <source>License</source>
         <translation>许可证</translation>
     </message>
@@ -4609,13 +4641,13 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1235"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2445"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2457"/>
         <source>DingTalk Notification Enabled</source>
         <translation>钉钉通知已启用</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1237"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2447"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2459"/>
         <source>DingTalk Notification Disabled</source>
         <translation>钉钉通知已禁用</translation>
     </message>
@@ -4636,13 +4668,13 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1247"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2451"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2463"/>
         <source>Lark Notification Enabled</source>
         <translation>飞书通知已启用</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1249"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2453"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2465"/>
         <source>Lark Notification Disabled</source>
         <translation>飞书通知已禁用</translation>
     </message>
@@ -4653,13 +4685,13 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1258"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2457"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2469"/>
         <source>SMTP Notification Enabled</source>
         <translation>SMTP通知已启用</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1260"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2459"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2471"/>
         <source>SMTP Notification Disabled</source>
         <translation>SMTP通知已禁用</translation>
     </message>
@@ -4670,13 +4702,13 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1269"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2463"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2475"/>
         <source>WxPusher Notification Enabled</source>
         <translation>微信通知已启用</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1271"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2465"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2477"/>
         <source>WxPusher Notification Disabled</source>
         <translation>微信通知已禁用</translation>
     </message>
@@ -4687,13 +4719,13 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1281"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2469"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2481"/>
         <source>QYWX Notification Enabled</source>
         <translation>企业微信通知已启用</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1283"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2471"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2483"/>
         <source>QYWX Notification Disabled</source>
         <translation>企业微信通知已禁用</translation>
     </message>
@@ -4704,13 +4736,13 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1294"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2475"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2487"/>
         <source>Gotify Notification Enabled</source>
         <translation>gotify通知已启用</translation>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1296"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2477"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2489"/>
         <source>Gotify Notification Disabled</source>
         <translation>gotify通知已禁用</translation>
     </message>
@@ -4862,7 +4894,7 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1418"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1599"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1611"/>
         <source>Enter mirrorchyan CDK for stable update path</source>
         <translation>输入Mirror酱CDK以获取稳定的更新</translation>
     </message>
@@ -4959,241 +4991,251 @@ Please check for updates first, or visit the GitHub releases page.</source>
     </message>
     <message>
         <location filename="../view/setting_interface/setting_interface.py" line="1508"/>
+        <source>Multi-instance mode</source>
+        <translation>多实例模式</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1510"/>
+        <source>Experimental. Allow multiple configurations to run at the same time, each with its own start/stop control, log, and monitor. When off, switching the active configuration is blocked while a task is running.</source>
+        <translation>实验性功能。允许多个配置同时运行，每个配置有独立的启动/停止控制、日志和监控。关闭后，任务运行期间将禁止切换激活配置。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1519"/>
         <source>Multi-resource adaptation</source>
         <translation>多资源适应</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1510"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1521"/>
         <source>Experimental. Enable loading multiple resource bundles; may impact stability.</source>
         <translation>实验性功能。启用加载多个资源包；可能会影响稳定性。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1518"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1529"/>
         <source>Save screenshot</source>
         <translation>保存截图</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1519"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1530"/>
         <source>Save a screenshot when experimental features run</source>
         <translation>保存运行时的截图</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1526"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1537"/>
         <source>Include images in log zip</source>
         <translation>日志压缩包中包含图片</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1528"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1539"/>
         <source>Include log images when generating log zip package. The number of images included equals the number displayed in the log interface.</source>
         <translation>生成日志压缩包时，请包含日志镜像文件。包含的镜像文件数量与日志界面中显示的数量一致。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1546"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2431"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1557"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2443"/>
         <source>Set cache image count, current cache usage: {}</source>
         <translation>设置缓存图片数量，当前缓存使用情况：{}</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1551"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1562"/>
         <source>Max log images</source>
         <translation>最大日志图像数</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1605"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1617"/>
         <source>Resource does not support Mirrorchyan, right-click about mirror to unlock input</source>
         <translation>资源不支持Mirror酱,右键关于Mirror以解锁输入</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1628"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1640"/>
         <source>decrypt Mirror CDK failed, please fill in again and save.</source>
         <translation>解密Mirror CDK 失败，请重新填写并保存。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1659"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1671"/>
         <source>Failed to save Mirror CDK: {}</source>
         <translation>保存镜像 CDK 失败：{}</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1678"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1690"/>
         <source>Failed to read GitHub token, please save it again.</source>
         <translation>无法读取 GitHub 令牌，请重新保存。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1703"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1715"/>
         <source>Failed to save GitHub token: {}.</source>
         <translation>保存 GitHub 令牌失败：{}。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1738"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1794"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1750"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1806"/>
         <source>Current version: </source>
         <translation>当前版本</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1741"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1753"/>
         <source>Latest version: </source>
         <translation>最新版本</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1744"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1756"/>
         <source>UI version: </source>
         <translation>UI 版本</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1747"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1797"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1759"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1809"/>
         <source>MaaFW version: </source>
         <translation>MaaFW 版本</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1764"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1776"/>
         <source>MFW-ChainFlow Assistant</source>
         <translation>链程助手</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1777"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1789"/>
         <source>MFW-ChainFlow Assistant provides a visual orchestrator for MaaFramework users, covering configuration management, scheduling, notifications and custom extensions.</source>
         <translation>MFW-ChainFlow Assistant 为 MaaFramework 用户提供了一个可视化编排器，涵盖配置管理、调度、通知和自定义扩展。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1871"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1883"/>
         <source>Select background image</source>
         <translation>选择背景图片</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1873"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="1891"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1885"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1903"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp *.webp)</source>
         <translation>图片 (*.png *.jpg *.jpeg *.bmp *.webp)</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1889"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1901"/>
         <source>Select home cover image</source>
         <translation>选择首页封面图</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="1908"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1920"/>
         <source>UI update feature is not implemented yet.</source>
         <translation>UI更新功能尚未实现。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2280"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2292"/>
         <source>Enable multi-resource adaptation?</source>
         <translation>启用多资源自适应?</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2284"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2296"/>
         <source>After enabling the multi-configuration feature, the resource directories will be reconfigured. This operation is irreversible; please proceed with caution.</source>
         <translation>启用多重配置功能后，资源目录将被重新配置。此操作不可逆，请谨慎操作。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2297"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2309"/>
         <source>Enable</source>
         <translation>开启</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2299"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="3066"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2311"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3089"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2346"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2365"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2358"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2377"/>
         <source>Image file does not exist</source>
         <translation>图片不存在</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2532"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2544"/>
         <source>Configuration takes effect after restart</source>
         <translation>配置保存,重启后生效</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2634"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2657"/>
         <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
         <translation>CI/Alpha 资源版本已禁用自动更新，请手动更新。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2718"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2741"/>
         <source>Update failed too many times, local update package has been cleared.</source>
         <translation>多次更新失败,本地更新包已移除</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2794"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2837"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2887"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="2938"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2817"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2860"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2910"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2961"/>
         <source>Stop update</source>
         <translation>停止更新</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2858"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2881"/>
         <source>New version available: </source>
         <translation>最新版本: </translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2919"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2942"/>
         <source>Task page layout has been reset</source>
         <translation>任务页面布局已重置</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2926"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2949"/>
         <source>Update is already running</source>
         <translation>更新正在运行</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2932"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2955"/>
         <source>Service is not ready, cannot reset resource</source>
         <translation>服务未准备完成,无法重置资源</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2943"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2966"/>
         <source>Starting Reset Resource</source>
         <translation>重置资源中</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="2993"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3016"/>
         <source>Failed to rename updater: {}</source>
         <translation>重命名更新器失败：{}</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3005"/>
-        <location filename="../view/setting_interface/setting_interface.py" line="3138"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3028"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3161"/>
         <source>Failed to start updater: {}</source>
         <translation>启动更新器失败：{}</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3048"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3071"/>
         <source>Update package not found, please try updating again.</source>
         <translation>未找到更新包，请重试更新。</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3065"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3088"/>
         <source>Update now</source>
         <translation>立刻更新</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3069"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3092"/>
         <source>Restart required to update</source>
         <translation>需要重启来完成更新</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3071"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3094"/>
         <source>Update package detected</source>
         <translation>更新包删除</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3074"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3097"/>
         <source>Hot update is unavailable. A restart update is required. Proceed?</source>
         <translation>热更不可用,需要重启来进行更新,是否继续?</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3077"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3100"/>
         <source>Found a downloaded update package. Do you want to launch the updater now?</source>
         <translation>找到本地更新包,是否希望进行更新?</translation>
     </message>
     <message>
-        <location filename="../view/setting_interface/setting_interface.py" line="3100"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3123"/>
         <source>Auto updating in %1 s</source>
         <translation>自动更新与 %1 秒</translation>
     </message>
@@ -5609,53 +5651,53 @@ You can copy the detailed stack trace below and report it to the developer.</sou
 <context>
     <name>TaskFlowRunner</name>
     <message>
-        <location filename="../core/runner/task_flow.py" line="346"/>
+        <location filename="../core/runner/task_flow.py" line="379"/>
         <source>Resource or controller not initialized</source>
         <translation>资源或者控制器初始化失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="348"/>
+        <location filename="../core/runner/task_flow.py" line="381"/>
         <source>Agent connection failed</source>
         <translation>MAA Agent服务连接失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="355"/>
+        <location filename="../core/runner/task_flow.py" line="388"/>
         <source>Agent connection timed out ({}s)</source>
         <translation>MAA Agent 服务连接超时（{} 秒）</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="357"/>
+        <location filename="../core/runner/task_flow.py" line="390"/>
         <source>Agent configuration is missing</source>
         <translation>缺少 Agent 配置</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="359"/>
+        <location filename="../core/runner/task_flow.py" line="392"/>
         <source>Agent configuration list is empty</source>
         <translation>Agent 配置列表为空</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="361"/>
+        <location filename="../core/runner/task_flow.py" line="394"/>
         <source>Agent configuration is invalid</source>
         <translation>Agent 配置无效</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="363"/>
+        <location filename="../core/runner/task_flow.py" line="396"/>
         <source>Agent child_exec is missing</source>
         <translation>Agent 缺少 child_exec 配置</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="365"/>
+        <location filename="../core/runner/task_flow.py" line="398"/>
         <source>Failed to start agent process</source>
         <translation>Agent 进程启动失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="367"/>
+        <location filename="../core/runner/task_flow.py" line="400"/>
         <source>Tasker not initialized</source>
         <translation>任务初始化失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="369"/>
-        <location filename="../core/runner/task_flow.py" line="374"/>
+        <location filename="../core/runner/task_flow.py" line="402"/>
+        <location filename="../core/runner/task_flow.py" line="407"/>
         <source>Unknown MaaFW error code: {}</source>
         <translation>未知的 MaaFW 错误代码：{}</translation>
     </message>
@@ -5664,54 +5706,54 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">未知配置</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="422"/>
+        <location filename="../core/runner/task_flow.py" line="455"/>
         <source>Task Flow Started</source>
         <translation>任务流程已启动</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="423"/>
+        <location filename="../core/runner/task_flow.py" line="456"/>
         <source>Task flow has been started.</source>
         <translation>任务流程已启动。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="698"/>
+        <location filename="../core/runner/task_flow.py" line="715"/>
         <source>Starting to connect device...</source>
         <translation>开始连接设备</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="713"/>
+        <location filename="../core/runner/task_flow.py" line="730"/>
         <source>Device Connection Failed</source>
         <translation>设备连接失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="715"/>
+        <location filename="../core/runner/task_flow.py" line="732"/>
         <source>Failed to connect to the device.</source>
         <translation>连接设备失败。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="718"/>
-        <location filename="../core/runner/task_flow.py" line="2953"/>
-        <location filename="../core/runner/task_flow.py" line="2965"/>
+        <location filename="../core/runner/task_flow.py" line="735"/>
+        <location filename="../core/runner/task_flow.py" line="2970"/>
+        <location filename="../core/runner/task_flow.py" line="2982"/>
         <source>Device connected successfully</source>
         <translation>设备连接成功</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="723"/>
+        <location filename="../core/runner/task_flow.py" line="740"/>
         <source>Device Connected Successfully</source>
         <translation>设备连接成功</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="724"/>
+        <location filename="../core/runner/task_flow.py" line="741"/>
         <source>Device has been connected successfully.</source>
         <translation>设备已成功连接。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="597"/>
+        <location filename="../core/runner/task_flow.py" line="630"/>
         <source>Agent Service Start</source>
         <translation>Agent 服务启动</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="606"/>
+        <location filename="../core/runner/task_flow.py" line="639"/>
         <source>Starting to load custom components...</source>
         <translation>开始加载自定义模块</translation>
     </message>
@@ -5720,17 +5762,17 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">自定义组件加载失败，流程终止：</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="657"/>
-        <location filename="../core/runner/task_flow.py" line="1505"/>
-        <location filename="../core/runner/task_flow.py" line="1536"/>
+        <location filename="../core/runner/task_flow.py" line="697"/>
+        <location filename="../core/runner/task_flow.py" line="1522"/>
+        <location filename="../core/runner/task_flow.py" line="1553"/>
         <source>please try to reset resource in setting</source>
         <translation>请尝试在设置中重置资源</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="775"/>
-        <location filename="../core/runner/task_flow.py" line="798"/>
-        <location filename="../core/runner/task_flow.py" line="827"/>
-        <location filename="../core/runner/task_flow.py" line="1638"/>
+        <location filename="../core/runner/task_flow.py" line="792"/>
+        <location filename="../core/runner/task_flow.py" line="815"/>
+        <location filename="../core/runner/task_flow.py" line="844"/>
+        <location filename="../core/runner/task_flow.py" line="1655"/>
         <source>Task Failed</source>
         <translation>任务失败</translation>
     </message>
@@ -5739,37 +5781,37 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">任务“{}”已中止或失败。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="811"/>
+        <location filename="../core/runner/task_flow.py" line="828"/>
         <source>Task Completed</source>
         <translation>任务完成</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="813"/>
+        <location filename="../core/runner/task_flow.py" line="830"/>
         <source>Task &apos;{}&apos; has been completed successfully.</source>
         <translation>任务“{}”已成功完成。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="777"/>
+        <location filename="../core/runner/task_flow.py" line="794"/>
         <source>Task &apos;{}&apos; failed and the flow was terminated.</source>
         <translation>任务“{}”失败，流程已终止。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="799"/>
+        <location filename="../core/runner/task_flow.py" line="816"/>
         <source>Task &apos;{}&apos; was aborted.</source>
         <translation>任务“{}”已中止。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="828"/>
+        <location filename="../core/runner/task_flow.py" line="845"/>
         <source>Task &apos;{}&apos; failed with error: {}</source>
         <translation>任务“{}”失败，错误信息：{}</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="844"/>
+        <location filename="../core/runner/task_flow.py" line="861"/>
         <source>All tasks have been completed</source>
         <translation>所有任务都已完成</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="849"/>
+        <location filename="../core/runner/task_flow.py" line="866"/>
         <source>Task flow error: </source>
         <translation>任务流程错误：</translation>
     </message>
@@ -5806,72 +5848,72 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">任务结果总结：</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="901"/>
+        <location filename="../core/runner/task_flow.py" line="918"/>
         <source>Task Flow Completed</source>
         <translation>任务完成</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1015"/>
+        <location filename="../core/runner/task_flow.py" line="1032"/>
         <source>INFO</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1016"/>
+        <location filename="../core/runner/task_flow.py" line="1033"/>
         <source>WARNING</source>
         <translation>警报</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1017"/>
+        <location filename="../core/runner/task_flow.py" line="1034"/>
         <source>ERROR</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1018"/>
+        <location filename="../core/runner/task_flow.py" line="1035"/>
         <source>CRITICAL</source>
         <translation>严重</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1868"/>
+        <location filename="../core/runner/task_flow.py" line="1885"/>
         <source>{} hours {} minutes</source>
         <translation>{} 小时 {} 分钟</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1870"/>
+        <location filename="../core/runner/task_flow.py" line="1887"/>
         <source>{} minutes</source>
         <translation>{} 分钟</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1873"/>
+        <location filename="../core/runner/task_flow.py" line="1890"/>
         <source>Task entry &apos;{}&apos; has been running for {}. This may indicate a problem. Please check the task status.</source>
         <translation>任务条目“{}”已运行{}分钟。这可能表明存在问题。请检查任务状态。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1887"/>
+        <location filename="../core/runner/task_flow.py" line="1904"/>
         <source>Task running time too long</source>
         <translation>任务运行时间过长</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2311"/>
+        <location filename="../core/runner/task_flow.py" line="2328"/>
         <source>PlayCover controller is only supported on macOS</source>
         <translation>PlayCover 控制器仅支持 macOS。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1530"/>
+        <location filename="../core/runner/task_flow.py" line="1547"/>
         <source>Resource </source>
         <translation>资源 </translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1532"/>
+        <location filename="../core/runner/task_flow.py" line="1549"/>
         <source> not found in bundle: </source>
         <translation> 不存在于: </translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1599"/>
+        <location filename="../core/runner/task_flow.py" line="1616"/>
         <source>Task </source>
         <translation>任务 </translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1601"/>
+        <location filename="../core/runner/task_flow.py" line="1618"/>
         <source> follows speedrun limit, skipping this run: </source>
         <translation>遵循speedrun限制,跳过本运行: </translation>
     </message>
@@ -5880,18 +5922,18 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">speedrun规则错误</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1639"/>
+        <location filename="../core/runner/task_flow.py" line="1656"/>
         <source>Task &apos;{}&apos; execution failed.</source>
         <translation>任务“{}”执行失败。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1752"/>
+        <location filename="../core/runner/task_flow.py" line="1769"/>
         <source>Stopping task...</source>
         <translation>停止任务中...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1779"/>
-        <location filename="../core/runner/task_flow.py" line="1862"/>
+        <location filename="../core/runner/task_flow.py" line="1796"/>
+        <location filename="../core/runner/task_flow.py" line="1879"/>
         <source>Unknown Task Entry</source>
         <translation>未知任务入口</translation>
     </message>
@@ -5924,261 +5966,260 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">任务 {} 超时,{}次重启后仍无法运行,终止任务流.</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1941"/>
+        <location filename="../core/runner/task_flow.py" line="1958"/>
         <source>Auto searching ADB devices...</source>
         <translation>自动检测ADB设备...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2687"/>
+        <location filename="../core/runner/task_flow.py" line="2704"/>
         <source>ADB path is empty, please configure ADB path in settings</source>
         <translation>ADB路径为空，请在控制器中配置ADB路径</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2706"/>
+        <location filename="../core/runner/task_flow.py" line="2723"/>
         <source>ADB connection address is empty, please configure device connection in settings</source>
         <translation>ADB 连接地址为空，请在控制器中配置设备连接</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1957"/>
+        <location filename="../core/runner/task_flow.py" line="1974"/>
         <source>try to start emulator</source>
         <translation>尝试启动模拟器</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1967"/>
+        <location filename="../core/runner/task_flow.py" line="1984"/>
         <source>waiting for emulator start...</source>
         <translation>等待模拟器启动中...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1997"/>
-        <location filename="../core/runner/task_flow.py" line="2111"/>
-        <location filename="../core/runner/task_flow.py" line="2118"/>
-        <location filename="../core/runner/task_flow.py" line="2166"/>
-        <location filename="../core/runner/task_flow.py" line="2254"/>
-        <location filename="../core/runner/task_flow.py" line="2261"/>
-        <location filename="../core/runner/task_flow.py" line="2304"/>
-        <location filename="../core/runner/task_flow.py" line="2546"/>
-        <location filename="../core/runner/task_flow.py" line="2552"/>
-        <location filename="../core/runner/task_flow.py" line="2597"/>
+        <location filename="../core/runner/task_flow.py" line="2014"/>
+        <location filename="../core/runner/task_flow.py" line="2128"/>
+        <location filename="../core/runner/task_flow.py" line="2135"/>
+        <location filename="../core/runner/task_flow.py" line="2183"/>
+        <location filename="../core/runner/task_flow.py" line="2271"/>
+        <location filename="../core/runner/task_flow.py" line="2278"/>
+        <location filename="../core/runner/task_flow.py" line="2321"/>
+        <location filename="../core/runner/task_flow.py" line="2563"/>
+        <location filename="../core/runner/task_flow.py" line="2569"/>
+        <location filename="../core/runner/task_flow.py" line="2614"/>
         <source>Device connection failed</source>
         <translation>设备连接失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2080"/>
+        <location filename="../core/runner/task_flow.py" line="2097"/>
         <source>Auto searching Win32 windows...</source>
         <translation>自动搜索Win32窗口...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2093"/>
-        <location filename="../core/runner/task_flow.py" line="2240"/>
+        <location filename="../core/runner/task_flow.py" line="2110"/>
+        <location filename="../core/runner/task_flow.py" line="2257"/>
         <source>Window handle (hwnd) is empty, please configure window connection in settings</source>
         <translation>窗口句柄 (hwnd) 为空，请在控制器中配置窗口连接</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2126"/>
-        <location filename="../core/runner/task_flow.py" line="2268"/>
-        <location filename="../core/runner/task_flow.py" line="2559"/>
+        <location filename="../core/runner/task_flow.py" line="2143"/>
+        <location filename="../core/runner/task_flow.py" line="2285"/>
+        <location filename="../core/runner/task_flow.py" line="2576"/>
         <source>try to start program</source>
         <translation>尝试启动程序</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2004"/>
+        <location filename="../core/runner/task_flow.py" line="2021"/>
         <source>Win32 controller is only supported on Windows</source>
         <translation>Win32 控制器仅在 Windows 系统上受支持。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="517"/>
+        <location filename="../core/runner/task_flow.py" line="550"/>
         <source>Controller or resource in current config does not exist in interface. They have been reset to default. Please check and run again.</source>
         <translation>当前配置中的控制器或资源在界面中不存在。它们已被重置为默认值。请检查并重新运行。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="526"/>
+        <location filename="../core/runner/task_flow.py" line="559"/>
         <source>Starting to load resources...</source>
         <translation>开始加载资源……</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="577"/>
+        <location filename="../core/runner/task_flow.py" line="610"/>
         <source>Embedded Agent prepare failed: </source>
         <translation>嵌入式代理准备失败：</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="578"/>
+        <location filename="../core/runner/task_flow.py" line="611"/>
         <source>Unknown reason</source>
         <translation>未知原因</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="653"/>
+        <location filename="../core/runner/task_flow.py" line="693"/>
         <source>Custom components loading failed, the flow is terminated.</source>
         <translation>自定义组件加载失败，流程已终止。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="667"/>
         <source>Embedded aspect ratio checker failed to load, the flow is terminated.</source>
-        <translation>内嵌宽高比检查器加载失败，流程已终止。</translation>
+        <translation type="vanished">内嵌宽高比检查器加载失败，流程已终止。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1039"/>
+        <location filename="../core/runner/task_flow.py" line="1056"/>
         <source>Base controller/resource task is missing.</source>
         <translation>基础控制器/资源任务缺失。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1060"/>
+        <location filename="../core/runner/task_flow.py" line="1077"/>
         <source>Current controller does not exist in interface: {}</source>
         <translation>当前控制器在界面中不存在：{}</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1061"/>
-        <location filename="../core/runner/task_flow.py" line="1066"/>
-        <location filename="../core/runner/task_flow.py" line="1077"/>
         <location filename="../core/runner/task_flow.py" line="1078"/>
+        <location filename="../core/runner/task_flow.py" line="1083"/>
+        <location filename="../core/runner/task_flow.py" line="1094"/>
+        <location filename="../core/runner/task_flow.py" line="1095"/>
         <source>(empty)</source>
         <translation>(空)</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1065"/>
+        <location filename="../core/runner/task_flow.py" line="1082"/>
         <source>Current resource does not exist in interface: {}</source>
         <translation>当前资源在界面中不存在：{}</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1075"/>
+        <location filename="../core/runner/task_flow.py" line="1092"/>
         <source>Current resource is not enabled for current controller: {} -&gt; {}</source>
         <translation>当前资源未对当前控制器启用：{} -&gt; {}</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1274"/>
+        <location filename="../core/runner/task_flow.py" line="1291"/>
         <source>Controller name is empty, please configure controller in settings</source>
         <translation>控制器名称为空，请在设置中配置控制器。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1293"/>
-        <location filename="../core/runner/task_flow.py" line="1466"/>
+        <location filename="../core/runner/task_flow.py" line="1310"/>
+        <location filename="../core/runner/task_flow.py" line="1483"/>
         <source>Controller &apos;{}&apos; not found, please reset controller in settings</source>
         <translation>未找到控制器“{}”，请在设置中重置控制器</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1373"/>
+        <location filename="../core/runner/task_flow.py" line="1390"/>
         <source>this Controller requires admin permission to run</source>
         <translation>此控制器需要管理员权限运行</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1388"/>
+        <location filename="../core/runner/task_flow.py" line="1405"/>
         <source>Controller configuration is invalid, please reset controller in settings</source>
         <translation>控制器配置无效，请在设置中重置控制器。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1456"/>
+        <location filename="../core/runner/task_flow.py" line="1473"/>
         <source>Controller config not found, please configure controller first</source>
         <translation>未找到控制器配置，请先配置控制器。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1482"/>
+        <location filename="../core/runner/task_flow.py" line="1499"/>
         <source>Resource target is empty, please configure resource in settings</source>
         <translation>资源目标为空，请在设置中配置资源。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1500"/>
+        <location filename="../core/runner/task_flow.py" line="1517"/>
         <source>Resource &apos;{}&apos; not found, please reset resource in settings</source>
         <translation>未找到资源“{}”，请在设置中重置资源。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="1665"/>
+        <location filename="../core/runner/task_flow.py" line="1682"/>
         <source>Builtin task failed: </source>
         <translation>内置任务失败：</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2154"/>
-        <location filename="../core/runner/task_flow.py" line="2292"/>
-        <location filename="../core/runner/task_flow.py" line="2585"/>
+        <location filename="../core/runner/task_flow.py" line="2171"/>
+        <location filename="../core/runner/task_flow.py" line="2309"/>
+        <location filename="../core/runner/task_flow.py" line="2602"/>
         <source>waiting for program start...</source>
         <translation>等待程序启动中...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2173"/>
+        <location filename="../core/runner/task_flow.py" line="2190"/>
         <source>Gamepad controller is only supported on Windows</source>
         <translation>Gamepad 控制器仅在 Windows 系统上受支持。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2230"/>
+        <location filename="../core/runner/task_flow.py" line="2247"/>
         <source>Auto searching desktop windows...</source>
         <translation>自动搜索桌面窗口...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2349"/>
+        <location filename="../core/runner/task_flow.py" line="2366"/>
         <source>PlayCover UUID is empty, please configure UUID in settings</source>
         <translation>PlayCover UUID 为空，请在设置中配置 UUID。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2361"/>
+        <location filename="../core/runner/task_flow.py" line="2378"/>
         <source>PlayCover connection address is empty, please configure address in settings</source>
         <translation>PlayCover 连接地址为空，请在设置中配置地址。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2374"/>
+        <location filename="../core/runner/task_flow.py" line="2391"/>
         <source>Connecting to PlayCover: {address} (UUID: {uuid})</source>
         <translation>正在连接到 PlayCover：{address}（UUID：{uuid}）</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2383"/>
+        <location filename="../core/runner/task_flow.py" line="2400"/>
         <source>PlayCover connected successfully</source>
         <translation>PlayCover 已成功连接</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2387"/>
+        <location filename="../core/runner/task_flow.py" line="2404"/>
         <source>Failed to connect to PlayCover</source>
         <translation>连接 PlayCover 失败</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2395"/>
+        <location filename="../core/runner/task_flow.py" line="2412"/>
         <source>WlRoots controller is only supported on Linux</source>
         <translation>WlRoots 控制器仅在 Linux 上受支持</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2426"/>
+        <location filename="../core/runner/task_flow.py" line="2443"/>
         <source>WlRoots Wayland socket path is empty, please configure it in settings</source>
         <translation>WlRoots Wayland 套接字路径为空，请在设置中配置</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2443"/>
+        <location filename="../core/runner/task_flow.py" line="2460"/>
         <source>Connecting to WlRoots: {socket}</source>
         <translation>正在连接到 WlRoots: {socket}</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2448"/>
+        <location filename="../core/runner/task_flow.py" line="2465"/>
         <source>WlRoots connected successfully</source>
         <translation>WlRoots 连接成功</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2452"/>
+        <location filename="../core/runner/task_flow.py" line="2469"/>
         <source>Failed to connect to WlRoots</source>
         <translation>无法连接到 WlRoots</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2458"/>
+        <location filename="../core/runner/task_flow.py" line="2475"/>
         <source>MacOS controller is only supported on macOS</source>
         <translation>MacOS 控制器仅在 macOS 上受支持</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2521"/>
+        <location filename="../core/runner/task_flow.py" line="2538"/>
         <source>Auto searching MacOS windows...</source>
         <translation>正在自动搜索 MacOS 窗口...</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2532"/>
+        <location filename="../core/runner/task_flow.py" line="2549"/>
         <source>Window ID is empty, please configure window connection in settings</source>
         <translation>窗口 ID 为空，请在设置中配置窗口连接</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2715"/>
+        <location filename="../core/runner/task_flow.py" line="2732"/>
         <source>ADB connection port is empty; use host:port (for example 127.0.0.1:5555) or pick a device after starting the emulator.</source>
         <translation>ADB 连接端口为空；请使用 主机:端口 格式（例如 127.0.0.1:5555），或启动模拟器后选择设备。</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="2942"/>
-        <location filename="../core/runner/task_flow.py" line="2989"/>
+        <location filename="../core/runner/task_flow.py" line="2959"/>
+        <location filename="../core/runner/task_flow.py" line="3006"/>
         <source> seconds</source>
         <translation> 秒</translation>
     </message>
     <message>
-        <location filename="../core/runner/task_flow.py" line="3386"/>
+        <location filename="../core/runner/task_flow.py" line="3411"/>
         <source>Notifications are being sent, please wait up to {} seconds</source>
         <translation>通知正在发送中，请稍候，最多{}秒。</translation>
     </message>
@@ -6311,12 +6352,12 @@ You can copy the detailed stack trace below and report it to the developer.</sou
 <context>
     <name>TaskListToolBarWidget</name>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="303"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="322"/>
         <source>Tasks</source>
         <translation>任务</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="335"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="354"/>
         <source>No available tasks to add.</source>
         <translation>无可用任务</translation>
     </message>
@@ -6337,7 +6378,7 @@ You can copy the detailed stack trace below and report it to the developer.</sou
         <translation type="vanished">切换</translation>
     </message>
     <message>
-        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="455"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="474"/>
         <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
         <translation>基础任务不能被删除</translation>
     </message>

--- a/app/i18n/i18n.zh_TW.ts
+++ b/app/i18n/i18n.zh_TW.ts
@@ -1,6038 +1,6079 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_TW">
-    <context>
-        <name />
-        <message>
-            <source>Single at {time}</source>
-            <translation type="vanished">單次於 {time}</translation>
-        </message>
-        <message>
-            <source>Daily every {n} day(s) at {time}</source>
-            <translation type="vanished">每日每 {n} 天於 {time}</translation>
-        </message>
-        <message>
-            <source>Weekly every {n} week(s) at {time}</source>
-            <translation type="vanished">每週每 {n} 週於 {time}</translation>
-        </message>
-        <message>
-            <source>Every month</source>
-            <translation type="vanished">每月</translation>
-        </message>
-        <message>
-            <source>Last</source>
-            <translation type="vanished">最後</translation>
-        </message>
-        <message>
-            <source>Monthly ({month}) on the {ordinal} {weekday} at {time}</source>
-            <translation type="vanished">每月（{month}）於第 {ordinal} 個 {weekday} 於 {time}</translation>
-        </message>
-        <message>
-            <source>Monthly ({month}) on day {day} at {time}</source>
-            <translation type="vanished">每月（{month}）於第 {day} 天於 {time}</translation>
-        </message>
-        <message>
-            <source>Custom</source>
-            <translation type="vanished">自訂</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="181" />
-            <source>GitHub API rate limit exceeded. Please try again later or configure a GitHub Token.</source>
-            <translation>GitHub API 速率限制已超出，請稍後再試或設定 GitHub Token。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="185" />
-            <source>GitHub SSL connection failed. Check system time, proxy, or certificate settings.</source>
-            <translation>GitHub SSL 連線失敗，請檢查系統時間、代理或憑證設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="189" />
-            <source>GitHub request timed out. Check your network or proxy and try again.</source>
-            <translation>GitHub 請求逾時，請檢查網路或代理後重試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="193" />
-            <source>GitHub domain could not be resolved. Check DNS or network settings.</source>
-            <translation>GitHub 網域無法解析，請檢查 DNS 或網路設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="197" />
-            <source>GitHub connection failed. Check your network and try again.</source>
-            <translation>GitHub 連線失敗，請檢查網路後重試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="200" />
-            <source>GitHub request was rejected. Check the project URL or permissions.</source>
-            <translation>GitHub 請求被拒絕，請檢查專案 URL 或權限。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="202" />
-            <source>GitHub service is temporarily unavailable. Please try again later.</source>
-            <translation>GitHub 服務暫時不可用，請稍後再試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="204" />
-            <source>GitHub returned an invalid response. Please try again later.</source>
-            <translation>GitHub 回傳無效回應，請稍後再試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="205" />
-            <source>GitHub {action} failed. Please try again later.</source>
-            <translation>GitHub {action} 失敗，請稍後再試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="215" />
-            <source> Will try GitHub source for update check.</source>
-            <translation>將嘗試使用 GitHub 來源進行更新檢查。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="222" />
-            <source>MirrorChyan SSL connection failed. Check system time, proxy, or certificate settings.</source>
-            <translation>MirrorChyan SSL 連線失敗，請檢查系統時間、代理或憑證設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="226" />
-            <source>MirrorChyan request timed out. Check your network or proxy.</source>
-            <translation>MirrorChyan 請求逾時，請檢查網路或代理。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="229" />
-            <source>MirrorChyan domain could not be resolved. Check DNS or network settings.</source>
-            <translation>MirrorChyan 網域無法解析，請檢查 DNS 或網路設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="232" />
-            <source>MirrorChyan connection failed. Check your network and try again.</source>
-            <translation>MirrorChyan 連線失敗，請檢查網路後重試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="235" />
-            <source>MirrorChyan request was rejected. Check CDK or resource settings.</source>
-            <translation>MirrorChyan 請求被拒絕，請檢查 CDK 或資源設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="238" />
-            <source>MirrorChyan service is temporarily unavailable.</source>
-            <translation>MirrorChyan 服務暫時不可用。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="241" />
-            <source>MirrorChyan CDK has expired.</source>
-            <translation>MirrorChyan CDK 已過期。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="243" />
-            <source>MirrorChyan CDK is invalid. Check your CDK in settings.</source>
-            <translation>MirrorChyan CDK 無效，請在設定中檢查您的 CDK。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="245" />
-            <source>MirrorChyan resource quota exhausted.</source>
-            <translation>MirrorChyan 資源配額已用盡。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="247" />
-            <source>MirrorChyan CDK does not match this resource.</source>
-            <translation>MirrorChyan CDK 與此資源不符。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="249" />
-            <source>MirrorChyan resource was not found. Check the resource ID.</source>
-            <translation>MirrorChyan 資源未找到，請檢查資源 ID。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="251" />
-            <source>MirrorChyan OS parameter is invalid for this resource.</source>
-            <translation>MirrorChyan 作業系統參數對此資源無效。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="253" />
-            <source>MirrorChyan architecture parameter is invalid for this resource.</source>
-            <translation>MirrorChyan 架構參數對此資源無效。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="255" />
-            <source>MirrorChyan channel parameter is invalid for this resource.</source>
-            <translation>MirrorChyan 頻道參數對此資源無效。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="257" />
-            <source>MirrorChyan request parameters are invalid.</source>
-            <translation>MirrorChyan 請求參數無效。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="258" />
-            <source>MirrorChyan update check failed.</source>
-            <translation>MirrorChyan 更新檢查失敗。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="409" />
-            <source>GitHub download timed out. Check your network or proxy.</source>
-            <translation>GitHub 下載逾時，請檢查網路或代理。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="412" />
-            <source>GitHub download SSL failed. Check certificate or proxy settings.</source>
-            <translation>GitHub 下載 SSL 失敗，請檢查憑證或代理設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="415" />
-            <source>GitHub download connection failed. Check your network.</source>
-            <translation>GitHub 下載連線失敗，請檢查網路。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="416" />
-            <source>GitHub download failed. Please try again.</source>
-            <translation>GitHub 下載失敗，請重試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="418" />
-            <source>MirrorChyan download timed out. Check your network or proxy.</source>
-            <translation>MirrorChyan 下載逾時，請檢查網路或代理。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="421" />
-            <source>MirrorChyan download SSL failed. Check certificate or proxy settings.</source>
-            <translation>MirrorChyan 下載 SSL 失敗，請檢查憑證或代理設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="424" />
-            <source>MirrorChyan download connection failed. Check your network.</source>
-            <translation>MirrorChyan 下載連線失敗，請檢查網路。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="425" />
-            <source>MirrorChyan download failed. Please try again.</source>
-            <translation>MirrorChyan 下載失敗，請重試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="269" />
-            <source>{channel} send failed: SSL error. Check certificate or proxy settings.</source>
-            <translation>{channel} 發送失敗：SSL 錯誤，請檢查憑證或代理設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="272" />
-            <source>{channel} send failed: request timed out. Check your network.</source>
-            <translation>{channel} 發送失敗：請求逾時，請檢查網路。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="277" />
-            <source>{channel} send failed: domain could not be resolved. Check DNS settings.</source>
-            <translation>{channel} 發送失敗：網域無法解析，請檢查 DNS 設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="281" />
-            <source>{channel} send failed: connection error. Check server address and network.</source>
-            <translation>{channel} 發送失敗：連線錯誤，請檢查伺服器位址與網路。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="285" />
-            <source>{channel} send failed: request rejected. Check URL, token, or webhook key.</source>
-            <translation>{channel} 發送失敗：請求被拒絕，請檢查 URL、Token 或 Webhook 金鑰。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="289" />
-            <source>{channel} send failed: remote service error. Try again later.</source>
-            <translation>{channel} 發送失敗：遠端服務錯誤，請稍後再試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="293" />
-            <source>{channel} send failed: invalid response from server. Check configuration.</source>
-            <translation>{channel} 發送失敗：伺服器回傳無效回應，請檢查設定。</translation>
-        </message>
-        <message>
-            <location filename="../utils/network_error_helper.py" line="295" />
-            <source>{channel} send failed due to a network error.</source>
-            <translation>{channel} 因網路錯誤發送失敗。</translation>
-        </message>
-        <message>
-            <source>{channel} sent successfully.</source>
-            <translation type="vanished">{channel} 發送成功。</translation>
-        </message>
-        <message>
-            <source>{channel} notifications are disabled.</source>
-            <translation type="vanished">{channel} 通知已停用。</translation>
-        </message>
-        <message>
-            <source>{channel}: required settings are empty.</source>
-            <translation type="vanished">{channel}：必要設定為空。</translation>
-        </message>
-        <message>
-            <source>{channel}: invalid URL or parameter format.</source>
-            <translation type="vanished">{channel}：URL 或參數格式無效。</translation>
-        </message>
-        <message>
-            <source>{channel} send failed due to a network error. (Network)</source>
-            <translation type="vanished">{channel} 因網路錯誤發送失敗。（網路）</translation>
-        </message>
-        <message>
-            <source>{channel} send failed: server returned an error. Check webhook or token.</source>
-            <translation type="vanished">{channel} 發送失敗：伺服器回傳錯誤，請檢查 Webhook 或 Token。</translation>
-        </message>
-        <message>
-            <source>{channel}: SMTP port must be a valid number. (Config)</source>
-            <translation type="vanished">{channel}：SMTP 連接埠必須為有效數字。（設定）</translation>
-        </message>
-        <message>
-            <source>{channel} SMTP connection failed. Check server address, port, and credentials. (Connection)</source>
-            <translation type="vanished">{channel} SMTP 連線失敗，請檢查伺服器位址、連接埠與憑證。（連線）</translation>
-        </message>
-        <message>
-            <source>{channel} send failed with an unknown error. (Unknown)</source>
-            <translation type="vanished">{channel} 因未知錯誤發送失敗。（未知）</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddBundleDialog</name>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1514" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1518" />
-            <source>Add Resource Bundle</source>
-            <translation>新增資源包</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1524" />
-            <source>Bundle Name:</source>
-            <translation>資源包名稱：</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1526" />
-            <source>Enter the name of the bundle</source>
-            <translation>輸入資源包的名稱</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1533" />
-            <source>Interface File:</source>
-            <translation>介面檔案：</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1536" />
-            <source>Select interface.json or interface.jsonc file</source>
-            <translation>選擇 interface.json 或 interface.jsonc 檔案</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1555" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1556" />
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1573" />
-            <source>Choose Interface File</source>
-            <translation>選擇介面檔案</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1575" />
-            <source>Interface Files (interface.json interface.jsonc)</source>
-            <translation>介面檔案 (interface.json interface.jsonc)</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1577" />
-            <source>JSON Files (*.json *.jsonc)</source>
-            <translation>JSON 檔案 (*.json *.jsonc)</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1579" />
-            <source>All Files (*)</source>
-            <translation>所有檔案 (*)</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1594" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1668" />
-            <source>Please select interface.json or interface.jsonc file</source>
-            <translation>請選擇 interface.json 或 interface.jsonc 檔案</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1614" />
-            <source>Default Bundle</source>
-            <translation>預設套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1644" />
-            <source>Interface file path cannot be empty</source>
-            <translation>介面檔案路徑不能為空</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1654" />
-            <source>Selected interface file does not exist</source>
-            <translation>選擇的介面檔案不存在</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1660" />
-            <source>Selected path is not a file</source>
-            <translation>選擇的路徑不是檔案</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1691" />
-            <source>Failed to read interface.json: {}</source>
-            <translation>讀取 interface.json 失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1697" />
-            <source>interface.json does not contain a valid 'name' field</source>
-            <translation>interface.json 不包含有效的 'name' 欄位</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1707" />
-            <source>Service is not ready, cannot save bundle</source>
-            <translation>服務未就緒，無法儲存資源包</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1723" />
-            <source>Bundle name already exists</source>
-            <translation>資源包名稱已存在</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1728" />
-            <source>Failed to check existing bundles: {}</source>
-            <translation>檢查現有套件失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1741" />
-            <source>Bundle directory does not exist: {}</source>
-            <translation>套件目錄不存在：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1747" />
-            <source>Bundle path is not a directory: {}</source>
-            <translation>套件路徑不是目錄：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1787" />
-            <source>Cannot move bundle: target directory is inside source directory</source>
-            <translation>無法移動套件：目標目錄位於來源目錄內</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1816" />
-            <source>Failed to remove existing bundle directory: {}</source>
-            <translation>移除現有套件目錄失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1844" />
-            <source>Failed to create bundle directory: {}</source>
-            <translation>建立套件目錄失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1890" />
-            <source>Failed to move bundle to target directory: {}</source>
-            <translation>移動套件至目標目錄失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1938" />
-            <source>Failed to update bundle path</source>
-            <translation>更新套件路徑失敗</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1943" />
-            <source>Failed to update bundle path: {}</source>
-            <translation>更新套件路徑失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1958" />
-            <source>An unexpected error occurred: {}</source>
-            <translation>發生未預期的錯誤：{}</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddConfigDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="98" />
-            <source>Add New Config</source>
-            <translation>新增設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="104" />
-            <source>Config Name:</source>
-            <translation>設定名稱：</translation>
-        </message>
-        <message>
-            <source>Enter the name of the config</source>
-            <translation type="vanished">輸入設定名稱</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="116" />
-            <source>Resource Bundle:</source>
-            <translation>資源套件：</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="135" />
-            <source>Preset:</source>
-            <translation>預設：</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="226" />
-            <source>Default (all tasks)</source>
-            <translation>預設（所有任務）</translation>
-        </message>
-        <message>
-            <source>Config name cannot be empty</source>
-            <translation type="vanished">設定名稱不能為空</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="107" />
-            <source>Enter name, or leave empty for auto (preset name + index)</source>
-            <translation>輸入名稱，或留空以自動生成（預設名稱+索引）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="147" />
-            <source>Import shared config:</source>
-            <translation>匯入共享設定：</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="149" />
-            <source>Off</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="150" />
-            <source>On</source>
-            <translation>開啟</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="158" />
-            <source>Paste shared config content here</source>
-            <translation>在此貼上共享設定內容</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="306" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="308" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="401" />
-            <source>Config</source>
-            <translation>配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="310" />
-            <source>{0} {1}</source>
-            <translation>{0} {1}</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="334" />
-            <source>Please paste shared config content</source>
-            <translation>請貼上共享設定內容</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="339" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="342" />
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="368" />
-            <source>Invalid shared config content</source>
-            <translation>無效的共享設定內容</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="345" />
-            <source>Shared config contains no tasks</source>
-            <translation>共享設定中沒有任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="350" />
-            <source>Please select a resource bundle</source>
-            <translation>請選擇資源包</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="362" />
-            <source>Resource mismatch: shared config is for "{0}", but you selected "{1}".</source>
-            <translation>資源不符：共享設定用於「{0}」，但你選擇了「{1}」。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="403" />
-            <source>New Config</source>
-            <translation>新增配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="406" />
-            <source>Could not allocate a unique config name</source>
-            <translation>無法分配唯一的配置名稱</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="412" />
-            <source>Cannot use 'default' as config name</source>
-            <translation>不能使用「default」作為設定名稱</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="427" />
-            <source>Resource bundle not found</source>
-            <translation>找不到資源套件</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="453" />
-            <source>Interface file not found in bundle: {}</source>
-            <translation>在套件中找不到介面檔案：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="464" />
-            <source>Failed to load interface from bundle: {}</source>
-            <translation>從套件載入介面失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="470" />
-            <source>Controller not found in bundle interface</source>
-            <translation>在套件介面中找不到控制器</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="473" />
-            <source>Resource not found in bundle interface</source>
-            <translation>在套件介面中找不到資源</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddTaskDialog</name>
-        <message>
-            <source>Framework Built-in Tasks</source>
-            <translation type="vanished">框架內建任務</translation>
-        </message>
-        <message>
-            <source>Builtin tasks loaded by the framework.</source>
-            <translation type="vanished">由框架載入的內建任務</translation>
-        </message>
-        <message>
-            <source>Launch Program</source>
-            <translation type="vanished">啟動程式</translation>
-        </message>
-        <message>
-            <source>Launch an external program and optionally wait for it to exit.</source>
-            <translation type="vanished">啟動外部程式，並可選擇是否等待行程結束。</translation>
-        </message>
-        <message>
-            <source>Wait</source>
-            <translation type="vanished">等待</translation>
-        </message>
-        <message>
-            <source>Wait for the specified number of seconds before continuing.</source>
-            <translation type="vanished">等待指定秒數後繼續執行後續任務。</translation>
-        </message>
-        <message>
-            <source>Wait Until</source>
-            <translation type="vanished">定時等待</translation>
-        </message>
-        <message>
-            <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
-            <translation type="vanished">等待到指定時間點後繼續。支援 HH:MM 或 YYYY-MM-DD HH:MM。</translation>
-        </message>
-        <message>
-            <source>System Notification</source>
-            <translation type="vanished">系統通知</translation>
-        </message>
-        <message>
-            <source>Send a system notification and optionally play the system sound.</source>
-            <translation type="vanished">傳送系統通知，並可同時播放系統提示音。</translation>
-        </message>
-        <message>
-            <source>External Notification</source>
-            <translation type="vanished">外部通知</translation>
-        </message>
-        <message>
-            <source>Send a message to all currently enabled external notification channels.</source>
-            <translation type="vanished">向目前已啟用的外部通知通道傳送訊息。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="544" />
-            <source>Add New Task</source>
-            <translation>新增任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="547" />
-            <source>Close</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="548" />
-            <source>Add</source>
-            <translation>新增</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="554" />
-            <source>Task List</source>
-            <translation>任務清單</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="556" />
-            <source>Select one task from the groups below.</source>
-            <translation>請從以下群組中選擇一個任務。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="652" />
-            <source>Default Group</source>
-            <translation>預設群組</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="653" />
-            <source>Tasks without an explicit group</source>
-            <translation>未明確分組的任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="727" />
-            <source>{} tasks</source>
-            <translation>{} 個任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="794" />
-            <source>Please select a task</source>
-            <translation>請選擇一個任務</translation>
-        </message>
-    </context>
-    <context>
-        <name>AprilFoolsEasterEgg</name>
-        <message>
-            <source> Checking anti-addiction system...</source>
-            <translation type="vanished"> 正在檢測防沉迷系統...</translation>
-        </message>
-        <message>
-            <source> April Fools detected. System verdict: "Limited-time April Fools addiction mode".</source>
-            <translation type="vanished"> 檢測到當前為愚人節，系統判定為「愚人節限時沉迷」。</translation>
-        </message>
-        <message>
-            <source> Task execution failed! Reason: You are granted "slacking rights" today. Please grab a coffee manually.</source>
-            <translation type="vanished"> 任務執行失敗！原因：今天你被賦予「摸魚」權利，請手動去喝杯咖啡。</translation>
-        </message>
-        <message>
-            <source> Just kidding, back to serious work...</source>
-            <translation type="vanished"> 騙你的，開始正經幹活...</translation>
-        </message>
-        <message>
-            <source> Today's task progress: ▓▓▓▓▓▓▓▓▓▓ 100%</source>
-            <translation type="vanished"> 今日任務進度: ▓▓▓▓▓▓▓▓▓▓ 100%</translation>
-        </message>
-        <message>
-            <source> Verifying... Verification failed!</source>
-            <translation type="vanished"> 校驗中... 校驗失敗！</translation>
-        </message>
-        <message>
-            <source> Server fluctuation detected (actually April Fools fluctuation), progress rolled back to 0%.</source>
-            <translation type="vanished"> 檢測到伺服器波動（其實是愚人節波動），進度已回滾至 0%。</translation>
-        </message>
-        <message>
-            <source> Re-executing...</source>
-            <translation type="vanished"> 正在重新執行...</translation>
-        </message>
-        <message>
-            <source> [System Notice] Since today is April Fools, all players can claim the limited title "Ultimate Sucker" upon login.</source>
-            <translation type="vanished"> [系統公告] 由於今天是愚人節，所有玩家今日登入即可領取限定稱號「大冤種」。</translation>
-        </message>
-        <message>
-            <source> Title claimed automatically. Please restart the game to view it.</source>
-            <translation type="vanished"> 已自動為您領取稱號，請重啟遊戲查看。</translation>
-        </message>
-        <message>
-            <source> Daily task completion: ■■□□□ 40%</source>
-            <translation type="vanished"> 每日任務完成度：■■□□□ 40%</translation>
-        </message>
-        <message>
-            <source> Injecting April Fools special patch...</source>
-            <translation type="vanished"> 注入愚人節特供補丁...</translation>
-        </message>
-        <message>
-            <source> Output: sudo rm -rf</source>
-            <translation type="vanished"> 輸出結果：sudo rm -rf</translation>
-        </message>
-        <message>
-            <source> Got scared? Back to normal task execution...</source>
-            <translation type="vanished"> 哈哈，嚇到了沒？正在正經執行任務...</translation>
-        </message>
-        <message>
-            <source> April Fools detected, enabling "Anti-Boss Mode" automatically.</source>
-            <translation type="vanished"> 檢測到今天是愚人節，自動開啟「防老闆模式」。</translation>
-        </message>
-        <message>
-            <source> Taskbar title changed to: "2026 Q2 Quarterly Report - Data Analysis.exe"</source>
-            <translation type="vanished"> 任務欄標題已修改為：「2026年Q2季度報表 - 數據分析.exe」</translation>
-        </message>
-        <message>
-            <source>2026 Q2 Quarterly Report - Data Analysis.exe</source>
-            <translation type="vanished">2026年Q2季度報表 - 數據分析.exe</translation>
-        </message>
-        <message>
-            <source> Pretending to load Excel...</source>
-            <translation type="vanished"> 正在假裝載入Excel...</translation>
-        </message>
-        <message>
-            <source> Today's task list: 1. Enter game; 2. Claim rewards; 3. Be kind to yourself.</source>
-            <translation type="vanished"> 今日任務列表：1.進入遊戲；2.領獎勵；3.對自己好一點。</translation>
-        </message>
-        <message>
-            <source> The first two are already done for you, please do the third one yourself.</source>
-            <translation type="vanished"> 前兩項任務已代勞，第三項請親自完成。</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseAddDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="58" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="59" />
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/add_task_message_box.py" line="78" />
-            <source>Error</source>
-            <translation>錯誤</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseListToolBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="72" />
-            <source>Select All</source>
-            <translation>全選</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="76" />
-            <source>Deselect All</source>
-            <translation>取消全選</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="80" />
-            <source>Add</source>
-            <translation>新增</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="84" />
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <source>Switch to Special Tasks</source>
-            <translation type="vanished">切換至特殊任務</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="29" />
-            <source>Test</source>
-            <translation>測試</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="93" />
-            <source>decrypt notice key failed: {}，please fill in again and save.</source>
-            <translation>解密通知金鑰失敗：{}，請重新填寫並儲存。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="99" />
-            <source>parse notice key error: {}，please save again.</source>
-            <translation>解析通知金鑰錯誤：{}，請重新儲存。</translation>
-        </message>
-    </context>
-    <context>
-        <name>BaseUpdate</name>
-        <message>
-            <location filename="../utils/update.py" line="240" />
-            <location filename="../utils/update.py" line="272" />
-            <source>User cancelled</source>
-            <translation>使用者已取消</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="274" />
-            <source>Download interrupted</source>
-            <translation>下載中斷</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="856" />
-            <source>GitHub API returned an error: {message}</source>
-            <translation>GitHub API 回傳錯誤：{message}</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="878" />
-            <source>GitHub returned an invalid response. Please try again later. (Response)</source>
-            <translation>GitHub 回傳無效回應，請稍後再試。（回應）</translation>
-        </message>
-        <message>
-            <source>Update check failed HTTP error,code: </source>
-            <translation type="vanished">更新檢查失敗 HTTP 錯誤，代碼：</translation>
-        </message>
-        <message>
-            <source>GitHub API request limit exceeded,please try again later</source>
-            <translation type="vanished">GitHub API 請求次數已達上限，請稍後再試</translation>
-        </message>
-        <message>
-            <source>Github Update check failed HTTP error,code: </source>
-            <translation type="vanished">GitHub 更新檢查失敗 HTTP 錯誤，代碼：</translation>
-        </message>
-        <message>
-            <source>MirrorChyan Update check failed SSL error</source>
-            <translation type="vanished">MirrorChyan 更新檢查失敗 SSL 錯誤</translation>
-        </message>
-        <message>
-            <source>switching to Github download</source>
-            <translation type="vanished">切換至 Github 下載</translation>
-        </message>
-        <message>
-            <source>Github Update check failed SSL error</source>
-            <translation type="vanished">Github 更新檢查失敗 SSL 錯誤</translation>
-        </message>
-        <message>
-            <source>INVALID_PARAMS</source>
-            <translation type="vanished">無效參數</translation>
-        </message>
-        <message>
-            <source>KEY_EXPIRED</source>
-            <translation type="vanished">金鑰已過期</translation>
-        </message>
-        <message>
-            <source>KEY_INVALID</source>
-            <translation type="vanished">金鑰無效</translation>
-        </message>
-        <message>
-            <source>RESOURCE_QUOTA_EXHAUSTED</source>
-            <translation type="vanished">資源配額已耗盡</translation>
-        </message>
-        <message>
-            <source>KEY_MISMATCHED</source>
-            <translation type="vanished">金鑰不匹配</translation>
-        </message>
-        <message>
-            <source>RESOURCE_NOT_FOUND</source>
-            <translation type="vanished">資源未找到</translation>
-        </message>
-        <message>
-            <source>INVALID_OS</source>
-            <translation type="vanished">無效作業系統</translation>
-        </message>
-        <message>
-            <source>INVALID_ARCH</source>
-            <translation type="vanished">無效架構</translation>
-        </message>
-        <message>
-            <source>INVALID_CHANNEL</source>
-            <translation type="vanished">無效頻道</translation>
-        </message>
-        <message>
-            <source>Unknown error</source>
-            <translation type="vanished">未知錯誤</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="835" />
-            <location filename="../utils/update.py" line="866" />
-            <source>current version is latest</source>
-            <translation>目前版本已是最新</translation>
-        </message>
-        <message>
-            <source>GitHub API ERROR: </source>
-            <translation type="vanished">GitHub API 錯誤：</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="933" />
-            <source>Failed to clean up temporary files</source>
-            <translation>清理暫存檔案失敗</translation>
-        </message>
-    </context>
-    <context>
-        <name>BundleDetailWidget</name>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="199" />
-            <source>Description</source>
-            <translation>描述</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="205" />
-            <source>No description available</source>
-            <translation>無可用描述</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="220" />
-            <source>Contact</source>
-            <translation>聯絡方式</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="224" />
-            <source>No contact information available</source>
-            <translation>無可用聯絡資訊</translation>
-        </message>
-    </context>
-    <context>
-        <name>BundleInterface</name>
-        <message>
-            <source>Open update log</source>
-            <translation type="vanished">開啟更新記錄</translation>
-        </message>
-        <message>
-            <source>Delete bundle</source>
-            <translation type="vanished">刪除套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="455" />
-            <source>Bundle List</source>
-            <translation>套件清單</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="456" />
-            <source>Bundle Details</source>
-            <translation>套件詳細資訊</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="457" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="459" />
-            <source>Auto Update</source>
-            <translation>自動更新</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="460" />
-            <source>Add Bundle</source>
-            <translation>新增套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="461" />
-            <source>Update All Bundles</source>
-            <translation>更新所有套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="463" />
-            <source>Please select a Bundle from the left</source>
-            <translation>請從左側選擇一個套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="591" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="926" />
-            <source>Unknown version</source>
-            <translation>未知版本</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="734" />
-            <source>No license information for this bundle</source>
-            <translation>此套件無授權資訊</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="465" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="739" />
-            <source>License</source>
-            <translation>授權</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="781" />
-            <source>No welcome message for this bundle</source>
-            <translation>此套件無歡迎訊息</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="466" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="786" />
-            <source>Welcome</source>
-            <translation>歡迎</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1018" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1076" />
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1298" />
-            <source>Multi-resource adaptation is not enabled. Please enable it in Settings first.</source>
-            <translation>未啟用多資源適配。請先在設定中啟用。</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1055" />
-            <source>All bundles are up to date</source>
-            <translation>所有套件皆為最新版本</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1106" />
-            <source>{count} bundle update(s) failed</source>
-            <translation>{count} 個套件更新失敗</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1115" />
-            <source>All updates completed</source>
-            <translation>所有更新已完成</translation>
-        </message>
-        <message>
-            <source>Updating bundle: {bundle_name}</source>
-            <translation type="vanished">正在更新套件：{bundle_name}</translation>
-        </message>
-        <message>
-            <source>Bundle '{bundle_name}' updated successfully</source>
-            <translation type="vanished">套件 '{bundle_name}' 更新成功</translation>
-        </message>
-        <message>
-            <source>Update cancelled: {bundle_name}</source>
-            <translation type="vanished">更新已取消：{bundle_name}</translation>
-        </message>
-        <message>
-            <source>Restart required for bundle: {bundle_name}</source>
-            <translation type="vanished">需要重新啟動套件：{bundle_name}</translation>
-        </message>
-        <message>
-            <source>Update failed for bundle: {bundle_name}</source>
-            <translation type="vanished">套件更新失敗：{bundle_name}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1170" />
-            <source>Updating bundle: {}</source>
-            <translation>正在更新套件：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1195" />
-            <source>Bundle '{}' updated successfully</source>
-            <translation>套件 '{}' 更新成功</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1208" />
-            <source>Update cancelled: {}</source>
-            <translation>更新已取消：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1216" />
-            <source>Restart required for bundle: {}</source>
-            <translation>套件 {} 需要重新啟動</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1227" />
-            <source>Update failed for bundle: {}</source>
-            <translation>套件 {} 更新失敗</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1248" />
-            <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
-            <translation>CI/Alpha 資源版本已停用自動更新，請手動更新。</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1336" />
-            <source>Bundle '{}' added successfully</source>
-            <translation>套件 '{}' 新增成功</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1379" />
-            <source>No update log</source>
-            <translation>無更新記錄</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1380" />
-            <source>No update log found locally for this bundle.
+<context>
+    <name></name>
+    <message>
+        <source>Single at {time}</source>
+        <translation type="vanished">單次於 {time}</translation>
+    </message>
+    <message>
+        <source>Daily every {n} day(s) at {time}</source>
+        <translation type="vanished">每日每 {n} 天於 {time}</translation>
+    </message>
+    <message>
+        <source>Weekly every {n} week(s) at {time}</source>
+        <translation type="vanished">每週每 {n} 週於 {time}</translation>
+    </message>
+    <message>
+        <source>Every month</source>
+        <translation type="vanished">每月</translation>
+    </message>
+    <message>
+        <source>Last</source>
+        <translation type="vanished">最後</translation>
+    </message>
+    <message>
+        <source>Monthly ({month}) on the {ordinal} {weekday} at {time}</source>
+        <translation type="vanished">每月（{month}）於第 {ordinal} 個 {weekday} 於 {time}</translation>
+    </message>
+    <message>
+        <source>Monthly ({month}) on day {day} at {time}</source>
+        <translation type="vanished">每月（{month}）於第 {day} 天於 {time}</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="vanished">自訂</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="181"/>
+        <source>GitHub API rate limit exceeded. Please try again later or configure a GitHub Token.</source>
+        <translation>GitHub API 速率限制已超出，請稍後再試或設定 GitHub Token。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="185"/>
+        <source>GitHub SSL connection failed. Check system time, proxy, or certificate settings.</source>
+        <translation>GitHub SSL 連線失敗，請檢查系統時間、代理或憑證設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="189"/>
+        <source>GitHub request timed out. Check your network or proxy and try again.</source>
+        <translation>GitHub 請求逾時，請檢查網路或代理後重試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="193"/>
+        <source>GitHub domain could not be resolved. Check DNS or network settings.</source>
+        <translation>GitHub 網域無法解析，請檢查 DNS 或網路設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="197"/>
+        <source>GitHub connection failed. Check your network and try again.</source>
+        <translation>GitHub 連線失敗，請檢查網路後重試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="200"/>
+        <source>GitHub request was rejected. Check the project URL or permissions.</source>
+        <translation>GitHub 請求被拒絕，請檢查專案 URL 或權限。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="202"/>
+        <source>GitHub service is temporarily unavailable. Please try again later.</source>
+        <translation>GitHub 服務暫時不可用，請稍後再試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="204"/>
+        <source>GitHub returned an invalid response. Please try again later.</source>
+        <translation>GitHub 回傳無效回應，請稍後再試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="205"/>
+        <source>GitHub {action} failed. Please try again later.</source>
+        <translation>GitHub {action} 失敗，請稍後再試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="215"/>
+        <source> Will try GitHub source for update check.</source>
+        <translation>將嘗試使用 GitHub 來源進行更新檢查。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="222"/>
+        <source>MirrorChyan SSL connection failed. Check system time, proxy, or certificate settings.</source>
+        <translation>MirrorChyan SSL 連線失敗，請檢查系統時間、代理或憑證設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="226"/>
+        <source>MirrorChyan request timed out. Check your network or proxy.</source>
+        <translation>MirrorChyan 請求逾時，請檢查網路或代理。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="229"/>
+        <source>MirrorChyan domain could not be resolved. Check DNS or network settings.</source>
+        <translation>MirrorChyan 網域無法解析，請檢查 DNS 或網路設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="232"/>
+        <source>MirrorChyan connection failed. Check your network and try again.</source>
+        <translation>MirrorChyan 連線失敗，請檢查網路後重試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="235"/>
+        <source>MirrorChyan request was rejected. Check CDK or resource settings.</source>
+        <translation>MirrorChyan 請求被拒絕，請檢查 CDK 或資源設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="238"/>
+        <source>MirrorChyan service is temporarily unavailable.</source>
+        <translation>MirrorChyan 服務暫時不可用。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="241"/>
+        <source>MirrorChyan CDK has expired.</source>
+        <translation>MirrorChyan CDK 已過期。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="243"/>
+        <source>MirrorChyan CDK is invalid. Check your CDK in settings.</source>
+        <translation>MirrorChyan CDK 無效，請在設定中檢查您的 CDK。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="245"/>
+        <source>MirrorChyan resource quota exhausted.</source>
+        <translation>MirrorChyan 資源配額已用盡。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="247"/>
+        <source>MirrorChyan CDK does not match this resource.</source>
+        <translation>MirrorChyan CDK 與此資源不符。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="249"/>
+        <source>MirrorChyan resource was not found. Check the resource ID.</source>
+        <translation>MirrorChyan 資源未找到，請檢查資源 ID。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="251"/>
+        <source>MirrorChyan OS parameter is invalid for this resource.</source>
+        <translation>MirrorChyan 作業系統參數對此資源無效。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="253"/>
+        <source>MirrorChyan architecture parameter is invalid for this resource.</source>
+        <translation>MirrorChyan 架構參數對此資源無效。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="255"/>
+        <source>MirrorChyan channel parameter is invalid for this resource.</source>
+        <translation>MirrorChyan 頻道參數對此資源無效。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="257"/>
+        <source>MirrorChyan request parameters are invalid.</source>
+        <translation>MirrorChyan 請求參數無效。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="258"/>
+        <source>MirrorChyan update check failed.</source>
+        <translation>MirrorChyan 更新檢查失敗。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="409"/>
+        <source>GitHub download timed out. Check your network or proxy.</source>
+        <translation>GitHub 下載逾時，請檢查網路或代理。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="412"/>
+        <source>GitHub download SSL failed. Check certificate or proxy settings.</source>
+        <translation>GitHub 下載 SSL 失敗，請檢查憑證或代理設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="415"/>
+        <source>GitHub download connection failed. Check your network.</source>
+        <translation>GitHub 下載連線失敗，請檢查網路。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="416"/>
+        <source>GitHub download failed. Please try again.</source>
+        <translation>GitHub 下載失敗，請重試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="418"/>
+        <source>MirrorChyan download timed out. Check your network or proxy.</source>
+        <translation>MirrorChyan 下載逾時，請檢查網路或代理。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="421"/>
+        <source>MirrorChyan download SSL failed. Check certificate or proxy settings.</source>
+        <translation>MirrorChyan 下載 SSL 失敗，請檢查憑證或代理設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="424"/>
+        <source>MirrorChyan download connection failed. Check your network.</source>
+        <translation>MirrorChyan 下載連線失敗，請檢查網路。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="425"/>
+        <source>MirrorChyan download failed. Please try again.</source>
+        <translation>MirrorChyan 下載失敗，請重試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="269"/>
+        <source>{channel} send failed: SSL error. Check certificate or proxy settings.</source>
+        <translation>{channel} 發送失敗：SSL 錯誤，請檢查憑證或代理設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="272"/>
+        <source>{channel} send failed: request timed out. Check your network.</source>
+        <translation>{channel} 發送失敗：請求逾時，請檢查網路。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="277"/>
+        <source>{channel} send failed: domain could not be resolved. Check DNS settings.</source>
+        <translation>{channel} 發送失敗：網域無法解析，請檢查 DNS 設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="281"/>
+        <source>{channel} send failed: connection error. Check server address and network.</source>
+        <translation>{channel} 發送失敗：連線錯誤，請檢查伺服器位址與網路。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="285"/>
+        <source>{channel} send failed: request rejected. Check URL, token, or webhook key.</source>
+        <translation>{channel} 發送失敗：請求被拒絕，請檢查 URL、Token 或 Webhook 金鑰。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="289"/>
+        <source>{channel} send failed: remote service error. Try again later.</source>
+        <translation>{channel} 發送失敗：遠端服務錯誤，請稍後再試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="293"/>
+        <source>{channel} send failed: invalid response from server. Check configuration.</source>
+        <translation>{channel} 發送失敗：伺服器回傳無效回應，請檢查設定。</translation>
+    </message>
+    <message>
+        <location filename="../utils/network_error_helper.py" line="295"/>
+        <source>{channel} send failed due to a network error.</source>
+        <translation>{channel} 因網路錯誤發送失敗。</translation>
+    </message>
+    <message>
+        <source>{channel} sent successfully.</source>
+        <translation type="vanished">{channel} 發送成功。</translation>
+    </message>
+    <message>
+        <source>{channel} notifications are disabled.</source>
+        <translation type="vanished">{channel} 通知已停用。</translation>
+    </message>
+    <message>
+        <source>{channel}: required settings are empty.</source>
+        <translation type="vanished">{channel}：必要設定為空。</translation>
+    </message>
+    <message>
+        <source>{channel}: invalid URL or parameter format.</source>
+        <translation type="vanished">{channel}：URL 或參數格式無效。</translation>
+    </message>
+    <message>
+        <source>{channel} send failed due to a network error. (Network)</source>
+        <translation type="vanished">{channel} 因網路錯誤發送失敗。（網路）</translation>
+    </message>
+    <message>
+        <source>{channel} send failed: server returned an error. Check webhook or token.</source>
+        <translation type="vanished">{channel} 發送失敗：伺服器回傳錯誤，請檢查 Webhook 或 Token。</translation>
+    </message>
+    <message>
+        <source>{channel}: SMTP port must be a valid number. (Config)</source>
+        <translation type="vanished">{channel}：SMTP 連接埠必須為有效數字。（設定）</translation>
+    </message>
+    <message>
+        <source>{channel} SMTP connection failed. Check server address, port, and credentials. (Connection)</source>
+        <translation type="vanished">{channel} SMTP 連線失敗，請檢查伺服器位址、連接埠與憑證。（連線）</translation>
+    </message>
+    <message>
+        <source>{channel} send failed with an unknown error. (Unknown)</source>
+        <translation type="vanished">{channel} 因未知錯誤發送失敗。（未知）</translation>
+    </message>
+</context>
+<context>
+    <name>AddBundleDialog</name>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1514"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1518"/>
+        <source>Add Resource Bundle</source>
+        <translation>新增資源包</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1524"/>
+        <source>Bundle Name:</source>
+        <translation>資源包名稱：</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1526"/>
+        <source>Enter the name of the bundle</source>
+        <translation>輸入資源包的名稱</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1533"/>
+        <source>Interface File:</source>
+        <translation>介面檔案：</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1536"/>
+        <source>Select interface.json or interface.jsonc file</source>
+        <translation>選擇 interface.json 或 interface.jsonc 檔案</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1555"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1556"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1573"/>
+        <source>Choose Interface File</source>
+        <translation>選擇介面檔案</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1575"/>
+        <source>Interface Files (interface.json interface.jsonc)</source>
+        <translation>介面檔案 (interface.json interface.jsonc)</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1577"/>
+        <source>JSON Files (*.json *.jsonc)</source>
+        <translation>JSON 檔案 (*.json *.jsonc)</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1579"/>
+        <source>All Files (*)</source>
+        <translation>所有檔案 (*)</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1594"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1668"/>
+        <source>Please select interface.json or interface.jsonc file</source>
+        <translation>請選擇 interface.json 或 interface.jsonc 檔案</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1614"/>
+        <source>Default Bundle</source>
+        <translation>預設套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1644"/>
+        <source>Interface file path cannot be empty</source>
+        <translation>介面檔案路徑不能為空</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1654"/>
+        <source>Selected interface file does not exist</source>
+        <translation>選擇的介面檔案不存在</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1660"/>
+        <source>Selected path is not a file</source>
+        <translation>選擇的路徑不是檔案</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1691"/>
+        <source>Failed to read interface.json: {}</source>
+        <translation>讀取 interface.json 失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1697"/>
+        <source>interface.json does not contain a valid &apos;name&apos; field</source>
+        <translation>interface.json 不包含有效的 &apos;name&apos; 欄位</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1707"/>
+        <source>Service is not ready, cannot save bundle</source>
+        <translation>服務未就緒，無法儲存資源包</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1723"/>
+        <source>Bundle name already exists</source>
+        <translation>資源包名稱已存在</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1728"/>
+        <source>Failed to check existing bundles: {}</source>
+        <translation>檢查現有套件失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1741"/>
+        <source>Bundle directory does not exist: {}</source>
+        <translation>套件目錄不存在：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1747"/>
+        <source>Bundle path is not a directory: {}</source>
+        <translation>套件路徑不是目錄：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1787"/>
+        <source>Cannot move bundle: target directory is inside source directory</source>
+        <translation>無法移動套件：目標目錄位於來源目錄內</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1816"/>
+        <source>Failed to remove existing bundle directory: {}</source>
+        <translation>移除現有套件目錄失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1844"/>
+        <source>Failed to create bundle directory: {}</source>
+        <translation>建立套件目錄失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1890"/>
+        <source>Failed to move bundle to target directory: {}</source>
+        <translation>移動套件至目標目錄失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1938"/>
+        <source>Failed to update bundle path</source>
+        <translation>更新套件路徑失敗</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1943"/>
+        <source>Failed to update bundle path: {}</source>
+        <translation>更新套件路徑失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1958"/>
+        <source>An unexpected error occurred: {}</source>
+        <translation>發生未預期的錯誤：{}</translation>
+    </message>
+</context>
+<context>
+    <name>AddConfigDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="98"/>
+        <source>Add New Config</source>
+        <translation>新增設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="104"/>
+        <source>Config Name:</source>
+        <translation>設定名稱：</translation>
+    </message>
+    <message>
+        <source>Enter the name of the config</source>
+        <translation type="vanished">輸入設定名稱</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="116"/>
+        <source>Resource Bundle:</source>
+        <translation>資源套件：</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="135"/>
+        <source>Preset:</source>
+        <translation>預設：</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="226"/>
+        <source>Default (all tasks)</source>
+        <translation>預設（所有任務）</translation>
+    </message>
+    <message>
+        <source>Config name cannot be empty</source>
+        <translation type="vanished">設定名稱不能為空</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="107"/>
+        <source>Enter name, or leave empty for auto (preset name + index)</source>
+        <translation>輸入名稱，或留空以自動生成（預設名稱+索引）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="147"/>
+        <source>Import shared config:</source>
+        <translation>匯入共享設定：</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="149"/>
+        <source>Off</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="150"/>
+        <source>On</source>
+        <translation>開啟</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="158"/>
+        <source>Paste shared config content here</source>
+        <translation>在此貼上共享設定內容</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="306"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="308"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="401"/>
+        <source>Config</source>
+        <translation>配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="310"/>
+        <source>{0} {1}</source>
+        <translation>{0} {1}</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="334"/>
+        <source>Please paste shared config content</source>
+        <translation>請貼上共享設定內容</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="339"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="342"/>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="368"/>
+        <source>Invalid shared config content</source>
+        <translation>無效的共享設定內容</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="345"/>
+        <source>Shared config contains no tasks</source>
+        <translation>共享設定中沒有任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="350"/>
+        <source>Please select a resource bundle</source>
+        <translation>請選擇資源包</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="362"/>
+        <source>Resource mismatch: shared config is for &quot;{0}&quot;, but you selected &quot;{1}&quot;.</source>
+        <translation>資源不符：共享設定用於「{0}」，但你選擇了「{1}」。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="403"/>
+        <source>New Config</source>
+        <translation>新增配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="406"/>
+        <source>Could not allocate a unique config name</source>
+        <translation>無法分配唯一的配置名稱</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="412"/>
+        <source>Cannot use &apos;default&apos; as config name</source>
+        <translation>不能使用「default」作為設定名稱</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="427"/>
+        <source>Resource bundle not found</source>
+        <translation>找不到資源套件</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="453"/>
+        <source>Interface file not found in bundle: {}</source>
+        <translation>在套件中找不到介面檔案：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="464"/>
+        <source>Failed to load interface from bundle: {}</source>
+        <translation>從套件載入介面失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="470"/>
+        <source>Controller not found in bundle interface</source>
+        <translation>在套件介面中找不到控制器</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="473"/>
+        <source>Resource not found in bundle interface</source>
+        <translation>在套件介面中找不到資源</translation>
+    </message>
+</context>
+<context>
+    <name>AddTaskDialog</name>
+    <message>
+        <source>Framework Built-in Tasks</source>
+        <translation type="vanished">框架內建任務</translation>
+    </message>
+    <message>
+        <source>Builtin tasks loaded by the framework.</source>
+        <translation type="vanished">由框架載入的內建任務</translation>
+    </message>
+    <message>
+        <source>Launch Program</source>
+        <translation type="vanished">啟動程式</translation>
+    </message>
+    <message>
+        <source>Launch an external program and optionally wait for it to exit.</source>
+        <translation type="vanished">啟動外部程式，並可選擇是否等待行程結束。</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation type="vanished">等待</translation>
+    </message>
+    <message>
+        <source>Wait for the specified number of seconds before continuing.</source>
+        <translation type="vanished">等待指定秒數後繼續執行後續任務。</translation>
+    </message>
+    <message>
+        <source>Wait Until</source>
+        <translation type="vanished">定時等待</translation>
+    </message>
+    <message>
+        <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
+        <translation type="vanished">等待到指定時間點後繼續。支援 HH:MM 或 YYYY-MM-DD HH:MM。</translation>
+    </message>
+    <message>
+        <source>System Notification</source>
+        <translation type="vanished">系統通知</translation>
+    </message>
+    <message>
+        <source>Send a system notification and optionally play the system sound.</source>
+        <translation type="vanished">傳送系統通知，並可同時播放系統提示音。</translation>
+    </message>
+    <message>
+        <source>External Notification</source>
+        <translation type="vanished">外部通知</translation>
+    </message>
+    <message>
+        <source>Send a message to all currently enabled external notification channels.</source>
+        <translation type="vanished">向目前已啟用的外部通知通道傳送訊息。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="544"/>
+        <source>Add New Task</source>
+        <translation>新增任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="547"/>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="548"/>
+        <source>Add</source>
+        <translation>新增</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="554"/>
+        <source>Task List</source>
+        <translation>任務清單</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="556"/>
+        <source>Select one task from the groups below.</source>
+        <translation>請從以下群組中選擇一個任務。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="652"/>
+        <source>Default Group</source>
+        <translation>預設群組</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="653"/>
+        <source>Tasks without an explicit group</source>
+        <translation>未明確分組的任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="727"/>
+        <source>{} tasks</source>
+        <translation>{} 個任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="794"/>
+        <source>Please select a task</source>
+        <translation>請選擇一個任務</translation>
+    </message>
+</context>
+<context>
+    <name>AprilFoolsEasterEgg</name>
+    <message>
+        <source> Checking anti-addiction system...</source>
+        <translation type="vanished"> 正在檢測防沉迷系統...</translation>
+    </message>
+    <message>
+        <source> April Fools detected. System verdict: &quot;Limited-time April Fools addiction mode&quot;.</source>
+        <translation type="vanished"> 檢測到當前為愚人節，系統判定為「愚人節限時沉迷」。</translation>
+    </message>
+    <message>
+        <source> Task execution failed! Reason: You are granted &quot;slacking rights&quot; today. Please grab a coffee manually.</source>
+        <translation type="vanished"> 任務執行失敗！原因：今天你被賦予「摸魚」權利，請手動去喝杯咖啡。</translation>
+    </message>
+    <message>
+        <source> Just kidding, back to serious work...</source>
+        <translation type="vanished"> 騙你的，開始正經幹活...</translation>
+    </message>
+    <message>
+        <source> Today&apos;s task progress: ▓▓▓▓▓▓▓▓▓▓ 100%</source>
+        <translation type="vanished"> 今日任務進度: ▓▓▓▓▓▓▓▓▓▓ 100%</translation>
+    </message>
+    <message>
+        <source> Verifying... Verification failed!</source>
+        <translation type="vanished"> 校驗中... 校驗失敗！</translation>
+    </message>
+    <message>
+        <source> Server fluctuation detected (actually April Fools fluctuation), progress rolled back to 0%.</source>
+        <translation type="vanished"> 檢測到伺服器波動（其實是愚人節波動），進度已回滾至 0%。</translation>
+    </message>
+    <message>
+        <source> Re-executing...</source>
+        <translation type="vanished"> 正在重新執行...</translation>
+    </message>
+    <message>
+        <source> [System Notice] Since today is April Fools, all players can claim the limited title &quot;Ultimate Sucker&quot; upon login.</source>
+        <translation type="vanished"> [系統公告] 由於今天是愚人節，所有玩家今日登入即可領取限定稱號「大冤種」。</translation>
+    </message>
+    <message>
+        <source> Title claimed automatically. Please restart the game to view it.</source>
+        <translation type="vanished"> 已自動為您領取稱號，請重啟遊戲查看。</translation>
+    </message>
+    <message>
+        <source> Daily task completion: ■■□□□ 40%</source>
+        <translation type="vanished"> 每日任務完成度：■■□□□ 40%</translation>
+    </message>
+    <message>
+        <source> Injecting April Fools special patch...</source>
+        <translation type="vanished"> 注入愚人節特供補丁...</translation>
+    </message>
+    <message>
+        <source> Output: sudo rm -rf</source>
+        <translation type="vanished"> 輸出結果：sudo rm -rf</translation>
+    </message>
+    <message>
+        <source> Got scared? Back to normal task execution...</source>
+        <translation type="vanished"> 哈哈，嚇到了沒？正在正經執行任務...</translation>
+    </message>
+    <message>
+        <source> April Fools detected, enabling &quot;Anti-Boss Mode&quot; automatically.</source>
+        <translation type="vanished"> 檢測到今天是愚人節，自動開啟「防老闆模式」。</translation>
+    </message>
+    <message>
+        <source> Taskbar title changed to: &quot;2026 Q2 Quarterly Report - Data Analysis.exe&quot;</source>
+        <translation type="vanished"> 任務欄標題已修改為：「2026年Q2季度報表 - 數據分析.exe」</translation>
+    </message>
+    <message>
+        <source>2026 Q2 Quarterly Report - Data Analysis.exe</source>
+        <translation type="vanished">2026年Q2季度報表 - 數據分析.exe</translation>
+    </message>
+    <message>
+        <source> Pretending to load Excel...</source>
+        <translation type="vanished"> 正在假裝載入Excel...</translation>
+    </message>
+    <message>
+        <source> Today&apos;s task list: 1. Enter game; 2. Claim rewards; 3. Be kind to yourself.</source>
+        <translation type="vanished"> 今日任務列表：1.進入遊戲；2.領獎勵；3.對自己好一點。</translation>
+    </message>
+    <message>
+        <source> The first two are already done for you, please do the third one yourself.</source>
+        <translation type="vanished"> 前兩項任務已代勞，第三項請親自完成。</translation>
+    </message>
+</context>
+<context>
+    <name>BaseAddDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="58"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="59"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/add_task_message_box.py" line="78"/>
+        <source>Error</source>
+        <translation>錯誤</translation>
+    </message>
+</context>
+<context>
+    <name>BaseListToolBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="72"/>
+        <source>Select All</source>
+        <translation>全選</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="76"/>
+        <source>Deselect All</source>
+        <translation>取消全選</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="80"/>
+        <source>Add</source>
+        <translation>新增</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="84"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <source>Switch to Special Tasks</source>
+        <translation type="vanished">切換至特殊任務</translation>
+    </message>
+</context>
+<context>
+    <name>BaseNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="29"/>
+        <source>Test</source>
+        <translation>測試</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="93"/>
+        <source>decrypt notice key failed: {}，please fill in again and save.</source>
+        <translation>解密通知金鑰失敗：{}，請重新填寫並儲存。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="99"/>
+        <source>parse notice key error: {}，please save again.</source>
+        <translation>解析通知金鑰錯誤：{}，請重新儲存。</translation>
+    </message>
+</context>
+<context>
+    <name>BaseUpdate</name>
+    <message>
+        <location filename="../utils/update.py" line="240"/>
+        <location filename="../utils/update.py" line="272"/>
+        <source>User cancelled</source>
+        <translation>使用者已取消</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="274"/>
+        <source>Download interrupted</source>
+        <translation>下載中斷</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="856"/>
+        <source>GitHub API returned an error: {message}</source>
+        <translation>GitHub API 回傳錯誤：{message}</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="878"/>
+        <source>GitHub returned an invalid response. Please try again later. (Response)</source>
+        <translation>GitHub 回傳無效回應，請稍後再試。（回應）</translation>
+    </message>
+    <message>
+        <source>Update check failed HTTP error,code: </source>
+        <translation type="vanished">更新檢查失敗 HTTP 錯誤，代碼：</translation>
+    </message>
+    <message>
+        <source>GitHub API request limit exceeded,please try again later</source>
+        <translation type="vanished">GitHub API 請求次數已達上限，請稍後再試</translation>
+    </message>
+    <message>
+        <source>Github Update check failed HTTP error,code: </source>
+        <translation type="vanished">GitHub 更新檢查失敗 HTTP 錯誤，代碼：</translation>
+    </message>
+    <message>
+        <source>MirrorChyan Update check failed SSL error</source>
+        <translation type="vanished">MirrorChyan 更新檢查失敗 SSL 錯誤</translation>
+    </message>
+    <message>
+        <source>switching to Github download</source>
+        <translation type="vanished">切換至 Github 下載</translation>
+    </message>
+    <message>
+        <source>Github Update check failed SSL error</source>
+        <translation type="vanished">Github 更新檢查失敗 SSL 錯誤</translation>
+    </message>
+    <message>
+        <source>INVALID_PARAMS</source>
+        <translation type="vanished">無效參數</translation>
+    </message>
+    <message>
+        <source>KEY_EXPIRED</source>
+        <translation type="vanished">金鑰已過期</translation>
+    </message>
+    <message>
+        <source>KEY_INVALID</source>
+        <translation type="vanished">金鑰無效</translation>
+    </message>
+    <message>
+        <source>RESOURCE_QUOTA_EXHAUSTED</source>
+        <translation type="vanished">資源配額已耗盡</translation>
+    </message>
+    <message>
+        <source>KEY_MISMATCHED</source>
+        <translation type="vanished">金鑰不匹配</translation>
+    </message>
+    <message>
+        <source>RESOURCE_NOT_FOUND</source>
+        <translation type="vanished">資源未找到</translation>
+    </message>
+    <message>
+        <source>INVALID_OS</source>
+        <translation type="vanished">無效作業系統</translation>
+    </message>
+    <message>
+        <source>INVALID_ARCH</source>
+        <translation type="vanished">無效架構</translation>
+    </message>
+    <message>
+        <source>INVALID_CHANNEL</source>
+        <translation type="vanished">無效頻道</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation type="vanished">未知錯誤</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="835"/>
+        <location filename="../utils/update.py" line="866"/>
+        <source>current version is latest</source>
+        <translation>目前版本已是最新</translation>
+    </message>
+    <message>
+        <source>GitHub API ERROR: </source>
+        <translation type="vanished">GitHub API 錯誤：</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="933"/>
+        <source>Failed to clean up temporary files</source>
+        <translation>清理暫存檔案失敗</translation>
+    </message>
+</context>
+<context>
+    <name>BundleDetailWidget</name>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="199"/>
+        <source>Description</source>
+        <translation>描述</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="205"/>
+        <source>No description available</source>
+        <translation>無可用描述</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="220"/>
+        <source>Contact</source>
+        <translation>聯絡方式</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="224"/>
+        <source>No contact information available</source>
+        <translation>無可用聯絡資訊</translation>
+    </message>
+</context>
+<context>
+    <name>BundleInterface</name>
+    <message>
+        <source>Open update log</source>
+        <translation type="vanished">開啟更新記錄</translation>
+    </message>
+    <message>
+        <source>Delete bundle</source>
+        <translation type="vanished">刪除套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="455"/>
+        <source>Bundle List</source>
+        <translation>套件清單</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="456"/>
+        <source>Bundle Details</source>
+        <translation>套件詳細資訊</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="457"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="459"/>
+        <source>Auto Update</source>
+        <translation>自動更新</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="460"/>
+        <source>Add Bundle</source>
+        <translation>新增套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="461"/>
+        <source>Update All Bundles</source>
+        <translation>更新所有套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="463"/>
+        <source>Please select a Bundle from the left</source>
+        <translation>請從左側選擇一個套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="591"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="926"/>
+        <source>Unknown version</source>
+        <translation>未知版本</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="734"/>
+        <source>No license information for this bundle</source>
+        <translation>此套件無授權資訊</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="465"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="739"/>
+        <source>License</source>
+        <translation>授權</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="781"/>
+        <source>No welcome message for this bundle</source>
+        <translation>此套件無歡迎訊息</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="466"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="786"/>
+        <source>Welcome</source>
+        <translation>歡迎</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1018"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1076"/>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1298"/>
+        <source>Multi-resource adaptation is not enabled. Please enable it in Settings first.</source>
+        <translation>未啟用多資源適配。請先在設定中啟用。</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1055"/>
+        <source>All bundles are up to date</source>
+        <translation>所有套件皆為最新版本</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1106"/>
+        <source>{count} bundle update(s) failed</source>
+        <translation>{count} 個套件更新失敗</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1115"/>
+        <source>All updates completed</source>
+        <translation>所有更新已完成</translation>
+    </message>
+    <message>
+        <source>Updating bundle: {bundle_name}</source>
+        <translation type="vanished">正在更新套件：{bundle_name}</translation>
+    </message>
+    <message>
+        <source>Bundle &apos;{bundle_name}&apos; updated successfully</source>
+        <translation type="vanished">套件 &apos;{bundle_name}&apos; 更新成功</translation>
+    </message>
+    <message>
+        <source>Update cancelled: {bundle_name}</source>
+        <translation type="vanished">更新已取消：{bundle_name}</translation>
+    </message>
+    <message>
+        <source>Restart required for bundle: {bundle_name}</source>
+        <translation type="vanished">需要重新啟動套件：{bundle_name}</translation>
+    </message>
+    <message>
+        <source>Update failed for bundle: {bundle_name}</source>
+        <translation type="vanished">套件更新失敗：{bundle_name}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1170"/>
+        <source>Updating bundle: {}</source>
+        <translation>正在更新套件：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1195"/>
+        <source>Bundle &apos;{}&apos; updated successfully</source>
+        <translation>套件 &apos;{}&apos; 更新成功</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1208"/>
+        <source>Update cancelled: {}</source>
+        <translation>更新已取消：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1216"/>
+        <source>Restart required for bundle: {}</source>
+        <translation>套件 {} 需要重新啟動</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1227"/>
+        <source>Update failed for bundle: {}</source>
+        <translation>套件 {} 更新失敗</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1248"/>
+        <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
+        <translation>CI/Alpha 資源版本已停用自動更新，請手動更新。</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1336"/>
+        <source>Bundle &apos;{}&apos; added successfully</source>
+        <translation>套件 &apos;{}&apos; 新增成功</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1379"/>
+        <source>No update log</source>
+        <translation>無更新記錄</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1380"/>
+        <source>No update log found locally for this bundle.
 
 Please check for updates first, or visit the GitHub releases page.</source>
-            <translation>本機找不到此套件的更新記錄。
+        <translation>本機找不到此套件的更新記錄。
 
 請先檢查更新，或造訪 GitHub 發佈頁面。</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1392" />
-            <source>Update Log</source>
-            <translation>更新記錄</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1429" />
-            <source>Failed to find configurations using this bundle: {}</source>
-            <translation>找不到使用此套件的設定：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1437" />
-            <source>Are you sure you want to delete bundle '{}'?
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1392"/>
+        <source>Update Log</source>
+        <translation>更新記錄</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1429"/>
+        <source>Failed to find configurations using this bundle: {}</source>
+        <translation>找不到使用此套件的設定：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1437"/>
+        <source>Are you sure you want to delete bundle &apos;{}&apos;?
 
 The following configurations using this bundle will also be deleted:
 {}</source>
-            <translation>確定要刪除套件 '{}' 嗎？
+        <translation>確定要刪除套件 &apos;{}&apos; 嗎？
 
 使用此套件的以下設定也將一併刪除：
 {}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1443" />
-            <source>Are you sure you want to delete bundle '{}'?</source>
-            <translation>確定要刪除套件 '{}' 嗎？</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1450" />
-            <source>Delete Bundle</source>
-            <translation>刪除套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1479" />
-            <source>Bundle '{}' and {} related configuration(s) deleted successfully</source>
-            <translation>套件 '{}' 及 {} 個相關設定已成功刪除</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1496" />
-            <source>Failed to delete bundle: {}</source>
-            <translation>刪除套件失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="1502" />
-            <source>An error occurred while deleting bundle: {}</source>
-            <translation>刪除套件時發生錯誤：{}</translation>
-        </message>
-    </context>
-    <context>
-        <name>BundleListItem</name>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="133" />
-            <source>Open update log</source>
-            <translation>開啟更新記錄</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="142" />
-            <source>Delete bundle</source>
-            <translation>刪除套件</translation>
-        </message>
-        <message>
-            <location filename="../view/bundle_interface/bundle_interface.py" line="154" />
-            <source>Latest version: {}</source>
-            <translation>最新版本：{}</translation>
-        </message>
-    </context>
-    <context>
-        <name>CallbackLogProcessor</name>
-        <message>
-            <location filename="../core/log_processor.py" line="38" />
-            <source>screenshot test success, time: </source>
-            <translation>截圖測試成功，時間：</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="76" />
-            <source>Resource Loading Failed</source>
-            <translation>資源載入失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="83" />
-            <source>Controller Started Connect</source>
-            <translation>控制器開始連線</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="86" />
-            <source>Controller Connect Failed</source>
-            <translation>控制器連線失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="92" />
-            <source>Unknown Task</source>
-            <translation>未知任務</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="97" />
-            <source>Task started execution: </source>
-            <translation>任務開始執行：</translation>
-        </message>
-        <message>
-            <location filename="../core/log_processor.py" line="100" />
-            <source>Task execution failed: </source>
-            <translation>任務執行失敗：</translation>
-        </message>
-    </context>
-    <context>
-        <name>ConfigListItem</name>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1103" />
-            <source>Rename config</source>
-            <translation>重新命名設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1108" />
-            <source>Copy config ID</source>
-            <translation>複製設定ID</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1113" />
-            <source>Share config</source>
-            <translation>共享設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1188" />
-            <source>Failed to load config for sharing.</source>
-            <translation>載入共享設定失敗。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1195" />
-            <source>Config has no resource bundle, cannot share.</source>
-            <translation>設定沒有資源包，無法共享。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1211" />
-            <location filename="../view/task_interface/components/list_item.py" line="1216" />
-            <source>Failed to encode config for sharing.</source>
-            <translation>編碼共享設定失敗。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="1222" />
-            <source>Config copied to clipboard.</source>
-            <translation>設定已複製到剪貼簿。</translation>
-        </message>
-    </context>
-    <context>
-        <name>ConfigListToolBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="139" />
-            <source>Configurations</source>
-            <translation>設定組態</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="184" />
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="253" />
-            <source>Task is running, configurations are locked.</source>
-            <translation>任務執行中，設定組態已鎖定。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="239" />
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="240" />
-            <source>unknown</source>
-            <translation>未知</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="244" />
-            <source>Shared config version ({0}) differs from current resource version ({1}); imported anyway.</source>
-            <translation>共享設定版本（{0}）與目前資源版本（{1}）不同；已強制匯入。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="259" />
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="262" />
-            <source>Cannot delete the last configuration!</source>
-            <translation>無法刪除最後一個設定組態！</translation>
-        </message>
-    </context>
-    <context>
-        <name>ControllerSettingWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="841" />
-            <source>Controller Type</source>
-            <translation>控制器類型</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="842" />
-            <source>this controller requires admin permission to run</source>
-            <translation>此控制器需要管理員權限才能執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="898" />
-            <source>Search Device</source>
-            <translation>搜尋裝置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="912" />
-            <source>Agent Timeout</source>
-            <translation>代理逾時</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="916" />
-            <source>-1 means infinite</source>
-            <translation>-1 表示無限</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="958" />
-            <source>Custom Module Path</source>
-            <translation>自訂模組路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="967" />
-            <source>GPU Acceleration</source>
-            <translation>GPU 加速</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="987" />
-            <source>Auto</source>
-            <translation>自動</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="988" />
-            <source>CPU</source>
-            <translation>CPU</translation>
-        </message>
-        <message>
-            <source>Description: No specific method (Null).
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1443"/>
+        <source>Are you sure you want to delete bundle &apos;{}&apos;?</source>
+        <translation>確定要刪除套件 &apos;{}&apos; 嗎？</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1450"/>
+        <source>Delete Bundle</source>
+        <translation>刪除套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1479"/>
+        <source>Bundle &apos;{}&apos; and {} related configuration(s) deleted successfully</source>
+        <translation>套件 &apos;{}&apos; 及 {} 個相關設定已成功刪除</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1496"/>
+        <source>Failed to delete bundle: {}</source>
+        <translation>刪除套件失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="1502"/>
+        <source>An error occurred while deleting bundle: {}</source>
+        <translation>刪除套件時發生錯誤：{}</translation>
+    </message>
+</context>
+<context>
+    <name>BundleListItem</name>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="133"/>
+        <source>Open update log</source>
+        <translation>開啟更新記錄</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="142"/>
+        <source>Delete bundle</source>
+        <translation>刪除套件</translation>
+    </message>
+    <message>
+        <location filename="../view/bundle_interface/bundle_interface.py" line="154"/>
+        <source>Latest version: {}</source>
+        <translation>最新版本：{}</translation>
+    </message>
+</context>
+<context>
+    <name>CallbackLogProcessor</name>
+    <message>
+        <location filename="../core/log_processor.py" line="38"/>
+        <source>screenshot test success, time: </source>
+        <translation>截圖測試成功，時間：</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="76"/>
+        <source>Resource Loading Failed</source>
+        <translation>資源載入失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="83"/>
+        <source>Controller Started Connect</source>
+        <translation>控制器開始連線</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="86"/>
+        <source>Controller Connect Failed</source>
+        <translation>控制器連線失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="92"/>
+        <source>Unknown Task</source>
+        <translation>未知任務</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="97"/>
+        <source>Task started execution: </source>
+        <translation>任務開始執行：</translation>
+    </message>
+    <message>
+        <location filename="../core/log_processor.py" line="100"/>
+        <source>Task execution failed: </source>
+        <translation>任務執行失敗：</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigListItem</name>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1016"/>
+        <source>Running</source>
+        <translation>執行中</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1124"/>
+        <source>Rename config</source>
+        <translation>重新命名設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1129"/>
+        <source>Copy config ID</source>
+        <translation>複製設定ID</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1134"/>
+        <source>Share config</source>
+        <translation>共享設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1209"/>
+        <source>Failed to load config for sharing.</source>
+        <translation>載入共享設定失敗。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1216"/>
+        <source>Config has no resource bundle, cannot share.</source>
+        <translation>設定沒有資源包，無法共享。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1232"/>
+        <location filename="../view/task_interface/components/list_item.py" line="1237"/>
+        <source>Failed to encode config for sharing.</source>
+        <translation>編碼共享設定失敗。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="1243"/>
+        <source>Config copied to clipboard.</source>
+        <translation>設定已複製到剪貼簿。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigListToolBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="139"/>
+        <source>Configurations</source>
+        <translation>設定組態</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="203"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="272"/>
+        <source>Task is running, configurations are locked.</source>
+        <translation>任務執行中，設定組態已鎖定。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="258"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="259"/>
+        <source>unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="263"/>
+        <source>Shared config version ({0}) differs from current resource version ({1}); imported anyway.</source>
+        <translation>共享設定版本（{0}）與目前資源版本（{1}）不同；已強制匯入。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="278"/>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="281"/>
+        <source>Cannot delete the last configuration!</source>
+        <translation>無法刪除最後一個設定組態！</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigMonitorTile</name>
+    <message>
+        <location filename="../view/monitor_interface/multi_config_monitor_grid.py" line="99"/>
+        <source>Running</source>
+        <translation>執行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/multi_config_monitor_grid.py" line="129"/>
+        <source>Not running</source>
+        <translation>未執行</translation>
+    </message>
+</context>
+<context>
+    <name>ControllerSettingWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="841"/>
+        <source>Controller Type</source>
+        <translation>控制器類型</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="842"/>
+        <source>this controller requires admin permission to run</source>
+        <translation>此控制器需要管理員權限才能執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="898"/>
+        <source>Search Device</source>
+        <translation>搜尋裝置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="912"/>
+        <source>Agent Timeout</source>
+        <translation>代理逾時</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="916"/>
+        <source>-1 means infinite</source>
+        <translation>-1 表示無限</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="958"/>
+        <source>Custom Module Path</source>
+        <translation>自訂模組路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="967"/>
+        <source>GPU Acceleration</source>
+        <translation>GPU 加速</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="987"/>
+        <source>Auto</source>
+        <translation>自動</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="988"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <source>Description: No specific method (Null).
 Speed: Depends on framework fallback.
 Mouse capture: N/A (desktop).
 Compatibility: Framework-defined.
 Admin rights: Usually not required; elevate if the target process runs elevated.</source>
-            <translation type="vanished">說明：無特定方法（空）。
+        <translation type="vanished">說明：無特定方法（空）。
 速度：取決於框架的後備方案。
 滑鼠捕捉：不適用（桌面）。
 相容性：由框架定義。
 管理員權限：通常不需要；若目標程序以管理員權限執行則需提升權限。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1118" />
-            <source>(No description for this category.)</source>
-            <translation>（此類別無說明。）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1123" />
-            <source>Description: Injects input on the target window thread; closest to real mouse/keyboard.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1118"/>
+        <source>(No description for this category.)</source>
+        <translation>（此類別無說明。）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1123"/>
+        <source>Description: Injects input on the target window thread; closest to real mouse/keyboard.
 Speed: Fast.
 Mouse capture: Yes (continuous capture of the window input queue).
 Compatibility: High.
 Admin rights: Usually not required; match elevation if the target runs elevated.</source>
-            <translation>說明：在目標視窗執行緒上注入輸入；最接近真實滑鼠/鍵盤。
+        <translation>說明：在目標視窗執行緒上注入輸入；最接近真實滑鼠/鍵盤。
 速度：快。
 滑鼠捕捉：是（持續捕捉視窗輸入佇列）。
 相容性：高。
 管理員權限：通常不需要；若目標以管理員權限執行則需匹配權限。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1131" />
-            <source>Description: Synchronously posts window messages via SendMessage.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1131"/>
+        <source>Description: Synchronously posts window messages via SendMessage.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Medium; some games/anti-cheat ignore synthetic messages.
 Admin rights: Often depends on the target process (elevated targets need an elevated client).</source>
-            <translation>說明：透過 SendMessage 同步發送視窗訊息。
+        <translation>說明：透過 SendMessage 同步發送視窗訊息。
 速度：中等。
 滑鼠捕捉：否。
 相容性：中等；部分遊戲/反作弊系統忽略合成訊息。
 管理員權限：通常取決於目標程序（提升權限的目標需要提升權限的客戶端）。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1139" />
-            <source>Description: Asynchronously posts window messages via PostMessage.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1139"/>
+        <source>Description: Asynchronously posts window messages via PostMessage.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Medium; some games/anti-cheat ignore synthetic messages.
 Admin rights: Often depends on the target process (elevated targets need an elevated client).</source>
-            <translation>說明：透過 PostMessage 非同步發送視窗訊息。
+        <translation>說明：透過 PostMessage 非同步發送視窗訊息。
 速度：中等。
 滑鼠捕捉：否。
 相容性：中等；部分遊戲/反作弊系統忽略合成訊息。
 管理員權限：通常取決於目標程序（提升權限的目標需要提升權限的客戶端）。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1147" />
-            <source>Description: Legacy event-injection path.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1147"/>
+        <source>Description: Legacy event-injection path.
 Speed: Medium.
 Mouse capture: Yes.
 Compatibility: Low.
 Admin rights: Usually not required; depends on the target process.</source>
-            <translation>說明：舊版事件注入路徑。
+        <translation>說明：舊版事件注入路徑。
 速度：中等。
 滑鼠捕捉：是。
 相容性：低。
 管理員權限：通常不需要；取決於目標程序。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1155" />
-            <source>Description: Posts messages to the window's owning thread.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1155"/>
+        <source>Description: Posts messages to the window&apos;s owning thread.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Low.
 Admin rights: Often depends on the target process.</source>
-            <translation>說明：將訊息發送到視窗所屬執行緒。
+        <translation>說明：將訊息發送到視窗所屬執行緒。
 速度：中等。
 滑鼠捕捉：否。
 相容性：低。
 管理員權限：通常取決於目標程序。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1163" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1171" />
-            <source>Description: Briefly moves the cursor to the target point, sends the message, then restores the cursor.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1163"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1171"/>
+        <source>Description: Briefly moves the cursor to the target point, sends the message, then restores the cursor.
 Speed: Medium.
 Mouse capture: Brief cursor movement.
 Compatibility: Medium.
 Admin rights: Often depends on the target process.</source>
-            <translation>說明：短暫移動游標到目標點，發送訊息，然後恢復游標位置。
+        <translation>說明：短暫移動游標到目標點，發送訊息，然後恢復游標位置。
 速度：中等。
 滑鼠捕捉：短暫游標移動。
 相容性：中等。
 管理員權限：通常取決於目標程序。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1179" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1187" />
-            <source>Description: Briefly moves the window so the target aligns with the current cursor, sends the message, then restores the window.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1179"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1187"/>
+        <source>Description: Briefly moves the window so the target aligns with the current cursor, sends the message, then restores the window.
 Speed: Medium.
 Mouse capture: No (the window moves, not the cursor).
 Compatibility: Medium; may fail for fullscreen or locked-layout games.
 Admin rights: Often depends on the target process.</source>
-            <translation>說明：短暫移動視窗使目標對齊當前游標，發送訊息，然後恢復視窗位置。
+        <translation>說明：短暫移動視窗使目標對齊當前游標，發送訊息，然後恢復視窗位置。
 速度：中等。
 滑鼠捕捉：否（視窗移動，非游標）。
 相容性：中等；可能對全螢幕或鎖定佈局的遊戲失敗。
 管理員權限：通常取決於目標程序。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1108" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1193" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1273" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1354" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1405" />
-            <source>(No description for this method.)</source>
-            <translation>（此方法無說明。）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="938" />
-            <source>Embedded Agent Mode</source>
-            <translation>嵌入式代理模式</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="940" />
-            <source>On</source>
-            <translation>開啟</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="941" />
-            <source>Off</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1198" />
-            <source>Description: GDI capture of the window client area.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1108"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1193"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1273"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1354"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1405"/>
+        <source>(No description for this method.)</source>
+        <translation>（此方法無說明。）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="938"/>
+        <source>Embedded Agent Mode</source>
+        <translation>嵌入式代理模式</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="940"/>
+        <source>On</source>
+        <translation>開啟</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="941"/>
+        <source>Off</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1198"/>
+        <source>Description: GDI capture of the window client area.
 Speed: Fast.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.
 Background: Often fails while minimized.</source>
-            <translation>說明：GDI 捕捉視窗客戶區。
+        <translation>說明：GDI 捕捉視窗客戶區。
 速度：快。
 滑鼠捕捉：否。
 相容性：中等。
 管理員權限：通常不需要。
 背景：最小化時常失敗。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1207" />
-            <source>Description: Windows.Graphics.Capture (Windows 10 1903+).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1207"/>
+        <source>Description: Windows.Graphics.Capture (Windows 10 1903+).
 Speed: Very fast.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.
 Background: Better for pseudo-minimized / quasi-background capture.</source>
-            <translation>說明：Windows.Graphics.Capture（Windows 10 1903+）。
+        <translation>說明：Windows.Graphics.Capture（Windows 10 1903+）。
 速度：非常快。
 滑鼠捕捉：否。
 相容性：中等。
 管理員權限：通常不需要。
 背景：更適合偽最小化/準背景捕捉。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1216" />
-            <source>Description: DXGI desktop duplication (full screen) then crop.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1216"/>
+        <source>Description: DXGI desktop duplication (full screen) then crop.
 Speed: Very fast.
 Mouse capture: No.
 Compatibility: Lower (drivers / multi-GPU sensitive).
 Admin rights: Usually not required.
 Background: Full-screen duplication; not window-exclusive.</source>
-            <translation>說明：DXGI 桌面複製（全螢幕）後裁剪。
+        <translation>說明：DXGI 桌面複製（全螢幕）後裁剪。
 速度：非常快。
 滑鼠捕捉：否。
 相容性：較低（驅動程式/多 GPU 敏感）。
 管理員權限：通常不需要。
 背景：全螢幕複製；非視窗專屬。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1225" />
-            <source>Description: Desktop duplication cropped to the window region.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1225"/>
+        <source>Description: Desktop duplication cropped to the window region.
 Speed: Very fast.
 Mouse capture: No.
 Compatibility: Lower.
 Admin rights: Usually not required.</source>
-            <translation>說明：桌面複製裁剪到視窗區域。
+        <translation>說明：桌面複製裁剪到視窗區域。
 速度：非常快。
 滑鼠捕捉：否。
 相容性：較低。
 管理員權限：通常不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1233" />
-            <source>Description: Capture via PrintWindow and related paths.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1233"/>
+        <source>Description: Capture via PrintWindow and related paths.
 Speed: Medium.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.
 Background: Friendlier to pseudo-minimized scenarios.</source>
-            <translation>說明：透過 PrintWindow 及相關路徑捕捉。
+        <translation>說明：透過 PrintWindow 及相關路徑捕捉。
 速度：中等。
 滑鼠捕捉：否。
 相容性：中等。
 管理員權限：通常不需要。
 背景：對偽最小化場景更友好。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1242" />
-            <source>Description: Screen DC and other compatible paths.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1242"/>
+        <source>Description: Screen DC and other compatible paths.
 Speed: Fast.
 Mouse capture: No.
 Compatibility: High.
 Admin rights: Usually not required.
 Background: Mostly foreground-oriented.</source>
-            <translation>說明：螢幕 DC 及其他相容路徑。
+        <translation>說明：螢幕 DC 及其他相容路徑。
 速度：快。
 滑鼠捕捉：否。
 相容性：高。
 管理員權限：通常不需要。
 背景：主要針對前景。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1251" />
-            <source>Description: Foreground preset (DXGI_DesktopDup_Window | ScreenDC).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1251"/>
+        <source>Description: Foreground preset (DXGI_DesktopDup_Window | ScreenDC).
 Speed: Fast.
 Mouse capture: No.
 Compatibility: Medium to low.
 Admin rights: Usually not required.</source>
-            <translation>說明：前景預設（DXGI_DesktopDup_Window | ScreenDC）。
+        <translation>說明：前景預設（DXGI_DesktopDup_Window | ScreenDC）。
 速度：快。
 滑鼠捕捉：否。
 相容性：中至低。
 管理員權限：通常不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1259" />
-            <source>Description: Background preset (FramePool | PrintWindow).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1259"/>
+        <source>Description: Background preset (FramePool | PrintWindow).
 Speed: Fast.
 Mouse capture: No.
 Compatibility: Medium.
 Admin rights: Usually not required.</source>
-            <translation>說明：背景預設（FramePool | PrintWindow）。
+        <translation>說明：背景預設（FramePool | PrintWindow）。
 速度：快。
 滑鼠捕捉：否。
 相容性：中等。
 管理員權限：通常不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1267" />
-            <source>Description: Bitwise OR of all Win32 capture flags.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1267"/>
+        <source>Description: Bitwise OR of all Win32 capture flags.
 Speed: Framework picks the fastest available method.
 Mouse capture: No.
 Compatibility: Varies by combination.
 Admin rights: Usually not required.</source>
-            <translation>說明：所有 Win32 捕捉標誌的位元 OR。
+        <translation>說明：所有 Win32 捕捉標誌的位元 OR。
 速度：框架選擇最快的可用方法。
 滑鼠捕捉：否。
 相容性：因組合而異。
 管理員權限：通常不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1278" />
-            <source>Description: Encodes to a file on the device, then adb pull.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1278"/>
+        <source>Description: Encodes to a file on the device, then adb pull.
 Speed: Slow.
 Mouse capture: N/A (device-side).
 Compatibility: High.
 Admin rights: Not required on PC; USB debugging authorization on the device.
 Encoding: Lossless.</source>
-            <translation>說明：編碼為裝置上的檔案，然後 adb pull。
+        <translation>說明：編碼為裝置上的檔案，然後 adb pull。
 速度：慢。
 滑鼠捕捉：不適用（裝置端）。
 相容性：高。
 管理員權限：PC 上不需要；裝置上需要 USB 偵錯授權。
 編碼：無損。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1287" />
-            <source>Description: Encoded stream pulled over the adb pipe.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1287"/>
+        <source>Description: Encoded stream pulled over the adb pipe.
 Speed: Slow.
 Mouse capture: N/A (device-side).
 Compatibility: High.
 Admin rights: Not required.
 Encoding: Lossless.</source>
-            <translation>說明：透過 adb 管道拉取編碼串流。
+        <translation>說明：透過 adb 管道拉取編碼串流。
 速度：慢。
 滑鼠捕捉：不適用（裝置端）。
 相容性：高。
 管理員權限：不需要。
 編碼：無損。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1296" />
-            <source>Description: Raw frames with gzip compression.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1296"/>
+        <source>Description: Raw frames with gzip compression.
 Speed: Medium.
 Mouse capture: N/A (device-side).
 Compatibility: High.
 Admin rights: Not required.
 Encoding: Lossless.</source>
-            <translation>說明：原始幀帶 gzip 壓縮。
+        <translation>說明：原始幀帶 gzip 壓縮。
 速度：中等。
 滑鼠捕捉：不適用（裝置端）。
 相容性：高。
 管理員權限：不需要。
 編碼：無損。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1305" />
-            <source>Description: Raw frames over netcat.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1305"/>
+        <source>Description: Raw frames over netcat.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low (environment-dependent).
 Admin rights: Not required.</source>
-            <translation>說明：透過 netcat 傳輸原始幀。
+        <translation>說明：透過 netcat 傳輸原始幀。
 速度：快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：低（依賴環境）。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1313" />
-            <source>Description: Minicap direct connection.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1313"/>
+        <source>Description: Minicap direct connection.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low.
 Admin rights: Not required.
 Encoding: Lossy JPEG; may hurt template matching — not recommended.</source>
-            <translation>說明：Minicap 直接連接。
+        <translation>說明：Minicap 直接連接。
 速度：快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：低。
 管理員權限：不需要。
 編碼：有損 JPEG；可能影響模板匹配 — 不建議使用。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1322" />
-            <source>Description: Minicap streaming.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1322"/>
+        <source>Description: Minicap streaming.
 Speed: Very fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low.
 Admin rights: Not required.
 Encoding: Lossy JPEG — not recommended.</source>
-            <translation>說明：Minicap 串流。
+        <translation>說明：Minicap 串流。
 速度：非常快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：低。
 管理員權限：不需要。
 編碼：有損 JPEG — 不建議使用。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1331" />
-            <source>Description: Emulator-specific fast path (e.g. MuMu 12, LDPlayer 9).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1331"/>
+        <source>Description: Emulator-specific fast path (e.g. MuMu 12, LDPlayer 9).
 Speed: Very fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low (specific emulators).
 Admin rights: Not required.
 Encoding: Lossless.</source>
-            <translation>說明：模擬器專用快速路徑（例如 MuMu 12、LDPlayer 9）。
+        <translation>說明：模擬器專用快速路徑（例如 MuMu 12、LDPlayer 9）。
 速度：非常快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：低（特定模擬器）。
 管理員權限：不需要。
 編碼：無損。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1340" />
-            <source>Description: All ADB capture flags enabled; framework benchmarks and picks one.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1340"/>
+        <source>Description: All ADB capture flags enabled; framework benchmarks and picks one.
 Speed: Fastest available on the device.
 Mouse capture: N/A (device-side).
 Compatibility: Device-dependent.
 Admin rights: Not required.</source>
-            <translation>說明：啟用所有 ADB 捕捉標誌；框架基準測試並選擇一個。
+        <translation>說明：啟用所有 ADB 捕捉標誌；框架基準測試並選擇一個。
 速度：裝置上最快可用。
 滑鼠捕捉：不適用（裝置端）。
 相容性：依賴裝置。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1348" />
-            <source>Description: Framework default flag set (typically excludes netcat and lossy Minicap).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1348"/>
+        <source>Description: Framework default flag set (typically excludes netcat and lossy Minicap).
 Speed: Best within the default set.
 Mouse capture: N/A (device-side).
 Compatibility: Medium to high.
 Admin rights: Not required.</source>
-            <translation>說明：框架預設標誌集（通常排除 netcat 和有損 Minicap）。
+        <translation>說明：框架預設標誌集（通常排除 netcat 和有損 Minicap）。
 速度：預設集中最佳。
 滑鼠捕捉：不適用（裝置端）。
 相容性：中至高。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1359" />
-            <source>Description: Standard adb shell input commands.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1359"/>
+        <source>Description: Standard adb shell input commands.
 Speed: Slow.
 Mouse capture: N/A (injected on the device).
 Compatibility: High.
 Admin rights: Not required.</source>
-            <translation>說明：標準 adb shell input 命令。
+        <translation>說明：標準 adb shell input 命令。
 速度：慢。
 滑鼠捕捉：不適用（在裝置上注入）。
 相容性：高。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1367" />
-            <source>Description: Minitouch with adb key fallback.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1367"/>
+        <source>Description: Minitouch with adb key fallback.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Medium.
 Admin rights: Not required.</source>
-            <translation>說明：Minitouch 搭配 adb key 後備。
+        <translation>說明：Minitouch 搭配 adb key 後備。
 速度：快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：中等。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1375" />
-            <source>Description: Maatouch protocol for touch injection.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1375"/>
+        <source>Description: Maatouch protocol for touch injection.
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Medium.
 Admin rights: Not required.</source>
-            <translation>說明：Maatouch 協議用於觸控注入。
+        <translation>說明：Maatouch 協議用於觸控注入。
 速度：快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：中等。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1383" />
-            <source>Description: Emulator extras (e.g. MuMu 12).
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1383"/>
+        <source>Description: Emulator extras (e.g. MuMu 12).
 Speed: Fast.
 Mouse capture: N/A (device-side).
 Compatibility: Low (specific emulators).
 Admin rights: Not required.</source>
-            <translation>說明：模擬器擴展（例如 MuMu 12）。
+        <translation>說明：模擬器擴展（例如 MuMu 12）。
 速度：快。
 滑鼠捕捉：不適用（裝置端）。
 相容性：低（特定模擬器）。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1391" />
-            <source>Description: All ADB input flags; order EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1391"/>
+        <source>Description: All ADB input flags; order EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell.
 Speed: First available wins.
 Mouse capture: N/A (device-side).
 Compatibility: Device-dependent.
 Admin rights: Not required.</source>
-            <translation>說明：所有 ADB 輸入標誌；順序為 EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell。
+        <translation>說明：所有 ADB 輸入標誌；順序為 EmulatorExtras &gt; Maatouch &gt; MinitouchAndAdbKey &gt; AdbShell。
 速度：第一個可用者勝出。
 滑鼠捕捉：不適用（裝置端）。
 相容性：依賴裝置。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1399" />
-            <source>Description: Default set with EmulatorExtras disabled; remaining methods by priority.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1399"/>
+        <source>Description: Default set with EmulatorExtras disabled; remaining methods by priority.
 Speed: Device-dependent.
 Mouse capture: N/A (device-side).
 Compatibility: Medium to high.
 Admin rights: Not required.</source>
-            <translation>說明：預設集（禁用 EmulatorExtras）；其餘方法按優先順序。
+        <translation>說明：預設集（禁用 EmulatorExtras）；其餘方法按優先順序。
 速度：依賴裝置。
 滑鼠捕捉：不適用（裝置端）。
 相容性：中至高。
 管理員權限：不需要。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1437" />
-            <source>ADB Path</source>
-            <translation>ADB 路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1444" />
-            <source>ADB Address</source>
-            <translation>ADB 位址</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1450" />
-            <source>Emulator Path</source>
-            <translation>模擬器路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1457" />
-            <source>Emulator Params</source>
-            <translation>模擬器參數</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1463" />
-            <source>Wait for Emulator StartUp Time</source>
-            <translation>等待模擬器啟動時間</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1475" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1550" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1644" />
-            <source>Screencap Method</source>
-            <translation>截圖方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1484" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1650" />
-            <source>Input Method</source>
-            <translation>輸入方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1493" />
-            <source>Special Config</source>
-            <translation>特殊設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1508" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1567" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1624" />
-            <source>Program Path</source>
-            <translation>程式路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1515" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1574" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1630" />
-            <source>Program Params</source>
-            <translation>程式參數</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1521" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1580" />
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1635" />
-            <source>Wait for Launch Time</source>
-            <translation>等待啟動時間</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1533" />
-            <source>Mouse Input Method</source>
-            <translation>滑鼠輸入方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1541" />
-            <source>Keyboard Input Method</source>
-            <translation>鍵盤輸入方法</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1591" />
-            <source>Gamepad Type</source>
-            <translation>遊戲手把類型</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1601" />
-            <source>Address</source>
-            <translation>位址</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1610" />
-            <source>Wayland Socket Path</source>
-            <translation>Wayland 通訊端路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1619" />
-            <source>Window ID</source>
-            <translation>視窗 ID</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2135" />
-            <source>Unknown Device</source>
-            <translation>未知裝置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2204" />
-            <source>No ADB devices were found. Please check emulator or device connection.</source>
-            <translation>未找到 ADB 裝置。請檢查模擬器或裝置連線。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2208" />
-            <source>No desktop windows were found that match the filter.</source>
-            <translation>未找到符合篩選條件的桌面視窗。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2211" />
-            <source>No devices were found for current controller type.</source>
-            <translation>未找到當前控制器類型的裝置。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DashboardInterface</name>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="669" />
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="673" />
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="678" />
-            <source>A More Modern Console Interface</source>
-            <translation>更現代的控制台介面</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="562" />
-            <source>Update Log</source>
-            <translation>更新日誌</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="514" />
-            <source>FrameWork Version</source>
-            <translation>框架版本</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="570" />
-            <source>No update log found locally.
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1437"/>
+        <source>ADB Path</source>
+        <translation>ADB 路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1444"/>
+        <source>ADB Address</source>
+        <translation>ADB 位址</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1450"/>
+        <source>Emulator Path</source>
+        <translation>模擬器路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1457"/>
+        <source>Emulator Params</source>
+        <translation>模擬器參數</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1463"/>
+        <source>Wait for Emulator StartUp Time</source>
+        <translation>等待模擬器啟動時間</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1475"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1550"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1644"/>
+        <source>Screencap Method</source>
+        <translation>截圖方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1484"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1650"/>
+        <source>Input Method</source>
+        <translation>輸入方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1493"/>
+        <source>Special Config</source>
+        <translation>特殊設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1508"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1567"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1624"/>
+        <source>Program Path</source>
+        <translation>程式路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1515"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1574"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1630"/>
+        <source>Program Params</source>
+        <translation>程式參數</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1521"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1580"/>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1635"/>
+        <source>Wait for Launch Time</source>
+        <translation>等待啟動時間</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1533"/>
+        <source>Mouse Input Method</source>
+        <translation>滑鼠輸入方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1541"/>
+        <source>Keyboard Input Method</source>
+        <translation>鍵盤輸入方法</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1591"/>
+        <source>Gamepad Type</source>
+        <translation>遊戲手把類型</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1601"/>
+        <source>Address</source>
+        <translation>位址</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1610"/>
+        <source>Wayland Socket Path</source>
+        <translation>Wayland 通訊端路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="1619"/>
+        <source>Window ID</source>
+        <translation>視窗 ID</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2135"/>
+        <source>Unknown Device</source>
+        <translation>未知裝置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2204"/>
+        <source>No ADB devices were found. Please check emulator or device connection.</source>
+        <translation>未找到 ADB 裝置。請檢查模擬器或裝置連線。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2208"/>
+        <source>No desktop windows were found that match the filter.</source>
+        <translation>未找到符合篩選條件的桌面視窗。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/controller_setting_mixin.py" line="2211"/>
+        <source>No devices were found for current controller type.</source>
+        <translation>未找到當前控制器類型的裝置。</translation>
+    </message>
+</context>
+<context>
+    <name>DashboardInterface</name>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="669"/>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="673"/>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="678"/>
+        <source>A More Modern Console Interface</source>
+        <translation>更現代的控制台介面</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="562"/>
+        <source>Update Log</source>
+        <translation>更新日誌</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="514"/>
+        <source>FrameWork Version</source>
+        <translation>框架版本</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="570"/>
+        <source>No update log found locally.
 
 Please check for updates first, or visit the GitHub releases page.</source>
-            <translation>本機未找到更新日誌。
+        <translation>本機未找到更新日誌。
 
 請先檢查更新，或造訪 GitHub 發佈頁面。</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="593" />
-            <source>View full changelog in Settings &gt; Open update log.</source>
-            <translation>可在 設定 &gt; 開啟更新日誌 查看完整變更記錄。</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="609" />
-            <source>Task</source>
-            <translation>任務</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="610" />
-            <source>Configure and execute automation tasks</source>
-            <translation>設定並執行自動化任務</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="612" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="617" />
-            <source>Monitor</source>
-            <translation>監控</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="618" />
-            <source>View real-time frames and runtime status</source>
-            <translation>查看即時畫面與執行狀態</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="625" />
-            <source>Schedule</source>
-            <translation>排程</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="626" />
-            <source>Configure scheduled runs and force start</source>
-            <translation>設定定時執行與強制啟動</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="633" />
-            <source>Setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="634" />
-            <source>Theme, update, and resource management</source>
-            <translation>主題、更新與資源管理</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="662" />
-            <source>ChainFlow Assistant</source>
-            <translation>ChainFlow 助手</translation>
-        </message>
-        <message>
-            <location filename="../view/dashboard_interface/dashboard_interface.py" line="994" />
-            <source>No summary available</source>
-            <translation>暫無摘要</translation>
-        </message>
-    </context>
-    <context>
-        <name>DescriptionWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/description_widget.py" line="32" />
-            <source>Function Description</source>
-            <translation>功能描述</translation>
-        </message>
-    </context>
-    <context>
-        <name>DingTalkNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="133" />
-            <source>DingTalk Webhook URL:</source>
-            <translation>釘釘 Webhook URL：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="134" />
-            <source>DingTalk Secret:</source>
-            <translation>釘釘密鑰：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="135" />
-            <source>DingTalk Status:</source>
-            <translation>釘釘狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>DoubleButtonSettingCard</name>
-        <message>
-            <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="55" />
-            <source>stable</source>
-            <translation>穩定版</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="56" />
-            <source>beta</source>
-            <translation>測試版</translation>
-        </message>
-    </context>
-    <context>
-        <name>GotifyNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="482" />
-            <source>Gotify Server URL:</source>
-            <translation>Gotify 伺服器網址：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="483" />
-            <source>Gotify App Token:</source>
-            <translation>Gotify 應用程式令牌：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="484" />
-            <source>Notification Priority (0-10):</source>
-            <translation>通知優先級 (0-10)：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="485" />
-            <source>Gotify Status:</source>
-            <translation>Gotify 狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImagePreviewDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/image_preview_dialog.py" line="29" />
-            <source>Image Preview</source>
-            <translation>圖片預覽</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/image_preview_dialog.py" line="91" />
-            <source>Close</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/image_preview_dialog.py" line="121" />
-            <source>Failed to load image:
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="593"/>
+        <source>View full changelog in Settings &gt; Open update log.</source>
+        <translation>可在 設定 &gt; 開啟更新日誌 查看完整變更記錄。</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="609"/>
+        <source>Task</source>
+        <translation>任務</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="610"/>
+        <source>Configure and execute automation tasks</source>
+        <translation>設定並執行自動化任務</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="612"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="617"/>
+        <source>Monitor</source>
+        <translation>監控</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="618"/>
+        <source>View real-time frames and runtime status</source>
+        <translation>查看即時畫面與執行狀態</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="625"/>
+        <source>Schedule</source>
+        <translation>排程</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="626"/>
+        <source>Configure scheduled runs and force start</source>
+        <translation>設定定時執行與強制啟動</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="633"/>
+        <source>Setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="634"/>
+        <source>Theme, update, and resource management</source>
+        <translation>主題、更新與資源管理</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="662"/>
+        <source>ChainFlow Assistant</source>
+        <translation>ChainFlow 助手</translation>
+    </message>
+    <message>
+        <location filename="../view/dashboard_interface/dashboard_interface.py" line="994"/>
+        <source>No summary available</source>
+        <translation>暫無摘要</translation>
+    </message>
+</context>
+<context>
+    <name>DescriptionWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/description_widget.py" line="32"/>
+        <source>Function Description</source>
+        <translation>功能描述</translation>
+    </message>
+</context>
+<context>
+    <name>DingTalkNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="133"/>
+        <source>DingTalk Webhook URL:</source>
+        <translation>釘釘 Webhook URL：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="134"/>
+        <source>DingTalk Secret:</source>
+        <translation>釘釘密鑰：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="135"/>
+        <source>DingTalk Status:</source>
+        <translation>釘釘狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>DoubleButtonSettingCard</name>
+    <message>
+        <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="55"/>
+        <source>stable</source>
+        <translation>穩定版</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/double_button_setting_card.py" line="56"/>
+        <source>beta</source>
+        <translation>測試版</translation>
+    </message>
+</context>
+<context>
+    <name>GotifyNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="482"/>
+        <source>Gotify Server URL:</source>
+        <translation>Gotify 伺服器網址：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="483"/>
+        <source>Gotify App Token:</source>
+        <translation>Gotify 應用程式令牌：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="484"/>
+        <source>Notification Priority (0-10):</source>
+        <translation>通知優先級 (0-10)：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="485"/>
+        <source>Gotify Status:</source>
+        <translation>Gotify 狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>ImagePreviewDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/image_preview_dialog.py" line="29"/>
+        <source>Image Preview</source>
+        <translation>圖片預覽</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/image_preview_dialog.py" line="91"/>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/image_preview_dialog.py" line="121"/>
+        <source>Failed to load image:
 {path}</source>
-            <translation>無法載入圖片：
+        <translation>無法載入圖片：
 {path}</translation>
-        </message>
-    </context>
-    <context>
-        <name>LarkNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="185" />
-            <source>Lark Webhook URL:</source>
-            <translation>Lark Webhook 網址：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="186" />
-            <source>Lark App Key:</source>
-            <translation>Lark 應用程式金鑰：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="187" />
-            <source>Lark Status:</source>
-            <translation>Lark 狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogItemWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/log_item_widget.py" line="147" />
-            <source>Click to view full image</source>
-            <translation>點擊查看完整圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/log_item_widget.py" line="163" />
-            <source>No image</source>
-            <translation>無圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/log_item_widget.py" line="206" />
-            <source>Log Image</source>
-            <translation>記錄圖片</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogZipDialog</name>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="103" />
-            <source>Select the content to include in the log package.</source>
-            <translation>選擇要包含在記錄封裝中的內容。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="107" />
-            <source>Package logs</source>
-            <translation>封裝記錄</translation>
-        </message>
-        <message>
-            <source>Choose the log files and image folders to include. Image items can be filtered by time range.</source>
-            <translation type="vanished">選擇要包含的記錄檔案和圖片資料夾。圖片項目可按時間範圍篩選。</translation>
-        </message>
-        <message>
-            <source>Select one or more run records to include in the log package.</source>
-            <translation type="vanished">選擇一個或多個執行記錄以包含在日誌套件中。</translation>
-        </message>
-        <message>
-            <source>Log contents will be grouped by run records (task flow start/stop). You can select multiple run records.</source>
-            <translation type="vanished">日誌內容將按執行記錄（任務流程開始/停止）分組。您可以選擇多個執行記錄。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="160" />
-            <source>Start packaging</source>
-            <translation>開始封裝</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="161" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="412" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="428" />
-            <source>Close</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <source>Run records</source>
-            <translation type="vanished">執行記錄</translation>
-        </message>
-        <message>
-            <source>No run records found.</source>
-            <translation type="vanished">找不到任何執行記錄。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="173" />
-            <source>Logs</source>
-            <translation>記錄</translation>
-        </message>
-        <message>
-            <source>maafw.log</source>
-            <translation type="vanished">maafw.log</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="189" />
-            <source>other .log/.txt</source>
-            <translation>其他 .log/.txt</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="222" />
-            <source>on_error (debug/on_error)</source>
-            <translation>on_error (debug/on_error)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="225" />
-            <source>vision (debug/vision)</source>
-            <translation>vision (debug/vision)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="228" />
-            <source>screenshot (debug/screenshot)</source>
-            <translation>screenshot (debug/screenshot)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="231" />
-            <source>other .jpg/.png</source>
-            <translation>其他 .jpg/.png</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="255" />
-            <source>Other</source>
-            <translation>其他</translation>
-        </message>
-        <message>
-            <source>Run record </source>
-            <translation type="vanished">執行記錄 </translation>
-        </message>
-        <message>
-            <source>Select at least one run record and one content category.</source>
-            <translation type="vanished">請至少選擇一個執行記錄和一個內容類別。</translation>
-        </message>
-        <message>
-            <source>maa.log (including .bak)</source>
-            <translation type="vanished">maa.log (包含 .bak)</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="186" />
-            <source>gui.log</source>
-            <translation>gui.log</translation>
-        </message>
-        <message>
-            <source>custom.log</source>
-            <translation type="vanished">custom.log</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="258" />
-            <source>other files</source>
-            <translation>其他檔案</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="212" />
-            <source>Images</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Choose log files and image folders to include. Image items can be filtered by time range.</source>
-            <translation type="vanished">選擇要包含的日誌檔案和圖片資料夾。圖片項目可按時間範圍篩選。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="110" />
-            <source>Choose log files and image folders to include. Both logs and images can be filtered by time range.</source>
-            <translation>選擇要包含的日誌檔案和圖片資料夾。日誌與圖片均可按時間範圍篩選。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="176" />
-            <source>Default is all log categories with time range set to all.</source>
-            <translation>預設包含所有日誌類別，時間範圍為全部。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="183" />
-            <source>maafw.log (including .bak)</source>
-            <translation>maafw.log（包含 .bak）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="215" />
-            <source>Default is all image categories with time range set to all.</source>
-            <translation>預設為所有圖片類別，時間範圍設為全部。</translation>
-        </message>
-        <message>
-            <source>on_error folder</source>
-            <translation type="vanished">on_error 資料夾</translation>
-        </message>
-        <message>
-            <source>vision folder</source>
-            <translation type="vanished">vision 資料夾</translation>
-        </message>
-        <message>
-            <source>other images</source>
-            <translation type="vanished">其他圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="276" />
-            <source>all</source>
-            <translation>全部</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="277" />
-            <source>within 1 hour</source>
-            <translation>1小時內</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="278" />
-            <source>within 6 hours</source>
-            <translation>6小時內</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="279" />
-            <source>within 12 hours</source>
-            <translation>12小時內</translation>
-        </message>
-        <message>
-            <source>today</source>
-            <translation type="vanished">今日</translation>
-        </message>
-        <message>
-            <source>within 2 days</source>
-            <translation type="vanished">2天內</translation>
-        </message>
-        <message>
-            <source>within 3 days</source>
-            <translation type="vanished">3天內</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="280" />
-            <source>within 24 hours</source>
-            <translation>24小時內</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="281" />
-            <source>within 48 hours</source>
-            <translation>48小時內</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="282" />
-            <source>within 72 hours</source>
-            <translation>72小時內</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="285" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="292" />
-            <location filename="../view/main_window/log_zip_dialog.py" line="331" />
-            <source>Selected total size:</source>
-            <translation>已選取總大小：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="285" />
-            <source> calculating...</source>
-            <translation> 計算中...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="412" />
-            <source>Cancel packaging</source>
-            <translation>取消封裝</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="434" />
-            <source>Cancelling log packaging, please wait...</source>
-            <translation>正在取消日誌封裝，請稍候...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/log_zip_dialog.py" line="441" />
-            <source>Select at least one log or image category.</source>
-            <translation>請至少選擇一個日誌或圖片類別。</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogoutputWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="110" />
-            <source>Monitor</source>
-            <translation>監控</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="305" />
-            <source>Log Output</source>
-            <translation>日誌輸出</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="311" />
-            <source>generate log zip</source>
-            <translation>產生日誌壓縮檔</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="515" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="886" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="891" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="896" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="898" />
-            <location filename="../view/task_interface/components/logoutput_widget.py" line="899" />
-            <source>System</source>
-            <translation>系統</translation>
-        </message>
-    </context>
-    <context>
-        <name>MainWindow</name>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="356" />
-            <source>Home</source>
-            <translation>首頁</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="364" />
-            <source>Task</source>
-            <translation>任務</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="369" />
-            <source>Monitor</source>
-            <translation>監控</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="375" />
-            <source>Schedule</source>
-            <translation>排程</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="383" />
-            <source>test_interface</source>
-            <translation>test_interface</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="412" />
-            <location filename="../view/main_window/main_window.py" line="684" />
-            <location filename="../view/main_window/main_window.py" line="696" />
-            <source>Bundle</source>
-            <translation>套件</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="426" />
-            <source>Setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="541" />
-            <source>Show</source>
-            <translation>顯示</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="542" />
-            <source>Hide</source>
-            <translation>隱藏</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="543" />
-            <source>Quit</source>
-            <translation>結束</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="832" />
-            <source>Task flow is already running</source>
-            <translation>任務流程已在執行中</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="844" />
-            <source>Failed to start task flow</source>
-            <translation>啟動任務流程失敗</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1168" />
-            <source>Config load failed, automatically reset to default. Backup of corrupted config file completed. Error details:</source>
-            <translation>設定檔載入失敗，已自動重設為預設值。損壞設定檔的備份已完成。錯誤詳情：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1172" />
-            <source>Config load failed, automatically reset to default. Backup of corrupted config file completed.</source>
-            <translation>設定檔載入失敗，已自動重設為預設值。損壞設定檔的備份已完成。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1179" />
-            <source>Config load failed, automatically reset to default. Failed to backup corrupted config file. Error details:</source>
-            <translation>設定載入失敗，已自動重設為預設值。無法備份損壞的設定檔。錯誤詳情：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1183" />
-            <source>Config load failed, automatically reset to default. Failed to backup corrupted config file.</source>
-            <translation>設定載入失敗，已自動重設為預設值。無法備份損壞的設定檔。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1189" />
-            <source>Config load failed and error occurred while resetting config:</source>
-            <translation>設定載入失敗，且在重設設定時發生錯誤：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1193" />
-            <source>Config load failed and error occurred while resetting config.</source>
-            <translation>設定載入失敗，且在重設設定時發生錯誤。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1271" />
-            <source>(empty)</source>
-            <translation>（空）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1284" />
-            <source>(none)</source>
-            <translation>（無）</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1287" />
-            <source>Controller information is missing. Verify that {controller} is the expected controller.
+    </message>
+</context>
+<context>
+    <name>LarkNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="185"/>
+        <source>Lark Webhook URL:</source>
+        <translation>Lark Webhook 網址：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="186"/>
+        <source>Lark App Key:</source>
+        <translation>Lark 應用程式金鑰：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="187"/>
+        <source>Lark Status:</source>
+        <translation>Lark 狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>LogItemWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/log_item_widget.py" line="147"/>
+        <source>Click to view full image</source>
+        <translation>點擊查看完整圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/log_item_widget.py" line="163"/>
+        <source>No image</source>
+        <translation>無圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/log_item_widget.py" line="206"/>
+        <source>Log Image</source>
+        <translation>記錄圖片</translation>
+    </message>
+</context>
+<context>
+    <name>LogZipDialog</name>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="103"/>
+        <source>Select the content to include in the log package.</source>
+        <translation>選擇要包含在記錄封裝中的內容。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="107"/>
+        <source>Package logs</source>
+        <translation>封裝記錄</translation>
+    </message>
+    <message>
+        <source>Choose the log files and image folders to include. Image items can be filtered by time range.</source>
+        <translation type="vanished">選擇要包含的記錄檔案和圖片資料夾。圖片項目可按時間範圍篩選。</translation>
+    </message>
+    <message>
+        <source>Select one or more run records to include in the log package.</source>
+        <translation type="vanished">選擇一個或多個執行記錄以包含在日誌套件中。</translation>
+    </message>
+    <message>
+        <source>Log contents will be grouped by run records (task flow start/stop). You can select multiple run records.</source>
+        <translation type="vanished">日誌內容將按執行記錄（任務流程開始/停止）分組。您可以選擇多個執行記錄。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="160"/>
+        <source>Start packaging</source>
+        <translation>開始封裝</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="161"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="412"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="428"/>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>Run records</source>
+        <translation type="vanished">執行記錄</translation>
+    </message>
+    <message>
+        <source>No run records found.</source>
+        <translation type="vanished">找不到任何執行記錄。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="173"/>
+        <source>Logs</source>
+        <translation>記錄</translation>
+    </message>
+    <message>
+        <source>maafw.log</source>
+        <translation type="vanished">maafw.log</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="189"/>
+        <source>other .log/.txt</source>
+        <translation>其他 .log/.txt</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="222"/>
+        <source>on_error (debug/on_error)</source>
+        <translation>on_error (debug/on_error)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="225"/>
+        <source>vision (debug/vision)</source>
+        <translation>vision (debug/vision)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="228"/>
+        <source>screenshot (debug/screenshot)</source>
+        <translation>screenshot (debug/screenshot)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="231"/>
+        <source>other .jpg/.png</source>
+        <translation>其他 .jpg/.png</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="255"/>
+        <source>Other</source>
+        <translation>其他</translation>
+    </message>
+    <message>
+        <source>Run record </source>
+        <translation type="vanished">執行記錄 </translation>
+    </message>
+    <message>
+        <source>Select at least one run record and one content category.</source>
+        <translation type="vanished">請至少選擇一個執行記錄和一個內容類別。</translation>
+    </message>
+    <message>
+        <source>maa.log (including .bak)</source>
+        <translation type="vanished">maa.log (包含 .bak)</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="186"/>
+        <source>gui.log</source>
+        <translation>gui.log</translation>
+    </message>
+    <message>
+        <source>custom.log</source>
+        <translation type="vanished">custom.log</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="258"/>
+        <source>other files</source>
+        <translation>其他檔案</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="212"/>
+        <source>Images</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Choose log files and image folders to include. Image items can be filtered by time range.</source>
+        <translation type="vanished">選擇要包含的日誌檔案和圖片資料夾。圖片項目可按時間範圍篩選。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="110"/>
+        <source>Choose log files and image folders to include. Both logs and images can be filtered by time range.</source>
+        <translation>選擇要包含的日誌檔案和圖片資料夾。日誌與圖片均可按時間範圍篩選。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="176"/>
+        <source>Default is all log categories with time range set to all.</source>
+        <translation>預設包含所有日誌類別，時間範圍為全部。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="183"/>
+        <source>maafw.log (including .bak)</source>
+        <translation>maafw.log（包含 .bak）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="215"/>
+        <source>Default is all image categories with time range set to all.</source>
+        <translation>預設為所有圖片類別，時間範圍設為全部。</translation>
+    </message>
+    <message>
+        <source>on_error folder</source>
+        <translation type="vanished">on_error 資料夾</translation>
+    </message>
+    <message>
+        <source>vision folder</source>
+        <translation type="vanished">vision 資料夾</translation>
+    </message>
+    <message>
+        <source>other images</source>
+        <translation type="vanished">其他圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="276"/>
+        <source>all</source>
+        <translation>全部</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="277"/>
+        <source>within 1 hour</source>
+        <translation>1小時內</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="278"/>
+        <source>within 6 hours</source>
+        <translation>6小時內</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="279"/>
+        <source>within 12 hours</source>
+        <translation>12小時內</translation>
+    </message>
+    <message>
+        <source>today</source>
+        <translation type="vanished">今日</translation>
+    </message>
+    <message>
+        <source>within 2 days</source>
+        <translation type="vanished">2天內</translation>
+    </message>
+    <message>
+        <source>within 3 days</source>
+        <translation type="vanished">3天內</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="280"/>
+        <source>within 24 hours</source>
+        <translation>24小時內</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="281"/>
+        <source>within 48 hours</source>
+        <translation>48小時內</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="282"/>
+        <source>within 72 hours</source>
+        <translation>72小時內</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="285"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="292"/>
+        <location filename="../view/main_window/log_zip_dialog.py" line="331"/>
+        <source>Selected total size:</source>
+        <translation>已選取總大小：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="285"/>
+        <source> calculating...</source>
+        <translation> 計算中...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="412"/>
+        <source>Cancel packaging</source>
+        <translation>取消封裝</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="434"/>
+        <source>Cancelling log packaging, please wait...</source>
+        <translation>正在取消日誌封裝，請稍候...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/log_zip_dialog.py" line="441"/>
+        <source>Select at least one log or image category.</source>
+        <translation>請至少選擇一個日誌或圖片類別。</translation>
+    </message>
+</context>
+<context>
+    <name>LogoutputWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="121"/>
+        <source>Monitor</source>
+        <translation>監控</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="319"/>
+        <source>Log Output</source>
+        <translation>日誌輸出</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="325"/>
+        <source>generate log zip</source>
+        <translation>產生日誌壓縮檔</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="582"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="954"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="961"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="966"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="968"/>
+        <location filename="../view/task_interface/components/logoutput_widget.py" line="969"/>
+        <source>System</source>
+        <translation>系統</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="356"/>
+        <source>Home</source>
+        <translation>首頁</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="364"/>
+        <source>Task</source>
+        <translation>任務</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="369"/>
+        <source>Monitor</source>
+        <translation>監控</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="375"/>
+        <source>Schedule</source>
+        <translation>排程</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="383"/>
+        <source>test_interface</source>
+        <translation>test_interface</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="412"/>
+        <location filename="../view/main_window/main_window.py" line="684"/>
+        <location filename="../view/main_window/main_window.py" line="696"/>
+        <source>Bundle</source>
+        <translation>套件</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="426"/>
+        <source>Setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="541"/>
+        <source>Show</source>
+        <translation>顯示</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="542"/>
+        <source>Hide</source>
+        <translation>隱藏</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="543"/>
+        <source>Quit</source>
+        <translation>結束</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="832"/>
+        <source>Task flow is already running</source>
+        <translation>任務流程已在執行中</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="844"/>
+        <source>Failed to start task flow</source>
+        <translation>啟動任務流程失敗</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1168"/>
+        <source>Config load failed, automatically reset to default. Backup of corrupted config file completed. Error details:</source>
+        <translation>設定檔載入失敗，已自動重設為預設值。損壞設定檔的備份已完成。錯誤詳情：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1172"/>
+        <source>Config load failed, automatically reset to default. Backup of corrupted config file completed.</source>
+        <translation>設定檔載入失敗，已自動重設為預設值。損壞設定檔的備份已完成。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1179"/>
+        <source>Config load failed, automatically reset to default. Failed to backup corrupted config file. Error details:</source>
+        <translation>設定載入失敗，已自動重設為預設值。無法備份損壞的設定檔。錯誤詳情：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1183"/>
+        <source>Config load failed, automatically reset to default. Failed to backup corrupted config file.</source>
+        <translation>設定載入失敗，已自動重設為預設值。無法備份損壞的設定檔。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1189"/>
+        <source>Config load failed and error occurred while resetting config:</source>
+        <translation>設定載入失敗，且在重設設定時發生錯誤：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1193"/>
+        <source>Config load failed and error occurred while resetting config.</source>
+        <translation>設定載入失敗，且在重設設定時發生錯誤。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1271"/>
+        <source>(empty)</source>
+        <translation>（空）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1284"/>
+        <source>(none)</source>
+        <translation>（無）</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1287"/>
+        <source>Controller information is missing. Verify that {controller} is the expected controller.
 Supported controllers in the current resource: {controllers}</source>
-            <translation>控制器資訊遺失。請確認 {controller} 是預期的控制器。
+        <translation>控制器資訊遺失。請確認 {controller} 是預期的控制器。
 目前資源中支援的控制器：{controllers}</translation>
-        </message>
-        <message>
-            <source>ADB path is not set. Tap Controller here and fill in the ADB executable path (usually next to your emulator).</source>
-            <translation type="vanished">ADB 路徑未設定。點擊此處的控制器，填入 ADB 執行檔路徑（通常位於模擬器旁）。</translation>
-        </message>
-        <message>
-            <source>ADB address is empty. Start the emulator so a device appears, or tap Controller here to pick a connection address.</source>
-            <translation type="vanished">ADB 位址為空。啟動模擬器以顯示裝置，或點擊此處的控制器選擇連線位址。</translation>
-        </message>
-        <message>
-            <source>ADB port is missing in the address. Use host:port (for example 127.0.0.1:5555), or tap Controller here to change settings.</source>
-            <translation type="vanished">位址中缺少 ADB 連接埠。請使用 host:port 格式（例如 127.0.0.1:5555），或點擊此處的控制器變更設定。</translation>
-        </message>
-        <message>
-            <source>Controller ADB settings are incomplete. Tap here to open the controller and fix path / address / port.</source>
-            <translation type="vanished">控制器 ADB 設定不完整。點擊此處開啟控制器，修正路徑/位址/連接埠。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1362" />
-            <location filename="../view/main_window/main_window.py" line="1368" />
-            <source>hotkey disabled due to permission issue</source>
-            <translation>由於權限問題，熱鍵已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1387" />
-            <source>Log is being packaged, please wait...</source>
-            <translation>正在封裝日誌，請稍候...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1408" />
-            <location filename="../view/main_window/main_window.py" line="1458" />
-            <source>Preparing files...</source>
-            <translation>正在準備檔案...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1430" />
-            <location filename="../view/main_window/main_window.py" line="1434" />
-            <source>Debug directory not found, cannot package logs.</source>
-            <translation>找不到除錯目錄，無法封裝日誌。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1449" />
-            <location filename="../view/main_window/main_window.py" line="1454" />
-            <source>No matching files were found for the selected options.</source>
-            <translation>所選選項未找到匹配的檔案。</translation>
-        </message>
-        <message>
-            <source>No run records were selected.</source>
-            <translation type="vanished">未選取任何執行記錄。</translation>
-        </message>
-        <message>
-            <source>No matching files were found for the selected run records.</source>
-            <translation type="vanished">找不到與所選執行記錄相符的檔案。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1467" />
-            <location filename="../view/main_window/main_window.py" line="1482" />
-            <source>Packing:</source>
-            <translation>封裝中：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1500" />
-            <location filename="../view/main_window/main_window.py" line="1501" />
-            <source>Log packaging cancelled.</source>
-            <translation>日誌封裝已取消。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="1505" />
-            <location filename="../view/main_window/main_window.py" line="1509" />
-            <source>Log packaging failed:</source>
-            <translation>日誌封裝失敗：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2076" />
-            <source>, there are </source>
-            <translation>，有 </translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2078" />
-            <source> files not added</source>
-            <translation> 個檔案未加入</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2082" />
-            <source>Log has been packaged, but some files failed to read:</source>
-            <translation>日誌已封裝，但部分檔案讀取失敗：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2089" />
-            <source>Log has been packaged:</source>
-            <translation>日誌已封裝：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2094" />
-            <source>Packaging completed, but some files were skipped.</source>
-            <translation>封裝完成，但部分檔案已跳過。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2095" />
-            <source>Packaging completed:</source>
-            <translation>封裝完成：</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2142" />
-            <location filename="../view/main_window/main_window.py" line="2309" />
-            <location filename="../view/main_window/main_window.py" line="2738" />
-            <source>Announcement</source>
-            <translation>公告</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2145" />
-            <source>There is no announcement at the moment.</source>
-            <translation>目前沒有公告。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2252" />
-            <location filename="../view/main_window/main_window.py" line="2262" />
-            <source>Welcome</source>
-            <translation>歡迎</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2365" />
-            <source>This is the configuration area. Each configuration maps to different task sets.</source>
-            <translation>這是設定區域。每個設定對應不同的任務集。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2371" />
-            <source>This is the task area. Set the controller and resource configurations first; aside from those two, every task can be dragged to reorder before running.</source>
-            <translation>這是任務區域。請先設定控制器與資源配置；除了這兩項，每個任務在執行前都可拖曳重新排序。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2377" />
-            <source>The monitor area displays live footage once tasks are running.</source>
-            <translation>監控區域會在任務執行時顯示即時畫面。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2383" />
-            <source>When you encounter issues while running, click this button and send the generated log zip file in the report folder to the developers.</source>
-            <translation>執行時若遇到問題，請點擊此按鈕，並將 report 目錄中產生的日誌壓縮包傳送給開發者。</translation>
-        </message>
-        <message>
-            <source>Click this button to switch to special tasks; only tasks marked as special will execute.</source>
-            <translation type="vanished">點擊此按鈕切換至特殊任務；僅標記為特殊的任務會執行。</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2719" />
-            <source>Close</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2755" />
-            <source>Item </source>
-            <translation>項目 </translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2759" />
-            <source>Detail</source>
-            <translation>詳細</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2770" />
-            <location filename="../view/main_window/main_window.py" line="2773" />
-            <location filename="../view/main_window/main_window.py" line="2829" />
-            <source>Info</source>
-            <translation>資訊</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2771" />
-            <source>Warning</source>
-            <translation>警告</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2772" />
-            <source>Error</source>
-            <translation>錯誤</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2837" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2857" />
-            <source>ChainFlow Assistant</source>
-            <translation>ChainFlow 助手</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2878" />
-            <source>admin</source>
-            <translation>admin</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2911" />
-            <source>Stopping task...</source>
-            <translation>正在停止任務...</translation>
-        </message>
-        <message>
-            <location filename="../view/main_window/main_window.py" line="2919" />
-            <source>Please wait...</source>
-            <translation>請稍候...</translation>
-        </message>
-    </context>
-    <context>
-        <name>MirrorCdkLineEditCard</name>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="123" />
-            <source>About Mirror</source>
-            <translation>關於 Mirror</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="158" />
-            <source>Remaining time: </source>
-            <translation>剩餘時間：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="162" />
-            <source>Unknown</source>
-            <translation>未知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="168" />
-            <source>Expired</source>
-            <translation>已過期</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="179" />
-            <source>year</source>
-            <translation>年</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="180" />
-            <source>day</source>
-            <translation>天</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="181" />
-            <source>hour</source>
-            <translation>小時</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="182" />
-            <source>minute</source>
-            <translation>分鐘</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="183" />
-            <source>second</source>
-            <translation>秒</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/line_edit_card.py" line="189" />
-            <source>Less than a second</source>
-            <translation>少於一秒</translation>
-        </message>
-    </context>
-    <context>
-        <name>MonitorDialog</name>
-        <message>
-            <source>Monitor</source>
-            <translation type="vanished">監視器</translation>
-        </message>
-    </context>
-    <context>
-        <name>MonitorInterface</name>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="204" />
-            <source>Click to sync this frame to the device</source>
-            <translation>點擊將此畫面同步至裝置</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="222" />
-            <source>FPS: --</source>
-            <translation>FPS：--</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="273" />
-            <source>Save Screenshot</source>
-            <translation>儲存截圖</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="279" />
-            <source>Capture the current preview and store it on disk</source>
-            <translation>擷取當前預覽畫面並儲存至磁碟</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="263" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="616" />
-            <source>Start Monitoring</source>
-            <translation>開始監控</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="154" />
-            <source>Monitor</source>
-            <translation>監控器</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="156" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="369" />
-            <source>Idle</source>
-            <translation>閒置</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="164" />
-            <source>Live device preview via an independent controller connection. Click the preview to sync taps to the device.</source>
-            <translation>透過獨立控制器連接進行裝置即時預覽。點擊預覽可將點擊同步至裝置。</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="213" />
-            <source>Preview will appear when monitoring starts</source>
-            <translation>監控開始時將顯示預覽</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="244" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="386" />
-            <source>Resolution: --</source>
-            <translation>解析度：--</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="270" />
-            <location filename="../view/monitor_interface/monitor_interface.py" line="618" />
-            <source>Start monitoring task</source>
-            <translation>開始監控任務</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="283" />
-            <source>Monitoring starts automatically when a task runs</source>
-            <translation>任務執行時自動開始監控</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="363" />
-            <source>Connecting</source>
-            <translation>連線中</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="366" />
-            <source>Running</source>
-            <translation>執行中</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="375" />
-            <source>Capture rate: {} FPS</source>
-            <translation>擷取率：{} FPS</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="381" />
-            <source>Resolution: {} × {}</source>
-            <translation>解析度：{} × {}</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="701" />
-            <source>Screenshot saved to </source>
-            <translation>螢幕截圖已儲存至 </translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="813" />
-            <source>Device connection failed, cannot start monitoring</source>
-            <translation>裝置連線失敗，無法開始監控</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="612" />
-            <source>Stop Monitoring</source>
-            <translation>停止監控</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="614" />
-            <source>Stop monitoring task</source>
-            <translation>停止監控任務</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="821" />
-            <source>Monitoring started</source>
-            <translation>監控已開始</translation>
-        </message>
-        <message>
-            <location filename="../view/monitor_interface/monitor_interface.py" line="827" />
-            <source>Failed to start monitoring: </source>
-            <translation>開始監控失敗：</translation>
-        </message>
-        <message>
-            <source>Monitoring stopped</source>
-            <translation type="vanished">監控已停止</translation>
-        </message>
-        <message>
-            <source>Failed to stop monitoring: </source>
-            <translation type="vanished">停止監控失敗：</translation>
-        </message>
-    </context>
-    <context>
-        <name>MonitorWidget</name>
-        <message>
-            <source>No screenshot available to save</source>
-            <translation type="vanished">無可用螢幕截圖可儲存</translation>
-        </message>
-        <message>
-            <source>Screenshot saved to </source>
-            <translation type="vanished">螢幕截圖已儲存至 </translation>
-        </message>
-        <message>
-            <source>Failed to save screenshot: </source>
-            <translation type="vanished">儲存螢幕截圖失敗：</translation>
-        </message>
-        <message>
-            <source>Controller not ready. Please ensure the device is connected.</source>
-            <translation type="vanished">控制器未就緒。請確認裝置已連線。</translation>
-        </message>
-        <message>
-            <source>Device connection failed, cannot start monitoring</source>
-            <translation type="vanished">裝置連線失敗，無法開始監控</translation>
-        </message>
-        <message>
-            <source>Failed to start monitoring loop</source>
-            <translation type="vanished">開始監控循環失敗</translation>
-        </message>
-        <message>
-            <source>Monitoring started</source>
-            <translation type="vanished">監控已開始</translation>
-        </message>
-        <message>
-            <source>Failed to start monitoring: </source>
-            <translation type="vanished">開始監控失敗：</translation>
-        </message>
-        <message>
-            <source>Monitoring stopped</source>
-            <translation type="vanished">監控已停止</translation>
-        </message>
-        <message>
-            <source>Failed to stop monitoring: </source>
-            <translation type="vanished">停止監控失敗：</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/monitor_widget.py" line="97" />
-            <source>Click to open the monitor page</source>
-            <translation>點擊開啟監控頁面</translation>
-        </message>
-    </context>
-    <context>
-        <name>MultiResourceUpdate</name>
-        <message>
-            <location filename="../utils/update.py" line="2630" />
-            <source>Checking for updates...</source>
-            <translation>正在檢查更新...</translation>
-        </message>
-        <message>
-            <source>Already up to date</source>
-            <translation type="vanished">已是最新版本</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2665" />
-            <location filename="../utils/update.py" line="2688" />
-            <source>Download failed</source>
-            <translation>下載失敗</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2659" />
-            <source>Preparing to download update...</source>
-            <translation>準備下載更新...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2696" />
-            <source>Download complete</source>
-            <translation>下載完成</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2699" />
-            <source>Applying hotfix...</source>
-            <translation>正在套用熱修復...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2756" />
-            <source>Update applied successfully</source>
-            <translation>更新已成功套用</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="2807" />
-            <source>Failed to update</source>
-            <translation>更新失敗</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeIndexCard</name>
-        <message>
-            <location filename="../widget/notice_message.py" line="158" />
-            <source>No information available</source>
-            <translation>無可用資訊</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeMessageBox</name>
-        <message>
-            <location filename="../widget/notice_message.py" line="83" />
-            <source>Confirm and never show again</source>
-            <translation>確認且不再顯示</translation>
-        </message>
-        <message>
-            <location filename="../widget/notice_message.py" line="84" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeSendThread</name>
-        <message>
-            <source> sent successfully.</source>
-            <translation type="vanished"> 傳送成功。</translation>
-        </message>
-        <message>
-            <source> disabled.</source>
-            <translation type="vanished"> 已停用。</translation>
-        </message>
-        <message>
-            <source> param empty.</source>
-            <translation type="vanished"> 參數為空。</translation>
-        </message>
-        <message>
-            <source> param invalid.</source>
-            <translation type="vanished"> 參數無效。</translation>
-        </message>
-        <message>
-            <source> network error.</source>
-            <translation type="vanished"> 網路錯誤。</translation>
-        </message>
-        <message>
-            <source> response error.</source>
-            <translation type="vanished"> 回應錯誤。</translation>
-        </message>
-        <message>
-            <source> unknown error.</source>
-            <translation type="vanished"> 未知錯誤。</translation>
-        </message>
-        <message>
-            <source> smtp port invalid.</source>
-            <translation type="vanished"> SMTP 連接埠無效。</translation>
-        </message>
-        <message>
-            <source> smtp connect failed.</source>
-            <translation type="vanished"> SMTP 連接失敗。</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoticeTimingDialog</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="554" />
-            <source>Notification Timing Settings</source>
-            <translation>通知時機設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="569" />
-            <source>Notify when task flow starts</source>
-            <translation>任務流程開始時通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="570" />
-            <source>Notify when device connects successfully</source>
-            <translation>裝置連接成功時通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="571" />
-            <source>Notify when device connection fails</source>
-            <translation>裝置連接失敗時通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="572" />
-            <source>Notify when task completes successfully</source>
-            <translation>任務成功完成時通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="573" />
-            <source>Notify when task fails</source>
-            <translation>任務失敗時通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="574" />
-            <source>Notify when task flow completes</source>
-            <translation>任務流程完成時通知</translation>
-        </message>
-    </context>
-    <context>
-        <name>OptionWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget.py" line="250" />
-            <location filename="../view/task_interface/components/option_widget.py" line="323" />
-            <source>Options</source>
-            <translation>選項</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget.py" line="324" />
-            <source>Conditions</source>
-            <translation>條件</translation>
-        </message>
-        <message>
-            <source>Speedrun</source>
-            <translation type="vanished">快速執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget.py" line="340" />
-            <source>Function Description</source>
-            <translation>功能描述</translation>
-        </message>
-        <message>
-            <source>Program</source>
-            <translation type="vanished">程式</translation>
-        </message>
-        <message>
-            <source>Program Path</source>
-            <translation type="vanished">程式路徑</translation>
-        </message>
-        <message>
-            <source>Arguments</source>
-            <translation type="vanished">啟動參數</translation>
-        </message>
-        <message>
-            <source>Wait for Process</source>
-            <translation type="vanished">等待程式結束</translation>
-        </message>
-        <message>
-            <source>Wait</source>
-            <translation type="vanished">等待</translation>
-        </message>
-        <message>
-            <source>Seconds</source>
-            <translation type="vanished">秒數</translation>
-        </message>
-        <message>
-            <source>Target Time</source>
-            <translation type="vanished">目標時間</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation type="vanished">時間</translation>
-        </message>
-        <message>
-            <source>System Notification</source>
-            <translation type="vanished">系統通知</translation>
-        </message>
-        <message>
-            <source>Message</source>
-            <translation type="vanished">內容</translation>
-        </message>
-        <message>
-            <source>Play System Sound</source>
-            <translation type="vanished">播放系統提示音</translation>
-        </message>
-        <message>
-            <source>External Notification</source>
-            <translation type="vanished">外部通知</translation>
-        </message>
-        <message>
-            <source>Title</source>
-            <translation type="vanished">標題</translation>
-        </message>
-        <message>
-            <source>Launch an external program and optionally wait for it to exit.</source>
-            <translation type="vanished">啟動外部程式，並可選擇是否等待行程結束。</translation>
-        </message>
-        <message>
-            <source>Wait for the specified number of seconds before continuing.</source>
-            <translation type="vanished">等待指定秒數後繼續執行後續任務。</translation>
-        </message>
-        <message>
-            <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
-            <translation type="vanished">等待到指定時間點後繼續。支援 HH:MM 或 YYYY-MM-DD HH:MM。</translation>
-        </message>
-        <message>
-            <source>Send a system notification and optionally play the system sound.</source>
-            <translation type="vanished">傳送系統通知，並可同時播放系統提示音。</translation>
-        </message>
-        <message>
-            <source>Send a message to all currently enabled external notification channels.</source>
-            <translation type="vanished">向目前已啟用的外部通知通道傳送訊息。</translation>
-        </message>
-        <message>
-            <source>Yes</source>
-            <translation type="vanished">是</translation>
-        </message>
-        <message>
-            <source>No</source>
-            <translation type="vanished">否</translation>
-        </message>
-    </context>
-    <context>
-        <name>PathLineEdit</name>
-        <message>
-            <location filename="../widget/path_line_edit.py" line="60" />
-            <source>Select File</source>
-            <translation>選擇檔案</translation>
-        </message>
-    </context>
-    <context>
-        <name>PostActionSettingMixin</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="72" />
-            <source>Do nothing</source>
-            <translation>不執行任何操作</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="73" />
-            <source>Shutdown</source>
-            <translation>關機</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="74" />
-            <source>Close controller</source>
-            <translation>關閉控制器</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="75" />
-            <source>Close software</source>
-            <translation>關閉軟體</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="76" />
-            <source>Run other configuration</source>
-            <translation>執行其他配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="77" />
-            <source>Run other program</source>
-            <translation>執行其他程式</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="87" />
-            <source>option_page_layout is not set, cannot render post action options</source>
-            <translation>option_page_layout 未設定，無法呈現後續操作選項</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="97" />
-            <source>Finish</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="102" />
-            <source>always run</source>
-            <translation>總是執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="106" />
-            <source>Whether to run the post-action regardless of success or failure</source>
-            <translation>無論成功或失敗是否執行後續操作</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="123" />
-            <source>Select the configuration to run</source>
-            <translation>選擇要執行的配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="208" />
-            <source>Unknown config</source>
-            <translation>未知配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="344" />
-            <source>Program path</source>
-            <translation>程式路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="349" />
-            <source>Select executable path</source>
-            <translation>選擇可執行檔路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="355" />
-            <source>Program arguments</source>
-            <translation>程式參數</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="359" />
-            <source>Extra startup arguments</source>
-            <translation>額外啟動參數</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="417" />
-            <source>Unnamed Configuration</source>
-            <translation>未命名配置</translation>
-        </message>
-    </context>
-    <context>
-        <name>QYWXNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="431" />
-            <source>QYWXbot Key:</source>
-            <translation>QYWXbot 金鑰：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="432" />
-            <source>QYWXbot Status:</source>
-            <translation>QYWXbot 狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>QmsgNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="240" />
-            <source>Server:</source>
-            <translation>伺服器：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="241" />
-            <source>Key:</source>
-            <translation>金鑰：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="242" />
-            <source>User QQ:</source>
-            <translation>使用者 QQ：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="243" />
-            <source>Robot QQ:</source>
-            <translation>機器人 QQ：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="244" />
-            <source>Qmsg Status:</source>
-            <translation>Qmsg 狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>RenameConfigDialog</name>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="915" />
-            <source>Rename config</source>
-            <translation>重新命名設定檔</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="921" />
-            <source>Enter new config name:</source>
-            <translation>輸入新設定檔名稱：</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="924" />
-            <source>Enter the name of the config</source>
-            <translation>輸入設定檔的名稱</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="939" />
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="940" />
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-    </context>
-    <context>
-        <name>ResourceSettingMixin</name>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="112" />
-            <source>Resource</source>
-            <translation>資源</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="440" />
-            <source>Global Option</source>
-            <translation>全域選項</translation>
-        </message>
-    </context>
-    <context>
-        <name>SMTPNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="304" />
-            <source>Use SSL</source>
-            <translation>使用 SSL</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="310" />
-            <source>Server Address:</source>
-            <translation>伺服器位址：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="311" />
-            <source>Server Port:</source>
-            <translation>伺服器埠：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="312" />
-            <source>User Name:</source>
-            <translation>使用者名稱：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="313" />
-            <source>Password:</source>
-            <translation>密碼：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="314" />
-            <source>Receive Mail:</source>
-            <translation>接收郵件：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="315" />
-            <source>SMTP Status:</source>
-            <translation>SMTP 狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScheduleInterface</name>
-        <message>
-            <source>Trigger</source>
-            <translation type="vanished">觸發器</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="155" />
-            <source>schedule_interface_info</source>
-            <translation>schedule_interface_info</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="150" />
-            <source>schedule_interface_info_windows</source>
-            <translation>schedule_interface_info_windows</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="152" />
-            <source>schedule_interface_info_macos</source>
-            <translation>schedule_interface_info_macos</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="154" />
-            <source>schedule_interface_info_linux</source>
-            <translation>schedule_interface_info_linux</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="172" />
-            <source>Select configuration</source>
-            <translation>選擇設定檔</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="174" />
-            <source>Configuration</source>
-            <translation>設定檔</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="183" />
-            <source>Single</source>
-            <translation>單次</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="184" />
-            <source>Daily</source>
-            <translation>每日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="185" />
-            <source>Weekly</source>
-            <translation>每週</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="186" />
-            <source>Monthly</source>
-            <translation>每月</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="177" />
-            <source>Trigger type</source>
-            <translation>觸發類型</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="197" />
-            <source>Timing</source>
-            <translation>時機</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="223" />
-            <source>Force start</source>
-            <translation>強制開始</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="224" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="464" />
-            <source>Enabled</source>
-            <translation>已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="162" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="231" />
-            <source>Add schedule</source>
-            <translation>新增排程</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="251" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="275" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="301" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="319" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="269" />
-            <source>days</source>
-            <translation>天</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="276" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="302" />
-            <source>Every</source>
-            <translation>每</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="296" />
-            <source>weeks</source>
-            <translation>週</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="305" />
-            <source>Weekdays</source>
-            <translation>工作日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="322" />
-            <source>Every month</source>
-            <translation>每月</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="343" />
-            <source>Month</source>
-            <translation>月份</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="348" />
-            <source>Day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="351" />
-            <source>Use ordinal weekday</source>
-            <translation>使用序數工作日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="358" />
-            <source>First</source>
-            <translation>第一</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="359" />
-            <source>Second</source>
-            <translation>第二</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="360" />
-            <source>Third</source>
-            <translation>第三</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="361" />
-            <source>Fourth</source>
-            <translation>第四</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="362" />
-            <source>Last</source>
-            <translation>最後</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="368" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="401" />
-            <source>Monday</source>
-            <translation>星期一</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="369" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="402" />
-            <source>Tuesday</source>
-            <translation>星期二</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="370" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="403" />
-            <source>Wednesday</source>
-            <translation>星期三</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="371" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="404" />
-            <source>Thursday</source>
-            <translation>星期四</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="372" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="405" />
-            <source>Friday</source>
-            <translation>星期五</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="373" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="406" />
-            <source>Saturday</source>
-            <translation>星期六</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="374" />
-            <location filename="../view/schedule_interface/schedule_interface.py" line="407" />
-            <source>Sunday</source>
-            <translation>星期日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="383" />
-            <source>Ordinal</source>
-            <translation>序數</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="384" />
-            <source>Weekday</source>
-            <translation>工作日</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="449" />
-            <source>Scheduled tasks</source>
-            <translation>排程任務</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="459" />
-            <source>Config</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="460" />
-            <source>Type</source>
-            <translation>類型</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="461" />
-            <source>Pattern</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="462" />
-            <source>Next run</source>
-            <translation>下次執行</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="463" />
-            <source>Force</source>
-            <translation>強制執行</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="465" />
-            <source>Action</source>
-            <translation>動作</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="490" />
-            <source>No schedules yet.</source>
-            <translation>尚無排程。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="563" />
-            <source>Unknown</source>
-            <translation>未知</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="579" />
-            <source>Pending</source>
-            <translation>待處理</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="586" />
-            <source>Yes</source>
-            <translation>是</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="586" />
-            <source>No</source>
-            <translation>否</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="605" />
-            <source>Delete schedule</source>
-            <translation>刪除排程</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="633" />
-            <source>Please select a configuration to schedule.</source>
-            <translation>請選擇要排程的設定。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="649" />
-            <source>Please choose a future date and time.</source>
-            <translation>請選擇未來的日期與時間。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="667" />
-            <source>Please select at least one weekday.</source>
-            <translation>請至少選擇一個工作日。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="680" />
-            <source>Please select ordinal and weekday.</source>
-            <translation>請選擇序數與工作日。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="704" />
-            <source>Failed to persist the schedule.</source>
-            <translation>儲存排程失敗。</translation>
-        </message>
-        <message>
-            <location filename="../view/schedule_interface/schedule_interface.py" line="708" />
-            <source>Schedule saved.</source>
-            <translation>排程已儲存。</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScheduleService</name>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="296" />
-            <source>Single</source>
-            <translation>單次</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="297" />
-            <source>Daily</source>
-            <translation>每日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="298" />
-            <source>Weekly</source>
-            <translation>每週</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="299" />
-            <source>Monthly</source>
-            <translation>每月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="301" />
-            <location filename="../core/service/schedule_service.py" line="355" />
-            <source>Custom</source>
-            <translation>自訂</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="314" />
-            <source>Once at {datetime}</source>
-            <translation>於 {datetime} 執行一次</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="319" />
-            <source>Every day at {time}</source>
-            <translation>每天於 {time}</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="320" />
-            <source>Every {n} days at {time}</source>
-            <translation>每 {n} 天於 {time}</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="329" />
-            <source>Every week on {weekdays} at {time}</source>
-            <translation>每週 {weekdays} 於 {time}</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="332" />
-            <source>Every {n} weeks on {weekdays} at {time}</source>
-            <translation>每 {n} 週 {weekdays} 於 {time}</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="343" />
-            <source>Every {month} on the {ordinal} {weekday} at {time}</source>
-            <translation>每月 {month} 第 {ordinal} 個 {weekday} 於 {time}</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="351" />
-            <source>Every {month} on day {day} at {time}</source>
-            <translation>每月 {month} 第 {day} 日於 {time}</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="365" />
-            <source>Monday</source>
-            <translation>星期一</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="366" />
-            <source>Tuesday</source>
-            <translation>星期二</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="367" />
-            <source>Wednesday</source>
-            <translation>星期三</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="368" />
-            <source>Thursday</source>
-            <translation>星期四</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="369" />
-            <source>Friday</source>
-            <translation>星期五</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="370" />
-            <source>Saturday</source>
-            <translation>星期六</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="371" />
-            <source>Sunday</source>
-            <translation>星期日</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="377" />
-            <source>Every month</source>
-            <translation>每月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="379" />
-            <source>January</source>
-            <translation>一月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="380" />
-            <source>February</source>
-            <translation>二月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="381" />
-            <source>March</source>
-            <translation>三月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="382" />
-            <source>April</source>
-            <translation>四月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="383" />
-            <source>May</source>
-            <translation>五月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="384" />
-            <source>June</source>
-            <translation>六月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="385" />
-            <source>July</source>
-            <translation>七月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="386" />
-            <source>August</source>
-            <translation>八月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="387" />
-            <source>September</source>
-            <translation>九月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="388" />
-            <source>October</source>
-            <translation>十月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="389" />
-            <source>November</source>
-            <translation>十一月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="390" />
-            <source>December</source>
-            <translation>十二月</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="396" />
-            <source>Last</source>
-            <translation>最後</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="398" />
-            <source>First</source>
-            <translation>第一</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="399" />
-            <source>Second</source>
-            <translation>第二</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="400" />
-            <source>Third</source>
-            <translation>第三</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="401" />
-            <source>Fourth</source>
-            <translation>第四</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="422" />
-            <source>Schedule: {name} ({describe}) added</source>
-            <translation>已新增排程：{name} ({describe})</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="439" />
-            <source>Schedule: {name} ({describe}) removed</source>
-            <translation>已移除排程：{name} ({describe})</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="460" />
-            <source>enabled</source>
-            <translation>已啟用</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="460" />
-            <source>disabled</source>
-            <translation>已停用</translation>
-        </message>
-        <message>
-            <location filename="../core/service/schedule_service.py" line="462" />
-            <source>Schedule: {name} ({describe}) {status}</source>
-            <translation>排程：{name} ({describe}) {status}</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} ({describe}) triggered</source>
-            <translation type="vanished">排程：{name} ({describe}) 已觸發</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} queued, {count} task(s) remaining</source>
-            <translation type="vanished">排程：{name} 已排入佇列，剩餘 {count} 項任務</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} ({describe}) started</source>
-            <translation type="vanished">排程：{name} ({describe}) 已開始</translation>
-        </message>
-        <message>
-            <source>Schedule: target config {config_id} not found, skipped</source>
-            <translation type="vanished">排程：目標設定 {config_id} 不存在，已跳過</translation>
-        </message>
-        <message>
-            <source>Schedule: {name} failed: {error}</source>
-            <translation type="vanished">排程：{name} 失敗：{error}</translation>
-        </message>
-    </context>
-    <context>
-        <name>SendSettingCard</name>
-        <message>
-            <location filename="../view/setting_interface/widget/send_setting_card.py" line="17" />
-            <source>When Connect Failed</source>
-            <translation>當連線失敗時</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/send_setting_card.py" line="18" />
-            <source>When Post Task</source>
-            <translation>當發布任務時</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/send_setting_card.py" line="19" />
-            <source>When Task Failed</source>
-            <translation>當任務失敗時</translation>
-        </message>
-    </context>
-    <context>
-        <name>SettingInterface</name>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="438" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1727" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1731" />
-            <source>ChainFlow Assistant</source>
-            <translation>ChainFlow 助理</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="511" />
-            <location filename="../view/setting_interface/setting_interface.py" line="600" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1756" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1806" />
-            <source>License</source>
-            <translation>授權</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="514" />
-            <source>GitHub URL</source>
-            <translation>GitHub 網址</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="516" />
-            <location filename="../view/setting_interface/setting_interface.py" line="715" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1412" />
-            <source>Update</source>
-            <translation>更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="518" />
-            <source>Open update log</source>
-            <translation>開啟更新日誌</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="577" />
-            <source>Description: </source>
-            <translation>描述：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="662" />
-            <source>No update log</source>
-            <translation>無更新日誌</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="663" />
-            <source>No update log found locally.
+    </message>
+    <message>
+        <source>ADB path is not set. Tap Controller here and fill in the ADB executable path (usually next to your emulator).</source>
+        <translation type="vanished">ADB 路徑未設定。點擊此處的控制器，填入 ADB 執行檔路徑（通常位於模擬器旁）。</translation>
+    </message>
+    <message>
+        <source>ADB address is empty. Start the emulator so a device appears, or tap Controller here to pick a connection address.</source>
+        <translation type="vanished">ADB 位址為空。啟動模擬器以顯示裝置，或點擊此處的控制器選擇連線位址。</translation>
+    </message>
+    <message>
+        <source>ADB port is missing in the address. Use host:port (for example 127.0.0.1:5555), or tap Controller here to change settings.</source>
+        <translation type="vanished">位址中缺少 ADB 連接埠。請使用 host:port 格式（例如 127.0.0.1:5555），或點擊此處的控制器變更設定。</translation>
+    </message>
+    <message>
+        <source>Controller ADB settings are incomplete. Tap here to open the controller and fix path / address / port.</source>
+        <translation type="vanished">控制器 ADB 設定不完整。點擊此處開啟控制器，修正路徑/位址/連接埠。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1362"/>
+        <location filename="../view/main_window/main_window.py" line="1368"/>
+        <source>hotkey disabled due to permission issue</source>
+        <translation>由於權限問題，熱鍵已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1387"/>
+        <source>Log is being packaged, please wait...</source>
+        <translation>正在封裝日誌，請稍候...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1408"/>
+        <location filename="../view/main_window/main_window.py" line="1458"/>
+        <source>Preparing files...</source>
+        <translation>正在準備檔案...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1430"/>
+        <location filename="../view/main_window/main_window.py" line="1434"/>
+        <source>Debug directory not found, cannot package logs.</source>
+        <translation>找不到除錯目錄，無法封裝日誌。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1449"/>
+        <location filename="../view/main_window/main_window.py" line="1454"/>
+        <source>No matching files were found for the selected options.</source>
+        <translation>所選選項未找到匹配的檔案。</translation>
+    </message>
+    <message>
+        <source>No run records were selected.</source>
+        <translation type="vanished">未選取任何執行記錄。</translation>
+    </message>
+    <message>
+        <source>No matching files were found for the selected run records.</source>
+        <translation type="vanished">找不到與所選執行記錄相符的檔案。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1467"/>
+        <location filename="../view/main_window/main_window.py" line="1482"/>
+        <source>Packing:</source>
+        <translation>封裝中：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1500"/>
+        <location filename="../view/main_window/main_window.py" line="1501"/>
+        <source>Log packaging cancelled.</source>
+        <translation>日誌封裝已取消。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="1505"/>
+        <location filename="../view/main_window/main_window.py" line="1509"/>
+        <source>Log packaging failed:</source>
+        <translation>日誌封裝失敗：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2076"/>
+        <source>, there are </source>
+        <translation>，有 </translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2078"/>
+        <source> files not added</source>
+        <translation> 個檔案未加入</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2082"/>
+        <source>Log has been packaged, but some files failed to read:</source>
+        <translation>日誌已封裝，但部分檔案讀取失敗：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2089"/>
+        <source>Log has been packaged:</source>
+        <translation>日誌已封裝：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2094"/>
+        <source>Packaging completed, but some files were skipped.</source>
+        <translation>封裝完成，但部分檔案已跳過。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2095"/>
+        <source>Packaging completed:</source>
+        <translation>封裝完成：</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2142"/>
+        <location filename="../view/main_window/main_window.py" line="2309"/>
+        <location filename="../view/main_window/main_window.py" line="2738"/>
+        <source>Announcement</source>
+        <translation>公告</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2145"/>
+        <source>There is no announcement at the moment.</source>
+        <translation>目前沒有公告。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2252"/>
+        <location filename="../view/main_window/main_window.py" line="2262"/>
+        <source>Welcome</source>
+        <translation>歡迎</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2365"/>
+        <source>This is the configuration area. Each configuration maps to different task sets.</source>
+        <translation>這是設定區域。每個設定對應不同的任務集。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2371"/>
+        <source>This is the task area. Set the controller and resource configurations first; aside from those two, every task can be dragged to reorder before running.</source>
+        <translation>這是任務區域。請先設定控制器與資源配置；除了這兩項，每個任務在執行前都可拖曳重新排序。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2377"/>
+        <source>The monitor area displays live footage once tasks are running.</source>
+        <translation>監控區域會在任務執行時顯示即時畫面。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2383"/>
+        <source>When you encounter issues while running, click this button and send the generated log zip file in the report folder to the developers.</source>
+        <translation>執行時若遇到問題，請點擊此按鈕，並將 report 目錄中產生的日誌壓縮包傳送給開發者。</translation>
+    </message>
+    <message>
+        <source>Click this button to switch to special tasks; only tasks marked as special will execute.</source>
+        <translation type="vanished">點擊此按鈕切換至特殊任務；僅標記為特殊的任務會執行。</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2719"/>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2755"/>
+        <source>Item </source>
+        <translation>項目 </translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2759"/>
+        <source>Detail</source>
+        <translation>詳細</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2770"/>
+        <location filename="../view/main_window/main_window.py" line="2773"/>
+        <location filename="../view/main_window/main_window.py" line="2829"/>
+        <source>Info</source>
+        <translation>資訊</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2771"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2772"/>
+        <source>Error</source>
+        <translation>錯誤</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2837"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2857"/>
+        <source>ChainFlow Assistant</source>
+        <translation>ChainFlow 助手</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2878"/>
+        <source>admin</source>
+        <translation>admin</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2911"/>
+        <source>Stopping task...</source>
+        <translation>正在停止任務...</translation>
+    </message>
+    <message>
+        <location filename="../view/main_window/main_window.py" line="2919"/>
+        <source>Please wait...</source>
+        <translation>請稍候...</translation>
+    </message>
+</context>
+<context>
+    <name>MirrorCdkLineEditCard</name>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="123"/>
+        <source>About Mirror</source>
+        <translation>關於 Mirror</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="158"/>
+        <source>Remaining time: </source>
+        <translation>剩餘時間：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="162"/>
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="168"/>
+        <source>Expired</source>
+        <translation>已過期</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="179"/>
+        <source>year</source>
+        <translation>年</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="180"/>
+        <source>day</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="181"/>
+        <source>hour</source>
+        <translation>小時</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="182"/>
+        <source>minute</source>
+        <translation>分鐘</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="183"/>
+        <source>second</source>
+        <translation>秒</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/line_edit_card.py" line="189"/>
+        <source>Less than a second</source>
+        <translation>少於一秒</translation>
+    </message>
+</context>
+<context>
+    <name>MonitorDialog</name>
+    <message>
+        <source>Monitor</source>
+        <translation type="vanished">監視器</translation>
+    </message>
+</context>
+<context>
+    <name>MonitorInterface</name>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="385"/>
+        <source>Click to sync this frame to the device</source>
+        <translation>點擊將此畫面同步至裝置</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="431"/>
+        <source>FPS: --</source>
+        <translation>FPS：--</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="482"/>
+        <source>Save Screenshot</source>
+        <translation>儲存截圖</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="488"/>
+        <source>Capture the current preview and store it on disk</source>
+        <translation>擷取當前預覽畫面並儲存至磁碟</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="472"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1074"/>
+        <source>Start Monitoring</source>
+        <translation>開始監控</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="341"/>
+        <source>Monitor</source>
+        <translation>監控器</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="343"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="654"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="672"/>
+        <source>Idle</source>
+        <translation>閒置</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="412"/>
+        <source>Live device preview via an independent controller connection. Click the preview to sync taps to the device.</source>
+        <translation>透過獨立控制器連接進行裝置即時預覽。點擊預覽可將點擊同步至裝置。</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="416"/>
+        <source>Multi-instance mode: all configurations are shown below. Stopped configurations display a power-off indicator. Click a card to switch the active configuration.</source>
+        <translation>多實例模式：下方顯示所有配置。已停止的配置顯示電源關閉圖示。點擊卡片可切換目前使用中配置。</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="422"/>
+        <source>Preview will appear when monitoring starts</source>
+        <translation>監控開始時將顯示預覽</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="453"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="689"/>
+        <source>Resolution: --</source>
+        <translation>解析度：--</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="479"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1076"/>
+        <source>Start monitoring task</source>
+        <translation>開始監控任務</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="492"/>
+        <source>Monitoring starts automatically when a task runs</source>
+        <translation>任務執行時自動開始監控</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="650"/>
+        <source>{0} / {1} running</source>
+        <translation>{0} / {1} 個執行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="666"/>
+        <source>Connecting</source>
+        <translation>連線中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="669"/>
+        <source>Running</source>
+        <translation>執行中</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="678"/>
+        <source>Capture rate: {} FPS</source>
+        <translation>擷取率：{} FPS</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="684"/>
+        <source>Resolution: {} × {}</source>
+        <translation>解析度：{} × {}</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1206"/>
+        <source>Screenshot saved to </source>
+        <translation>螢幕截圖已儲存至 </translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1333"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1378"/>
+        <source>Device connection failed, cannot start monitoring</source>
+        <translation>裝置連線失敗，無法開始監控</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1070"/>
+        <source>Stop Monitoring</source>
+        <translation>停止監控</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1072"/>
+        <source>Stop monitoring task</source>
+        <translation>停止監控任務</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1340"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1386"/>
+        <source>Monitoring started</source>
+        <translation>監控已開始</translation>
+    </message>
+    <message>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1347"/>
+        <location filename="../view/monitor_interface/monitor_interface.py" line="1392"/>
+        <source>Failed to start monitoring: </source>
+        <translation>開始監控失敗：</translation>
+    </message>
+    <message>
+        <source>Monitoring stopped</source>
+        <translation type="vanished">監控已停止</translation>
+    </message>
+    <message>
+        <source>Failed to stop monitoring: </source>
+        <translation type="vanished">停止監控失敗：</translation>
+    </message>
+</context>
+<context>
+    <name>MonitorWidget</name>
+    <message>
+        <source>No screenshot available to save</source>
+        <translation type="vanished">無可用螢幕截圖可儲存</translation>
+    </message>
+    <message>
+        <source>Screenshot saved to </source>
+        <translation type="vanished">螢幕截圖已儲存至 </translation>
+    </message>
+    <message>
+        <source>Failed to save screenshot: </source>
+        <translation type="vanished">儲存螢幕截圖失敗：</translation>
+    </message>
+    <message>
+        <source>Controller not ready. Please ensure the device is connected.</source>
+        <translation type="vanished">控制器未就緒。請確認裝置已連線。</translation>
+    </message>
+    <message>
+        <source>Device connection failed, cannot start monitoring</source>
+        <translation type="vanished">裝置連線失敗，無法開始監控</translation>
+    </message>
+    <message>
+        <source>Failed to start monitoring loop</source>
+        <translation type="vanished">開始監控循環失敗</translation>
+    </message>
+    <message>
+        <source>Monitoring started</source>
+        <translation type="vanished">監控已開始</translation>
+    </message>
+    <message>
+        <source>Failed to start monitoring: </source>
+        <translation type="vanished">開始監控失敗：</translation>
+    </message>
+    <message>
+        <source>Monitoring stopped</source>
+        <translation type="vanished">監控已停止</translation>
+    </message>
+    <message>
+        <source>Failed to stop monitoring: </source>
+        <translation type="vanished">停止監控失敗：</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/monitor_widget.py" line="97"/>
+        <source>Click to open the monitor page</source>
+        <translation>點擊開啟監控頁面</translation>
+    </message>
+</context>
+<context>
+    <name>MultiResourceUpdate</name>
+    <message>
+        <location filename="../utils/update.py" line="2630"/>
+        <source>Checking for updates...</source>
+        <translation>正在檢查更新...</translation>
+    </message>
+    <message>
+        <source>Already up to date</source>
+        <translation type="vanished">已是最新版本</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2665"/>
+        <location filename="../utils/update.py" line="2688"/>
+        <source>Download failed</source>
+        <translation>下載失敗</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2659"/>
+        <source>Preparing to download update...</source>
+        <translation>準備下載更新...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2696"/>
+        <source>Download complete</source>
+        <translation>下載完成</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2699"/>
+        <source>Applying hotfix...</source>
+        <translation>正在套用熱修復...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2756"/>
+        <source>Update applied successfully</source>
+        <translation>更新已成功套用</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="2807"/>
+        <source>Failed to update</source>
+        <translation>更新失敗</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeIndexCard</name>
+    <message>
+        <location filename="../widget/notice_message.py" line="158"/>
+        <source>No information available</source>
+        <translation>無可用資訊</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeMessageBox</name>
+    <message>
+        <location filename="../widget/notice_message.py" line="83"/>
+        <source>Confirm and never show again</source>
+        <translation>確認且不再顯示</translation>
+    </message>
+    <message>
+        <location filename="../widget/notice_message.py" line="84"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeSendThread</name>
+    <message>
+        <source> sent successfully.</source>
+        <translation type="vanished"> 傳送成功。</translation>
+    </message>
+    <message>
+        <source> disabled.</source>
+        <translation type="vanished"> 已停用。</translation>
+    </message>
+    <message>
+        <source> param empty.</source>
+        <translation type="vanished"> 參數為空。</translation>
+    </message>
+    <message>
+        <source> param invalid.</source>
+        <translation type="vanished"> 參數無效。</translation>
+    </message>
+    <message>
+        <source> network error.</source>
+        <translation type="vanished"> 網路錯誤。</translation>
+    </message>
+    <message>
+        <source> response error.</source>
+        <translation type="vanished"> 回應錯誤。</translation>
+    </message>
+    <message>
+        <source> unknown error.</source>
+        <translation type="vanished"> 未知錯誤。</translation>
+    </message>
+    <message>
+        <source> smtp port invalid.</source>
+        <translation type="vanished"> SMTP 連接埠無效。</translation>
+    </message>
+    <message>
+        <source> smtp connect failed.</source>
+        <translation type="vanished"> SMTP 連接失敗。</translation>
+    </message>
+</context>
+<context>
+    <name>NoticeTimingDialog</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="554"/>
+        <source>Notification Timing Settings</source>
+        <translation>通知時機設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="569"/>
+        <source>Notify when task flow starts</source>
+        <translation>任務流程開始時通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="570"/>
+        <source>Notify when device connects successfully</source>
+        <translation>裝置連接成功時通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="571"/>
+        <source>Notify when device connection fails</source>
+        <translation>裝置連接失敗時通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="572"/>
+        <source>Notify when task completes successfully</source>
+        <translation>任務成功完成時通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="573"/>
+        <source>Notify when task fails</source>
+        <translation>任務失敗時通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="574"/>
+        <source>Notify when task flow completes</source>
+        <translation>任務流程完成時通知</translation>
+    </message>
+</context>
+<context>
+    <name>OptionWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget.py" line="250"/>
+        <location filename="../view/task_interface/components/option_widget.py" line="323"/>
+        <source>Options</source>
+        <translation>選項</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget.py" line="324"/>
+        <source>Conditions</source>
+        <translation>條件</translation>
+    </message>
+    <message>
+        <source>Speedrun</source>
+        <translation type="vanished">快速執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget.py" line="340"/>
+        <source>Function Description</source>
+        <translation>功能描述</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation type="vanished">程式</translation>
+    </message>
+    <message>
+        <source>Program Path</source>
+        <translation type="vanished">程式路徑</translation>
+    </message>
+    <message>
+        <source>Arguments</source>
+        <translation type="vanished">啟動參數</translation>
+    </message>
+    <message>
+        <source>Wait for Process</source>
+        <translation type="vanished">等待程式結束</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation type="vanished">等待</translation>
+    </message>
+    <message>
+        <source>Seconds</source>
+        <translation type="vanished">秒數</translation>
+    </message>
+    <message>
+        <source>Target Time</source>
+        <translation type="vanished">目標時間</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="vanished">時間</translation>
+    </message>
+    <message>
+        <source>System Notification</source>
+        <translation type="vanished">系統通知</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="vanished">內容</translation>
+    </message>
+    <message>
+        <source>Play System Sound</source>
+        <translation type="vanished">播放系統提示音</translation>
+    </message>
+    <message>
+        <source>External Notification</source>
+        <translation type="vanished">外部通知</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="vanished">標題</translation>
+    </message>
+    <message>
+        <source>Launch an external program and optionally wait for it to exit.</source>
+        <translation type="vanished">啟動外部程式，並可選擇是否等待行程結束。</translation>
+    </message>
+    <message>
+        <source>Wait for the specified number of seconds before continuing.</source>
+        <translation type="vanished">等待指定秒數後繼續執行後續任務。</translation>
+    </message>
+    <message>
+        <source>Wait until the specified time. Supports HH:MM or YYYY-MM-DD HH:MM.</source>
+        <translation type="vanished">等待到指定時間點後繼續。支援 HH:MM 或 YYYY-MM-DD HH:MM。</translation>
+    </message>
+    <message>
+        <source>Send a system notification and optionally play the system sound.</source>
+        <translation type="vanished">傳送系統通知，並可同時播放系統提示音。</translation>
+    </message>
+    <message>
+        <source>Send a message to all currently enabled external notification channels.</source>
+        <translation type="vanished">向目前已啟用的外部通知通道傳送訊息。</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="vanished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="vanished">否</translation>
+    </message>
+</context>
+<context>
+    <name>PathLineEdit</name>
+    <message>
+        <location filename="../widget/path_line_edit.py" line="60"/>
+        <source>Select File</source>
+        <translation>選擇檔案</translation>
+    </message>
+</context>
+<context>
+    <name>PostActionSettingMixin</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="72"/>
+        <source>Do nothing</source>
+        <translation>不執行任何操作</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="73"/>
+        <source>Shutdown</source>
+        <translation>關機</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="74"/>
+        <source>Close controller</source>
+        <translation>關閉控制器</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="75"/>
+        <source>Close software</source>
+        <translation>關閉軟體</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="76"/>
+        <source>Run other configuration</source>
+        <translation>執行其他配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="77"/>
+        <source>Run other program</source>
+        <translation>執行其他程式</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="87"/>
+        <source>option_page_layout is not set, cannot render post action options</source>
+        <translation>option_page_layout 未設定，無法呈現後續操作選項</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="97"/>
+        <source>Finish</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="102"/>
+        <source>always run</source>
+        <translation>總是執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="106"/>
+        <source>Whether to run the post-action regardless of success or failure</source>
+        <translation>無論成功或失敗是否執行後續操作</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="123"/>
+        <source>Select the configuration to run</source>
+        <translation>選擇要執行的配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="208"/>
+        <source>Unknown config</source>
+        <translation>未知配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="344"/>
+        <source>Program path</source>
+        <translation>程式路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="349"/>
+        <source>Select executable path</source>
+        <translation>選擇可執行檔路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="355"/>
+        <source>Program arguments</source>
+        <translation>程式參數</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="359"/>
+        <source>Extra startup arguments</source>
+        <translation>額外啟動參數</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/post_action_setting_mixin.py" line="417"/>
+        <source>Unnamed Configuration</source>
+        <translation>未命名配置</translation>
+    </message>
+</context>
+<context>
+    <name>QYWXNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="431"/>
+        <source>QYWXbot Key:</source>
+        <translation>QYWXbot 金鑰：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="432"/>
+        <source>QYWXbot Status:</source>
+        <translation>QYWXbot 狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>QmsgNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="240"/>
+        <source>Server:</source>
+        <translation>伺服器：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="241"/>
+        <source>Key:</source>
+        <translation>金鑰：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="242"/>
+        <source>User QQ:</source>
+        <translation>使用者 QQ：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="243"/>
+        <source>Robot QQ:</source>
+        <translation>機器人 QQ：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="244"/>
+        <source>Qmsg Status:</source>
+        <translation>Qmsg 狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>RenameConfigDialog</name>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="915"/>
+        <source>Rename config</source>
+        <translation>重新命名設定檔</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="921"/>
+        <source>Enter new config name:</source>
+        <translation>輸入新設定檔名稱：</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="924"/>
+        <source>Enter the name of the config</source>
+        <translation>輸入設定檔的名稱</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="939"/>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="940"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>ResourceSettingMixin</name>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="112"/>
+        <source>Resource</source>
+        <translation>資源</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_widget_mixin/resource_setting_mixin.py" line="440"/>
+        <source>Global Option</source>
+        <translation>全域選項</translation>
+    </message>
+</context>
+<context>
+    <name>SMTPNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="304"/>
+        <source>Use SSL</source>
+        <translation>使用 SSL</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="310"/>
+        <source>Server Address:</source>
+        <translation>伺服器位址：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="311"/>
+        <source>Server Port:</source>
+        <translation>伺服器埠：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="312"/>
+        <source>User Name:</source>
+        <translation>使用者名稱：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="313"/>
+        <source>Password:</source>
+        <translation>密碼：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="314"/>
+        <source>Receive Mail:</source>
+        <translation>接收郵件：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="315"/>
+        <source>SMTP Status:</source>
+        <translation>SMTP 狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduleInterface</name>
+    <message>
+        <source>Trigger</source>
+        <translation type="vanished">觸發器</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="155"/>
+        <source>schedule_interface_info</source>
+        <translation>schedule_interface_info</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="150"/>
+        <source>schedule_interface_info_windows</source>
+        <translation>schedule_interface_info_windows</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="152"/>
+        <source>schedule_interface_info_macos</source>
+        <translation>schedule_interface_info_macos</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="154"/>
+        <source>schedule_interface_info_linux</source>
+        <translation>schedule_interface_info_linux</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="172"/>
+        <source>Select configuration</source>
+        <translation>選擇設定檔</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="174"/>
+        <source>Configuration</source>
+        <translation>設定檔</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="183"/>
+        <source>Single</source>
+        <translation>單次</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="184"/>
+        <source>Daily</source>
+        <translation>每日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="185"/>
+        <source>Weekly</source>
+        <translation>每週</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="186"/>
+        <source>Monthly</source>
+        <translation>每月</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="177"/>
+        <source>Trigger type</source>
+        <translation>觸發類型</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="197"/>
+        <source>Timing</source>
+        <translation>時機</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="223"/>
+        <source>Force start</source>
+        <translation>強制開始</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="224"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="464"/>
+        <source>Enabled</source>
+        <translation>已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="162"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="231"/>
+        <source>Add schedule</source>
+        <translation>新增排程</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="251"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="275"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="301"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="319"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="269"/>
+        <source>days</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="276"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="302"/>
+        <source>Every</source>
+        <translation>每</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="296"/>
+        <source>weeks</source>
+        <translation>週</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="305"/>
+        <source>Weekdays</source>
+        <translation>工作日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="322"/>
+        <source>Every month</source>
+        <translation>每月</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="343"/>
+        <source>Month</source>
+        <translation>月份</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="348"/>
+        <source>Day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="351"/>
+        <source>Use ordinal weekday</source>
+        <translation>使用序數工作日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="358"/>
+        <source>First</source>
+        <translation>第一</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="359"/>
+        <source>Second</source>
+        <translation>第二</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="360"/>
+        <source>Third</source>
+        <translation>第三</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="361"/>
+        <source>Fourth</source>
+        <translation>第四</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="362"/>
+        <source>Last</source>
+        <translation>最後</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="368"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="401"/>
+        <source>Monday</source>
+        <translation>星期一</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="369"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="402"/>
+        <source>Tuesday</source>
+        <translation>星期二</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="370"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="403"/>
+        <source>Wednesday</source>
+        <translation>星期三</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="371"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="404"/>
+        <source>Thursday</source>
+        <translation>星期四</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="372"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="405"/>
+        <source>Friday</source>
+        <translation>星期五</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="373"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="406"/>
+        <source>Saturday</source>
+        <translation>星期六</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="374"/>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="407"/>
+        <source>Sunday</source>
+        <translation>星期日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="383"/>
+        <source>Ordinal</source>
+        <translation>序數</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="384"/>
+        <source>Weekday</source>
+        <translation>工作日</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="449"/>
+        <source>Scheduled tasks</source>
+        <translation>排程任務</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="459"/>
+        <source>Config</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="460"/>
+        <source>Type</source>
+        <translation>類型</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="461"/>
+        <source>Pattern</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="462"/>
+        <source>Next run</source>
+        <translation>下次執行</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="463"/>
+        <source>Force</source>
+        <translation>強制執行</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="465"/>
+        <source>Action</source>
+        <translation>動作</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="490"/>
+        <source>No schedules yet.</source>
+        <translation>尚無排程。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="563"/>
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="579"/>
+        <source>Pending</source>
+        <translation>待處理</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="586"/>
+        <source>Yes</source>
+        <translation>是</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="586"/>
+        <source>No</source>
+        <translation>否</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="605"/>
+        <source>Delete schedule</source>
+        <translation>刪除排程</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="633"/>
+        <source>Please select a configuration to schedule.</source>
+        <translation>請選擇要排程的設定。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="649"/>
+        <source>Please choose a future date and time.</source>
+        <translation>請選擇未來的日期與時間。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="667"/>
+        <source>Please select at least one weekday.</source>
+        <translation>請至少選擇一個工作日。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="680"/>
+        <source>Please select ordinal and weekday.</source>
+        <translation>請選擇序數與工作日。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="704"/>
+        <source>Failed to persist the schedule.</source>
+        <translation>儲存排程失敗。</translation>
+    </message>
+    <message>
+        <location filename="../view/schedule_interface/schedule_interface.py" line="708"/>
+        <source>Schedule saved.</source>
+        <translation>排程已儲存。</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduleService</name>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="296"/>
+        <source>Single</source>
+        <translation>單次</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="297"/>
+        <source>Daily</source>
+        <translation>每日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="298"/>
+        <source>Weekly</source>
+        <translation>每週</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="299"/>
+        <source>Monthly</source>
+        <translation>每月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="301"/>
+        <location filename="../core/service/schedule_service.py" line="355"/>
+        <source>Custom</source>
+        <translation>自訂</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="314"/>
+        <source>Once at {datetime}</source>
+        <translation>於 {datetime} 執行一次</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="319"/>
+        <source>Every day at {time}</source>
+        <translation>每天於 {time}</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="320"/>
+        <source>Every {n} days at {time}</source>
+        <translation>每 {n} 天於 {time}</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="329"/>
+        <source>Every week on {weekdays} at {time}</source>
+        <translation>每週 {weekdays} 於 {time}</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="332"/>
+        <source>Every {n} weeks on {weekdays} at {time}</source>
+        <translation>每 {n} 週 {weekdays} 於 {time}</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="343"/>
+        <source>Every {month} on the {ordinal} {weekday} at {time}</source>
+        <translation>每月 {month} 第 {ordinal} 個 {weekday} 於 {time}</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="351"/>
+        <source>Every {month} on day {day} at {time}</source>
+        <translation>每月 {month} 第 {day} 日於 {time}</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="365"/>
+        <source>Monday</source>
+        <translation>星期一</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="366"/>
+        <source>Tuesday</source>
+        <translation>星期二</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="367"/>
+        <source>Wednesday</source>
+        <translation>星期三</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="368"/>
+        <source>Thursday</source>
+        <translation>星期四</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="369"/>
+        <source>Friday</source>
+        <translation>星期五</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="370"/>
+        <source>Saturday</source>
+        <translation>星期六</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="371"/>
+        <source>Sunday</source>
+        <translation>星期日</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="377"/>
+        <source>Every month</source>
+        <translation>每月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="379"/>
+        <source>January</source>
+        <translation>一月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="380"/>
+        <source>February</source>
+        <translation>二月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="381"/>
+        <source>March</source>
+        <translation>三月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="382"/>
+        <source>April</source>
+        <translation>四月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="383"/>
+        <source>May</source>
+        <translation>五月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="384"/>
+        <source>June</source>
+        <translation>六月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="385"/>
+        <source>July</source>
+        <translation>七月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="386"/>
+        <source>August</source>
+        <translation>八月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="387"/>
+        <source>September</source>
+        <translation>九月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="388"/>
+        <source>October</source>
+        <translation>十月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="389"/>
+        <source>November</source>
+        <translation>十一月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="390"/>
+        <source>December</source>
+        <translation>十二月</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="396"/>
+        <source>Last</source>
+        <translation>最後</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="398"/>
+        <source>First</source>
+        <translation>第一</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="399"/>
+        <source>Second</source>
+        <translation>第二</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="400"/>
+        <source>Third</source>
+        <translation>第三</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="401"/>
+        <source>Fourth</source>
+        <translation>第四</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="422"/>
+        <source>Schedule: {name} ({describe}) added</source>
+        <translation>已新增排程：{name} ({describe})</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="439"/>
+        <source>Schedule: {name} ({describe}) removed</source>
+        <translation>已移除排程：{name} ({describe})</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="460"/>
+        <source>enabled</source>
+        <translation>已啟用</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="460"/>
+        <source>disabled</source>
+        <translation>已停用</translation>
+    </message>
+    <message>
+        <location filename="../core/service/schedule_service.py" line="462"/>
+        <source>Schedule: {name} ({describe}) {status}</source>
+        <translation>排程：{name} ({describe}) {status}</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} ({describe}) triggered</source>
+        <translation type="vanished">排程：{name} ({describe}) 已觸發</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} queued, {count} task(s) remaining</source>
+        <translation type="vanished">排程：{name} 已排入佇列，剩餘 {count} 項任務</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} ({describe}) started</source>
+        <translation type="vanished">排程：{name} ({describe}) 已開始</translation>
+    </message>
+    <message>
+        <source>Schedule: target config {config_id} not found, skipped</source>
+        <translation type="vanished">排程：目標設定 {config_id} 不存在，已跳過</translation>
+    </message>
+    <message>
+        <source>Schedule: {name} failed: {error}</source>
+        <translation type="vanished">排程：{name} 失敗：{error}</translation>
+    </message>
+</context>
+<context>
+    <name>SendSettingCard</name>
+    <message>
+        <location filename="../view/setting_interface/widget/send_setting_card.py" line="17"/>
+        <source>When Connect Failed</source>
+        <translation>當連線失敗時</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/send_setting_card.py" line="18"/>
+        <source>When Post Task</source>
+        <translation>當發布任務時</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/send_setting_card.py" line="19"/>
+        <source>When Task Failed</source>
+        <translation>當任務失敗時</translation>
+    </message>
+</context>
+<context>
+    <name>SettingInterface</name>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="438"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1739"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1743"/>
+        <source>ChainFlow Assistant</source>
+        <translation>ChainFlow 助理</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="511"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="600"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1768"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1818"/>
+        <source>License</source>
+        <translation>授權</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="514"/>
+        <source>GitHub URL</source>
+        <translation>GitHub 網址</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="516"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="715"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1412"/>
+        <source>Update</source>
+        <translation>更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="518"/>
+        <source>Open update log</source>
+        <translation>開啟更新日誌</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="577"/>
+        <source>Description: </source>
+        <translation>描述：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="662"/>
+        <source>No update log</source>
+        <translation>無更新日誌</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="663"/>
+        <source>No update log found locally.
 
 Please check for updates first, or visit the GitHub releases page.</source>
-            <translation>本機未找到更新日誌。
+        <translation>本機未找到更新日誌。
 
 請先檢查更新，或造訪 GitHub 發佈頁面。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="671" />
-            <source>Update Log</source>
-            <translation>更新日誌</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="729" />
-            <source>Update Now</source>
-            <translation>立即更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="824" />
-            <source>Custom Startup</source>
-            <translation>自訂啟動</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="828" />
-            <source>run after startup</source>
-            <translation>啟動後執行</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="829" />
-            <source>Launch the task immediately after starting the GUI program</source>
-            <translation>啟動圖形介面程式後立即執行任務</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="835" />
-            <source>Start minimized</source>
-            <translation>啟動時最小化</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="836" />
-            <source>Automatically minimize the window right after launch</source>
-            <translation>啟動後自動最小化視窗</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="842" />
-            <source>Minimize to tray (Windows)</source>
-            <translation>最小化至系統匣 (Windows)</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="844" />
-            <source>When enabled, minimizing the window will hide it to the system tray</source>
-            <translation>啟用時，最小化視窗會將其隱藏至系統匣</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="855" />
-            <source>Initial Page</source>
-            <translation>初始頁面</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="856" />
-            <source>Choose which page to show after launch</source>
-            <translation>選擇啟動後顯示的頁面</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="858" />
-            <source>Last visited</source>
-            <translation>上次瀏覽</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="859" />
-            <source>Home</source>
-            <translation>首頁</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="860" />
-            <source>Task</source>
-            <translation>任務</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="861" />
-            <source>Monitor</source>
-            <translation>監控</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="862" />
-            <source>Schedule</source>
-            <translation>排程</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="863" />
-            <source>Setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="876" />
-            <source>Personalization</source>
-            <translation>個人化</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="881" />
-            <source>Mica Effect</source>
-            <translation>雲母效果</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="882" />
-            <source>Apply semi transparent to windows and surfaces</source>
-            <translation>套用半透明效果至視窗與表面</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="889" />
-            <source>Application Theme</source>
-            <translation>應用程式主題</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="890" />
-            <source>Change the appearance of your application</source>
-            <translation>變更應用程式外觀</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="891" />
-            <source>Light</source>
-            <translation>淺色</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="891" />
-            <source>Dark</source>
-            <translation>深色</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="891" />
-            <location filename="../view/setting_interface/setting_interface.py" line="912" />
-            <source>Use system setting</source>
-            <translation>使用系統設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="897" />
-            <source>Theme Color</source>
-            <translation>主題色彩</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="898" />
-            <source>Change the theme color of your application</source>
-            <translation>變更應用程式的主題色彩</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="904" />
-            <source>Interface Zoom</source>
-            <translation>介面縮放</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="905" />
-            <source>Change the size of widgets and fonts</source>
-            <translation>調整小工具與字型的大小</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="919" />
-            <source>Language</source>
-            <translation>語言</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="920" />
-            <source>Set your preferred language for UI</source>
-            <translation>設定您偏好的介面語言</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="927" />
-            <source>Restore window position</source>
-            <translation>還原視窗位置</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="929" />
-            <source>When enabled, the application reopens at the last recorded size and position</source>
-            <translation>啟用後，應用程式將以最後記錄的大小與位置重新開啟</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="936" />
-            <source>Advanced Settings</source>
-            <translation>進階設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="937" />
-            <source>Enable to show more options in Pre-configuration</source>
-            <translation>啟用以在預先設定中顯示更多選項</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="945" />
-            <source>Background Image</source>
-            <translation>背景圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="947" />
-            <source>Select an image as application background</source>
-            <translation>選擇圖片作為應用程式背景</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="953" />
-            <location filename="../view/setting_interface/setting_interface.py" line="994" />
-            <source>Choose an image file (png/jpg/webp/bmp)</source>
-            <translation>選擇圖片檔案 (png/jpg/webp/bmp)</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="960" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1001" />
-            <source>Browse image file</source>
-            <translation>瀏覽圖片檔案</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="974" />
-            <source>Clear background image</source>
-            <translation>清除背景圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="986" />
-            <source>Home Cover Image</source>
-            <translation>首頁封面圖</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="988" />
-            <source>Select an image as Home hero cover</source>
-            <translation>選擇一張圖片作為首頁封面</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1011" />
-            <source>Clear home cover image</source>
-            <translation>清除首頁封面圖</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1022" />
-            <source>Background Opacity</source>
-            <translation>背景透明度</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1023" />
-            <source>Adjust transparency of the background image</source>
-            <translation>調整背景圖片的透明度</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1048" />
-            <source>Global Shortcuts</source>
-            <translation>全域快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1056" />
-            <source>Start task shortcut</source>
-            <translation>開始任務快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1059" />
-            <source>Default Ctrl+F1, can also trigger when focus is not on the main window</source>
-            <translation>預設 Ctrl+F1，即使焦點不在主視窗時也能觸發</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1064" />
-            <source>Ctrl+</source>
-            <translation>Ctrl+</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1067" />
-            <source>Format: Modifier+[Key], e.g. Ctrl+F1</source>
-            <translation>格式：修飾鍵+[按鍵]，例如 Ctrl+F1</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1079" />
-            <source>Stop task shortcut</source>
-            <translation>停止任務快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1081" />
-            <source>Default Alt+F1, used to interrupt tasks in advance</source>
-            <translation>預設 Alt+F1，用於提前中斷任務</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1085" />
-            <source>Alt+</source>
-            <translation>Alt+</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1088" />
-            <source>Format: Modifier+[Key], e.g. Alt+F1</source>
-            <translation>格式：修飾鍵+[按鍵]，例如 Alt+F1</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1126" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1129" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1137" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1140" />
-            <source>Permission denied, shortcuts disabled</source>
-            <translation>權限不足，快捷鍵已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1156" />
-            <source>Key cannot be empty</source>
-            <translation>按鍵不能為空</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1165" />
-            <source>Key format is invalid, restored to previous configuration.</source>
-            <translation>按鍵格式無效，已恢復為先前設定。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1174" />
-            <source>Ctrl</source>
-            <translation>Ctrl</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1174" />
-            <source>Alt</source>
-            <translation>Alt</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1177" />
-            <source>Start task</source>
-            <translation>開始任務</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1179" />
-            <source>Stop task</source>
-            <translation>停止任務</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1183" />
-            <source>Shortcut must start with %1+, used for %2.</source>
-            <translation>快捷鍵必須以 %1+ 開頭，用於 %2。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1232" />
-            <source>Notice</source>
-            <translation>通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1235" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2445" />
-            <source>DingTalk Notification Enabled</source>
-            <translation>釘釘通知已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1237" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2447" />
-            <source>DingTalk Notification Disabled</source>
-            <translation>釘釘通知已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1240" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1251" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1262" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1274" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1286" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1299" />
-            <source>Modify</source>
-            <translation>修改</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1242" />
-            <source>DingTalk</source>
-            <translation>釘釘</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1247" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2451" />
-            <source>Lark Notification Enabled</source>
-            <translation>飛書通知已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1249" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2453" />
-            <source>Lark Notification Disabled</source>
-            <translation>飛書通知已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1253" />
-            <source>Lark</source>
-            <translation>飛書</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1258" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2457" />
-            <source>SMTP Notification Enabled</source>
-            <translation>SMTP 通知已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1260" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2459" />
-            <source>SMTP Notification Disabled</source>
-            <translation>SMTP 通知已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1264" />
-            <source>SMTP</source>
-            <translation>SMTP</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1269" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2463" />
-            <source>WxPusher Notification Enabled</source>
-            <translation>WxPusher 通知已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1271" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2465" />
-            <source>WxPusher Notification Disabled</source>
-            <translation>WxPusher 通知已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1276" />
-            <source>WxPusher</source>
-            <translation>WxPusher</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1281" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2469" />
-            <source>QYWX Notification Enabled</source>
-            <translation>QYWX 通知已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1283" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2471" />
-            <source>QYWX Notification Disabled</source>
-            <translation>QYWX 通知已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1288" />
-            <source>QYWX</source>
-            <translation>QYWX</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1294" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2475" />
-            <source>Gotify Notification Enabled</source>
-            <translation>Gotify 通知已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1296" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2477" />
-            <source>Gotify Notification Disabled</source>
-            <translation>Gotify 通知已停用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1301" />
-            <source>Gotify</source>
-            <translation>Gotify</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1317" />
-            <source>Send Format</source>
-            <translation>傳送格式</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1318" />
-            <source>Plain text or HTML for external notifications (e.g. email body)</source>
-            <translation>外部通知的純文字或 HTML（例如電子郵件內文）</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1319" />
-            <source>Plain text</source>
-            <translation>純文字</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1319" />
-            <source>HTML</source>
-            <translation>HTML</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1327" />
-            <source>Attach screenshot to notice</source>
-            <translation>附加螢幕截圖至通知</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1329" />
-            <source>When enabled, a screenshot is captured and sent with notifications (e.g. as email attachment) if controller is available</source>
-            <translation>啟用時，若控制器可用，將擷取螢幕截圖並隨通知傳送（例如作為電子郵件附件）</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1338" />
-            <source>Configure</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1340" />
-            <source>Notification Timing</source>
-            <translation>通知時機</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1341" />
-            <source>Configure when to send notifications</source>
-            <translation>設定傳送通知的時機</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1351" />
-            <source>Task Settings</source>
-            <translation>任務設定</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1356" />
-            <source>Monitor capture rate</source>
-            <translation>監控截圖速率</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1358" />
-            <source>Screenshot frames per second for the monitoring preview (uses a separate controller connection based on your controller settings)</source>
-            <translation>監控預覽每秒截圖幀數，依主設定的控制器類型建立獨立連線</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1373" />
-            <source>Recognition ROI overlay</source>
-            <translation>識別框疊加</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1375" />
-            <source>Draw recognition hit boxes on the monitoring preview during tasks. This feature consumes significant system resources.</source>
-            <translation>任務執行時在監控預覽上繪製識別命中框。本功能會占用大量系統資源。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1385" />
-            <source>GPU Acceleration</source>
-            <translation>GPU 硬體加速</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1386" />
-            <source>Enable GPU hardware acceleration for resource inference</source>
-            <translation>為資源推理啟用 GPU 硬體加速</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1396" />
-            <source>Reset task page layout</source>
-            <translation>重設任務頁面佈局</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1398" />
-            <source>Restore the task, option, and log columns to equal width (1:1:1)</source>
-            <translation>將任務、選項和日誌欄恢復為等寬（1:1:1）</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1417" />
-            <source>mirrorchyan CDK</source>
-            <translation>mirrorchyan CDK</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1418" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1599" />
-            <source>Enter mirrorchyan CDK for stable update path</source>
-            <translation>輸入 mirrorchyan CDK 以獲取穩定更新路徑</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1420" />
-            <source>About Mirror</source>
-            <translation>關於 Mirror</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1426" />
-            <source>Automatically update after startup</source>
-            <translation>啟動後自動更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1427" />
-            <source>Automatically download and apply updates once available</source>
-            <translation>自動下載並套用可用更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1436" />
-            <source>select update channel for resource</source>
-            <translation>選擇資源更新頻道</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1437" />
-            <source>select the update channel for the resource</source>
-            <translation>選擇資源的更新頻道</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1444" />
-            <source>Force use GitHub</source>
-            <translation>強制使用 GitHub</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1445" />
-            <source>Force use GitHub for resource update</source>
-            <translation>強制使用 GitHub 進行資源更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1394" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1451" />
-            <source>Reset</source>
-            <translation>重設</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1453" />
-            <source>Reset resource</source>
-            <translation>重設資源</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1454" />
-            <source>Redownload resource package without version/tag check</source>
-            <translation>重新下載資源套件，不檢查版本/標籤</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1460" />
-            <source>GitHub API Key</source>
-            <translation>GitHub API 金鑰</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1462" />
-            <source>Personal access tokens increase GitHub API rate limits for update checks.</source>
-            <translation>個人存取權杖可提高 GitHub API 的更新檢查速率限制。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1469" />
-            <source>Optional token for authenticated GitHub requests</source>
-            <translation>用於 GitHub 認證請求的選用權杖</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1478" />
-            <source>Use Proxy</source>
-            <translation>使用代理伺服器</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1480" />
-            <source>After filling in the proxy settings, all traffic except that to the Mirror will be proxied.</source>
-            <translation>填寫代理伺服器設定後，除鏡像站外的所有流量都將透過代理伺服器傳送。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1504" />
-            <source>Experimental / Compatibility</source>
-            <translation>實驗性 / 相容性</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1508" />
-            <source>Multi-resource adaptation</source>
-            <translation>多資源適配</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1510" />
-            <source>Experimental. Enable loading multiple resource bundles; may impact stability.</source>
-            <translation>實驗性功能。啟用載入多個資源套件；可能影響穩定性。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1518" />
-            <source>Save screenshot</source>
-            <translation>儲存螢幕截圖</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1519" />
-            <source>Save a screenshot when experimental features run</source>
-            <translation>實驗性功能執行時儲存螢幕截圖</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1526" />
-            <source>Include images in log zip</source>
-            <translation>在日誌壓縮檔中包含圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1528" />
-            <source>Include log images when generating log zip package. The number of images included equals the number displayed in the log interface.</source>
-            <translation>生成日誌壓縮套件時包含日誌圖片。包含的圖片數量等於日誌介面中顯示的數量。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1546" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2431" />
-            <source>Set cache image count, current cache usage: {}</source>
-            <translation>設定快取圖片數量，目前快取使用量：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1551" />
-            <source>Max log images</source>
-            <translation>最大日誌圖片數量</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1605" />
-            <source>Resource does not support Mirrorchyan, right-click about mirror to unlock input</source>
-            <translation>資源不支援 Mirrorchyan，請右鍵點擊關於鏡像以解鎖輸入</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1628" />
-            <source>decrypt Mirror CDK failed, please fill in again and save.</source>
-            <translation>解密 Mirror CDK 失敗，請重新填寫並儲存。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1659" />
-            <source>Failed to save Mirror CDK: {}</source>
-            <translation>儲存 Mirror CDK 失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1678" />
-            <source>Failed to read GitHub token, please save it again.</source>
-            <translation>無法讀取 GitHub token，請重新儲存。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1703" />
-            <source>Failed to save GitHub token: {}.</source>
-            <translation>儲存 GitHub token 失敗：{}。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1738" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1794" />
-            <source>Current version: </source>
-            <translation>目前版本：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1741" />
-            <source>Latest version: </source>
-            <translation>最新版本：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1744" />
-            <source>UI version: </source>
-            <translation>介面版本：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1747" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1797" />
-            <source>MaaFW version: </source>
-            <translation>MaaFW 版本：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1764" />
-            <source>MFW-ChainFlow Assistant</source>
-            <translation>MFW-ChainFlow 助手</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1777" />
-            <source>MFW-ChainFlow Assistant provides a visual orchestrator for MaaFramework users, covering configuration management, scheduling, notifications and custom extensions.</source>
-            <translation>MFW-ChainFlow 助手為 MaaFramework 使用者提供視覺化流程編排工具，涵蓋配置管理、排程、通知及自訂擴充功能。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1871" />
-            <source>Select background image</source>
-            <translation>選擇背景圖片</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1873" />
-            <location filename="../view/setting_interface/setting_interface.py" line="1891" />
-            <source>Images (*.png *.jpg *.jpeg *.bmp *.webp)</source>
-            <translation>圖片 (*.png *.jpg *.jpeg *.bmp *.webp)</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1889" />
-            <source>Select home cover image</source>
-            <translation>選擇首頁封面圖</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="1908" />
-            <source>UI update feature is not implemented yet.</source>
-            <translation>介面更新功能尚未實作。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2280" />
-            <source>Enable multi-resource adaptation?</source>
-            <translation>啟用多資源適配？</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2284" />
-            <source>After enabling the multi-configuration feature, the resource directories will be reconfigured. This operation is irreversible; please proceed with caution.</source>
-            <translation>啟用多配置功能後，資源目錄將重新配置。此操作不可逆，請謹慎進行。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2297" />
-            <source>Enable</source>
-            <translation>啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2299" />
-            <location filename="../view/setting_interface/setting_interface.py" line="3066" />
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2346" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2365" />
-            <source>Image file does not exist</source>
-            <translation>圖片檔案不存在</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2532" />
-            <source>Configuration takes effect after restart</source>
-            <translation>配置需重新啟動後生效</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2634" />
-            <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
-            <translation>CI/Alpha 資源版本已停用自動更新，請手動更新。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2718" />
-            <source>Update failed too many times, local update package has been cleared.</source>
-            <translation>更新失敗次數過多，本地更新套件已清除。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2794" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2837" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2887" />
-            <location filename="../view/setting_interface/setting_interface.py" line="2938" />
-            <source>Stop update</source>
-            <translation>停止更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2858" />
-            <source>New version available: </source>
-            <translation>有新版本可用：</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2919" />
-            <source>Task page layout has been reset</source>
-            <translation>任務頁面佈局已重設</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2926" />
-            <source>Update is already running</source>
-            <translation>更新已在進行中</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2932" />
-            <source>Service is not ready, cannot reset resource</source>
-            <translation>服務未就緒，無法重置資源</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2943" />
-            <source>Starting Reset Resource</source>
-            <translation>正在開始重置資源</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="2993" />
-            <source>Failed to rename updater: {}</source>
-            <translation>重新命名更新程式失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3005" />
-            <location filename="../view/setting_interface/setting_interface.py" line="3138" />
-            <source>Failed to start updater: {}</source>
-            <translation>啟動更新程式失敗：{}</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3048" />
-            <source>Update package not found, please try updating again.</source>
-            <translation>未找到更新套件，請嘗試重新更新。</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3065" />
-            <source>Update now</source>
-            <translation>立即更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3069" />
-            <source>Restart required to update</source>
-            <translation>需重新啟動以完成更新</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3071" />
-            <source>Update package detected</source>
-            <translation>偵測到更新套件</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3074" />
-            <source>Hot update is unavailable. A restart update is required. Proceed?</source>
-            <translation>熱更新不可用。需要重新啟動更新。是否繼續？</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3077" />
-            <source>Found a downloaded update package. Do you want to launch the updater now?</source>
-            <translation>發現已下載的更新套件。是否要立即啟動更新程式？</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/setting_interface.py" line="3100" />
-            <source>Auto updating in %1 s</source>
-            <translation>自動更新於 %1 秒後</translation>
-        </message>
-    </context>
-    <context>
-        <name>SpeedrunConfigWidget</name>
-        <message>
-            <source>Speedrun Configuration</source>
-            <translation type="vanished">快速執行設定</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="80" />
-            <source>Daily</source>
-            <translation>每日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="81" />
-            <source>Weekly</source>
-            <translation>每週</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="82" />
-            <source>Monthly</source>
-            <translation>每月</translation>
-        </message>
-        <message>
-            <source>Mode</source>
-            <translation type="vanished">模式</translation>
-        </message>
-        <message>
-            <source>Refresh Hour</source>
-            <translation type="vanished">更新時間</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="169" />
-            <source>Monday</source>
-            <translation>星期一</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="170" />
-            <source>Tuesday</source>
-            <translation>星期二</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="171" />
-            <source>Wednesday</source>
-            <translation>星期三</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="172" />
-            <source>Thursday</source>
-            <translation>星期四</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="173" />
-            <source>Friday</source>
-            <translation>星期五</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="174" />
-            <source>Saturday</source>
-            <translation>星期六</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="175" />
-            <source>Sunday</source>
-            <translation>星期日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="64" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="86" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="107" />
-            <source>Weekday</source>
-            <translation>工作日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="37" />
-            <source>Condition Execution</source>
-            <translation>條件執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="53" />
-            <source>Condition</source>
-            <translation>條件</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="62" />
-            <source>Always</source>
-            <translation>總是</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="63" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="97" />
-            <source>Run Count</source>
-            <translation>執行次數</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="65" />
-            <source>Month Day</source>
-            <translation>月份日期</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="66" />
-            <source>After Time</source>
-            <translation>時間之後</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="67" />
-            <source>Condition Type</source>
-            <translation>條件類型</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="70" />
-            <source>Condition Configuration</source>
-            <translation>條件配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="83" />
-            <source>Period</source>
-            <translation>週期</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="92" />
-            <source>Refresh Timeline</source>
-            <translation>重新整理時間軸</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="89" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="115" />
-            <source>Day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="123" />
-            <source>Hour</source>
-            <translation>小時</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="130" />
-            <source>Execution</source>
-            <translation>執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="139" />
-            <source>Run</source>
-            <translation>執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="140" />
-            <source>Skip</source>
-            <translation>跳過</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="141" />
-            <source>Execution Type</source>
-            <translation>執行類型</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="144" />
-            <source>Execution Configuration</source>
-            <translation>執行配置</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="152" />
-            <source>Notify</source>
-            <translation>通知</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="157" />
-            <source>External Notify</source>
-            <translation>外部通知</translation>
-        </message>
-        <message>
-            <source>General</source>
-            <translation type="vanished">一般</translation>
-        </message>
-        <message>
-            <source>Refresh Count</source>
-            <translation type="vanished">更新次數</translation>
-        </message>
-        <message>
-            <source>Min Interval (hours)</source>
-            <translation type="vanished">最小間隔（小時）</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="150" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="155" />
-            <source>Enabled</source>
-            <translation>已啟用</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="151" />
-            <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="156" />
-            <source>Disabled</source>
-            <translation>已停用</translation>
-        </message>
-        <message>
-            <source>Enable Speedrun</source>
-            <translation type="vanished">啟用快速執行</translation>
-        </message>
-        <message>
-            <source>N/A</source>
-            <translation type="vanished">N/A</translation>
-        </message>
-        <message>
-            <source>Current Count</source>
-            <translation type="vanished">目前計數</translation>
-        </message>
-        <message>
-            <source>Last Run Time</source>
-            <translation type="vanished">上次執行時間</translation>
-        </message>
-    </context>
-    <context>
-        <name>StartBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/start_bar_widget.py" line="30" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-    </context>
-    <context>
-        <name>StartupDialogManager</name>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="303" />
-            <source>Missing Runtime Library</source>
-            <translation>缺少執行階段程式庫</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="305" />
-            <source>Failed to load MAA framework library.
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="671"/>
+        <source>Update Log</source>
+        <translation>更新日誌</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="729"/>
+        <source>Update Now</source>
+        <translation>立即更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="824"/>
+        <source>Custom Startup</source>
+        <translation>自訂啟動</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="828"/>
+        <source>run after startup</source>
+        <translation>啟動後執行</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="829"/>
+        <source>Launch the task immediately after starting the GUI program</source>
+        <translation>啟動圖形介面程式後立即執行任務</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="835"/>
+        <source>Start minimized</source>
+        <translation>啟動時最小化</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="836"/>
+        <source>Automatically minimize the window right after launch</source>
+        <translation>啟動後自動最小化視窗</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="842"/>
+        <source>Minimize to tray (Windows)</source>
+        <translation>最小化至系統匣 (Windows)</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="844"/>
+        <source>When enabled, minimizing the window will hide it to the system tray</source>
+        <translation>啟用時，最小化視窗會將其隱藏至系統匣</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="855"/>
+        <source>Initial Page</source>
+        <translation>初始頁面</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="856"/>
+        <source>Choose which page to show after launch</source>
+        <translation>選擇啟動後顯示的頁面</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="858"/>
+        <source>Last visited</source>
+        <translation>上次瀏覽</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="859"/>
+        <source>Home</source>
+        <translation>首頁</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="860"/>
+        <source>Task</source>
+        <translation>任務</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="861"/>
+        <source>Monitor</source>
+        <translation>監控</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="862"/>
+        <source>Schedule</source>
+        <translation>排程</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="863"/>
+        <source>Setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="876"/>
+        <source>Personalization</source>
+        <translation>個人化</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="881"/>
+        <source>Mica Effect</source>
+        <translation>雲母效果</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="882"/>
+        <source>Apply semi transparent to windows and surfaces</source>
+        <translation>套用半透明效果至視窗與表面</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="889"/>
+        <source>Application Theme</source>
+        <translation>應用程式主題</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="890"/>
+        <source>Change the appearance of your application</source>
+        <translation>變更應用程式外觀</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="891"/>
+        <source>Light</source>
+        <translation>淺色</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="891"/>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="891"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="912"/>
+        <source>Use system setting</source>
+        <translation>使用系統設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="897"/>
+        <source>Theme Color</source>
+        <translation>主題色彩</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="898"/>
+        <source>Change the theme color of your application</source>
+        <translation>變更應用程式的主題色彩</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="904"/>
+        <source>Interface Zoom</source>
+        <translation>介面縮放</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="905"/>
+        <source>Change the size of widgets and fonts</source>
+        <translation>調整小工具與字型的大小</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="919"/>
+        <source>Language</source>
+        <translation>語言</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="920"/>
+        <source>Set your preferred language for UI</source>
+        <translation>設定您偏好的介面語言</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="927"/>
+        <source>Restore window position</source>
+        <translation>還原視窗位置</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="929"/>
+        <source>When enabled, the application reopens at the last recorded size and position</source>
+        <translation>啟用後，應用程式將以最後記錄的大小與位置重新開啟</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="936"/>
+        <source>Advanced Settings</source>
+        <translation>進階設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="937"/>
+        <source>Enable to show more options in Pre-configuration</source>
+        <translation>啟用以在預先設定中顯示更多選項</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="945"/>
+        <source>Background Image</source>
+        <translation>背景圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="947"/>
+        <source>Select an image as application background</source>
+        <translation>選擇圖片作為應用程式背景</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="953"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="994"/>
+        <source>Choose an image file (png/jpg/webp/bmp)</source>
+        <translation>選擇圖片檔案 (png/jpg/webp/bmp)</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="960"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1001"/>
+        <source>Browse image file</source>
+        <translation>瀏覽圖片檔案</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="974"/>
+        <source>Clear background image</source>
+        <translation>清除背景圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="986"/>
+        <source>Home Cover Image</source>
+        <translation>首頁封面圖</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="988"/>
+        <source>Select an image as Home hero cover</source>
+        <translation>選擇一張圖片作為首頁封面</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1011"/>
+        <source>Clear home cover image</source>
+        <translation>清除首頁封面圖</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1022"/>
+        <source>Background Opacity</source>
+        <translation>背景透明度</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1023"/>
+        <source>Adjust transparency of the background image</source>
+        <translation>調整背景圖片的透明度</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1048"/>
+        <source>Global Shortcuts</source>
+        <translation>全域快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1056"/>
+        <source>Start task shortcut</source>
+        <translation>開始任務快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1059"/>
+        <source>Default Ctrl+F1, can also trigger when focus is not on the main window</source>
+        <translation>預設 Ctrl+F1，即使焦點不在主視窗時也能觸發</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1064"/>
+        <source>Ctrl+</source>
+        <translation>Ctrl+</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1067"/>
+        <source>Format: Modifier+[Key], e.g. Ctrl+F1</source>
+        <translation>格式：修飾鍵+[按鍵]，例如 Ctrl+F1</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1079"/>
+        <source>Stop task shortcut</source>
+        <translation>停止任務快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1081"/>
+        <source>Default Alt+F1, used to interrupt tasks in advance</source>
+        <translation>預設 Alt+F1，用於提前中斷任務</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1085"/>
+        <source>Alt+</source>
+        <translation>Alt+</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1088"/>
+        <source>Format: Modifier+[Key], e.g. Alt+F1</source>
+        <translation>格式：修飾鍵+[按鍵]，例如 Alt+F1</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1126"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1129"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1137"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1140"/>
+        <source>Permission denied, shortcuts disabled</source>
+        <translation>權限不足，快捷鍵已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1156"/>
+        <source>Key cannot be empty</source>
+        <translation>按鍵不能為空</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1165"/>
+        <source>Key format is invalid, restored to previous configuration.</source>
+        <translation>按鍵格式無效，已恢復為先前設定。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1174"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1174"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1177"/>
+        <source>Start task</source>
+        <translation>開始任務</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1179"/>
+        <source>Stop task</source>
+        <translation>停止任務</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1183"/>
+        <source>Shortcut must start with %1+, used for %2.</source>
+        <translation>快捷鍵必須以 %1+ 開頭，用於 %2。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1232"/>
+        <source>Notice</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1235"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2457"/>
+        <source>DingTalk Notification Enabled</source>
+        <translation>釘釘通知已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1237"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2459"/>
+        <source>DingTalk Notification Disabled</source>
+        <translation>釘釘通知已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1240"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1251"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1262"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1274"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1286"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1299"/>
+        <source>Modify</source>
+        <translation>修改</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1242"/>
+        <source>DingTalk</source>
+        <translation>釘釘</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1247"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2463"/>
+        <source>Lark Notification Enabled</source>
+        <translation>飛書通知已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1249"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2465"/>
+        <source>Lark Notification Disabled</source>
+        <translation>飛書通知已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1253"/>
+        <source>Lark</source>
+        <translation>飛書</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1258"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2469"/>
+        <source>SMTP Notification Enabled</source>
+        <translation>SMTP 通知已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1260"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2471"/>
+        <source>SMTP Notification Disabled</source>
+        <translation>SMTP 通知已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1264"/>
+        <source>SMTP</source>
+        <translation>SMTP</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1269"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2475"/>
+        <source>WxPusher Notification Enabled</source>
+        <translation>WxPusher 通知已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1271"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2477"/>
+        <source>WxPusher Notification Disabled</source>
+        <translation>WxPusher 通知已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1276"/>
+        <source>WxPusher</source>
+        <translation>WxPusher</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1281"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2481"/>
+        <source>QYWX Notification Enabled</source>
+        <translation>QYWX 通知已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1283"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2483"/>
+        <source>QYWX Notification Disabled</source>
+        <translation>QYWX 通知已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1288"/>
+        <source>QYWX</source>
+        <translation>QYWX</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1294"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2487"/>
+        <source>Gotify Notification Enabled</source>
+        <translation>Gotify 通知已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1296"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2489"/>
+        <source>Gotify Notification Disabled</source>
+        <translation>Gotify 通知已停用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1301"/>
+        <source>Gotify</source>
+        <translation>Gotify</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1317"/>
+        <source>Send Format</source>
+        <translation>傳送格式</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1318"/>
+        <source>Plain text or HTML for external notifications (e.g. email body)</source>
+        <translation>外部通知的純文字或 HTML（例如電子郵件內文）</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1319"/>
+        <source>Plain text</source>
+        <translation>純文字</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1319"/>
+        <source>HTML</source>
+        <translation>HTML</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1327"/>
+        <source>Attach screenshot to notice</source>
+        <translation>附加螢幕截圖至通知</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1329"/>
+        <source>When enabled, a screenshot is captured and sent with notifications (e.g. as email attachment) if controller is available</source>
+        <translation>啟用時，若控制器可用，將擷取螢幕截圖並隨通知傳送（例如作為電子郵件附件）</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1338"/>
+        <source>Configure</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1340"/>
+        <source>Notification Timing</source>
+        <translation>通知時機</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1341"/>
+        <source>Configure when to send notifications</source>
+        <translation>設定傳送通知的時機</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1351"/>
+        <source>Task Settings</source>
+        <translation>任務設定</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1356"/>
+        <source>Monitor capture rate</source>
+        <translation>監控截圖速率</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1358"/>
+        <source>Screenshot frames per second for the monitoring preview (uses a separate controller connection based on your controller settings)</source>
+        <translation>監控預覽每秒截圖幀數，依主設定的控制器類型建立獨立連線</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1373"/>
+        <source>Recognition ROI overlay</source>
+        <translation>識別框疊加</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1375"/>
+        <source>Draw recognition hit boxes on the monitoring preview during tasks. This feature consumes significant system resources.</source>
+        <translation>任務執行時在監控預覽上繪製識別命中框。本功能會占用大量系統資源。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1385"/>
+        <source>GPU Acceleration</source>
+        <translation>GPU 硬體加速</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1386"/>
+        <source>Enable GPU hardware acceleration for resource inference</source>
+        <translation>為資源推理啟用 GPU 硬體加速</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1396"/>
+        <source>Reset task page layout</source>
+        <translation>重設任務頁面佈局</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1398"/>
+        <source>Restore the task, option, and log columns to equal width (1:1:1)</source>
+        <translation>將任務、選項和日誌欄恢復為等寬（1:1:1）</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1417"/>
+        <source>mirrorchyan CDK</source>
+        <translation>mirrorchyan CDK</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1418"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1611"/>
+        <source>Enter mirrorchyan CDK for stable update path</source>
+        <translation>輸入 mirrorchyan CDK 以獲取穩定更新路徑</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1420"/>
+        <source>About Mirror</source>
+        <translation>關於 Mirror</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1426"/>
+        <source>Automatically update after startup</source>
+        <translation>啟動後自動更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1427"/>
+        <source>Automatically download and apply updates once available</source>
+        <translation>自動下載並套用可用更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1436"/>
+        <source>select update channel for resource</source>
+        <translation>選擇資源更新頻道</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1437"/>
+        <source>select the update channel for the resource</source>
+        <translation>選擇資源的更新頻道</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1444"/>
+        <source>Force use GitHub</source>
+        <translation>強制使用 GitHub</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1445"/>
+        <source>Force use GitHub for resource update</source>
+        <translation>強制使用 GitHub 進行資源更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1394"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1451"/>
+        <source>Reset</source>
+        <translation>重設</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1453"/>
+        <source>Reset resource</source>
+        <translation>重設資源</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1454"/>
+        <source>Redownload resource package without version/tag check</source>
+        <translation>重新下載資源套件，不檢查版本/標籤</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1460"/>
+        <source>GitHub API Key</source>
+        <translation>GitHub API 金鑰</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1462"/>
+        <source>Personal access tokens increase GitHub API rate limits for update checks.</source>
+        <translation>個人存取權杖可提高 GitHub API 的更新檢查速率限制。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1469"/>
+        <source>Optional token for authenticated GitHub requests</source>
+        <translation>用於 GitHub 認證請求的選用權杖</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1478"/>
+        <source>Use Proxy</source>
+        <translation>使用代理伺服器</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1480"/>
+        <source>After filling in the proxy settings, all traffic except that to the Mirror will be proxied.</source>
+        <translation>填寫代理伺服器設定後，除鏡像站外的所有流量都將透過代理伺服器傳送。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1504"/>
+        <source>Experimental / Compatibility</source>
+        <translation>實驗性 / 相容性</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1508"/>
+        <source>Multi-instance mode</source>
+        <translation>多實例模式</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1510"/>
+        <source>Experimental. Allow multiple configurations to run at the same time, each with its own start/stop control, log, and monitor. When off, switching the active configuration is blocked while a task is running.</source>
+        <translation>實驗性功能。允許多個配置同時執行，每個配置有獨立的啟動/停止控制、日誌和監控。關閉後，任務執行期間將禁止切換使用中配置。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1519"/>
+        <source>Multi-resource adaptation</source>
+        <translation>多資源適配</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1521"/>
+        <source>Experimental. Enable loading multiple resource bundles; may impact stability.</source>
+        <translation>實驗性功能。啟用載入多個資源套件；可能影響穩定性。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1529"/>
+        <source>Save screenshot</source>
+        <translation>儲存螢幕截圖</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1530"/>
+        <source>Save a screenshot when experimental features run</source>
+        <translation>實驗性功能執行時儲存螢幕截圖</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1537"/>
+        <source>Include images in log zip</source>
+        <translation>在日誌壓縮檔中包含圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1539"/>
+        <source>Include log images when generating log zip package. The number of images included equals the number displayed in the log interface.</source>
+        <translation>生成日誌壓縮套件時包含日誌圖片。包含的圖片數量等於日誌介面中顯示的數量。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1557"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2443"/>
+        <source>Set cache image count, current cache usage: {}</source>
+        <translation>設定快取圖片數量，目前快取使用量：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1562"/>
+        <source>Max log images</source>
+        <translation>最大日誌圖片數量</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1617"/>
+        <source>Resource does not support Mirrorchyan, right-click about mirror to unlock input</source>
+        <translation>資源不支援 Mirrorchyan，請右鍵點擊關於鏡像以解鎖輸入</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1640"/>
+        <source>decrypt Mirror CDK failed, please fill in again and save.</source>
+        <translation>解密 Mirror CDK 失敗，請重新填寫並儲存。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1671"/>
+        <source>Failed to save Mirror CDK: {}</source>
+        <translation>儲存 Mirror CDK 失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1690"/>
+        <source>Failed to read GitHub token, please save it again.</source>
+        <translation>無法讀取 GitHub token，請重新儲存。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1715"/>
+        <source>Failed to save GitHub token: {}.</source>
+        <translation>儲存 GitHub token 失敗：{}。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1750"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1806"/>
+        <source>Current version: </source>
+        <translation>目前版本：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1753"/>
+        <source>Latest version: </source>
+        <translation>最新版本：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1756"/>
+        <source>UI version: </source>
+        <translation>介面版本：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1759"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1809"/>
+        <source>MaaFW version: </source>
+        <translation>MaaFW 版本：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1776"/>
+        <source>MFW-ChainFlow Assistant</source>
+        <translation>MFW-ChainFlow 助手</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1789"/>
+        <source>MFW-ChainFlow Assistant provides a visual orchestrator for MaaFramework users, covering configuration management, scheduling, notifications and custom extensions.</source>
+        <translation>MFW-ChainFlow 助手為 MaaFramework 使用者提供視覺化流程編排工具，涵蓋配置管理、排程、通知及自訂擴充功能。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1883"/>
+        <source>Select background image</source>
+        <translation>選擇背景圖片</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1885"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="1903"/>
+        <source>Images (*.png *.jpg *.jpeg *.bmp *.webp)</source>
+        <translation>圖片 (*.png *.jpg *.jpeg *.bmp *.webp)</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1901"/>
+        <source>Select home cover image</source>
+        <translation>選擇首頁封面圖</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="1920"/>
+        <source>UI update feature is not implemented yet.</source>
+        <translation>介面更新功能尚未實作。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2292"/>
+        <source>Enable multi-resource adaptation?</source>
+        <translation>啟用多資源適配？</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2296"/>
+        <source>After enabling the multi-configuration feature, the resource directories will be reconfigured. This operation is irreversible; please proceed with caution.</source>
+        <translation>啟用多配置功能後，資源目錄將重新配置。此操作不可逆，請謹慎進行。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2309"/>
+        <source>Enable</source>
+        <translation>啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2311"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3089"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2358"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2377"/>
+        <source>Image file does not exist</source>
+        <translation>圖片檔案不存在</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2544"/>
+        <source>Configuration takes effect after restart</source>
+        <translation>配置需重新啟動後生效</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2657"/>
+        <source>Auto update is disabled for CI/Alpha resource versions. Please update manually.</source>
+        <translation>CI/Alpha 資源版本已停用自動更新，請手動更新。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2741"/>
+        <source>Update failed too many times, local update package has been cleared.</source>
+        <translation>更新失敗次數過多，本地更新套件已清除。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2817"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2860"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2910"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="2961"/>
+        <source>Stop update</source>
+        <translation>停止更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2881"/>
+        <source>New version available: </source>
+        <translation>有新版本可用：</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2942"/>
+        <source>Task page layout has been reset</source>
+        <translation>任務頁面佈局已重設</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2949"/>
+        <source>Update is already running</source>
+        <translation>更新已在進行中</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2955"/>
+        <source>Service is not ready, cannot reset resource</source>
+        <translation>服務未就緒，無法重置資源</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="2966"/>
+        <source>Starting Reset Resource</source>
+        <translation>正在開始重置資源</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3016"/>
+        <source>Failed to rename updater: {}</source>
+        <translation>重新命名更新程式失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3028"/>
+        <location filename="../view/setting_interface/setting_interface.py" line="3161"/>
+        <source>Failed to start updater: {}</source>
+        <translation>啟動更新程式失敗：{}</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3071"/>
+        <source>Update package not found, please try updating again.</source>
+        <translation>未找到更新套件，請嘗試重新更新。</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3088"/>
+        <source>Update now</source>
+        <translation>立即更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3092"/>
+        <source>Restart required to update</source>
+        <translation>需重新啟動以完成更新</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3094"/>
+        <source>Update package detected</source>
+        <translation>偵測到更新套件</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3097"/>
+        <source>Hot update is unavailable. A restart update is required. Proceed?</source>
+        <translation>熱更新不可用。需要重新啟動更新。是否繼續？</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3100"/>
+        <source>Found a downloaded update package. Do you want to launch the updater now?</source>
+        <translation>發現已下載的更新套件。是否要立即啟動更新程式？</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/setting_interface.py" line="3123"/>
+        <source>Auto updating in %1 s</source>
+        <translation>自動更新於 %1 秒後</translation>
+    </message>
+</context>
+<context>
+    <name>SpeedrunConfigWidget</name>
+    <message>
+        <source>Speedrun Configuration</source>
+        <translation type="vanished">快速執行設定</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="80"/>
+        <source>Daily</source>
+        <translation>每日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="81"/>
+        <source>Weekly</source>
+        <translation>每週</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="82"/>
+        <source>Monthly</source>
+        <translation>每月</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation type="vanished">模式</translation>
+    </message>
+    <message>
+        <source>Refresh Hour</source>
+        <translation type="vanished">更新時間</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="169"/>
+        <source>Monday</source>
+        <translation>星期一</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="170"/>
+        <source>Tuesday</source>
+        <translation>星期二</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="171"/>
+        <source>Wednesday</source>
+        <translation>星期三</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="172"/>
+        <source>Thursday</source>
+        <translation>星期四</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="173"/>
+        <source>Friday</source>
+        <translation>星期五</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="174"/>
+        <source>Saturday</source>
+        <translation>星期六</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="175"/>
+        <source>Sunday</source>
+        <translation>星期日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="64"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="86"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="107"/>
+        <source>Weekday</source>
+        <translation>工作日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="37"/>
+        <source>Condition Execution</source>
+        <translation>條件執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="53"/>
+        <source>Condition</source>
+        <translation>條件</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="62"/>
+        <source>Always</source>
+        <translation>總是</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="63"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="97"/>
+        <source>Run Count</source>
+        <translation>執行次數</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="65"/>
+        <source>Month Day</source>
+        <translation>月份日期</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="66"/>
+        <source>After Time</source>
+        <translation>時間之後</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="67"/>
+        <source>Condition Type</source>
+        <translation>條件類型</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="70"/>
+        <source>Condition Configuration</source>
+        <translation>條件配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="83"/>
+        <source>Period</source>
+        <translation>週期</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="92"/>
+        <source>Refresh Timeline</source>
+        <translation>重新整理時間軸</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="89"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="115"/>
+        <source>Day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="123"/>
+        <source>Hour</source>
+        <translation>小時</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="130"/>
+        <source>Execution</source>
+        <translation>執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="139"/>
+        <source>Run</source>
+        <translation>執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="140"/>
+        <source>Skip</source>
+        <translation>跳過</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="141"/>
+        <source>Execution Type</source>
+        <translation>執行類型</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="144"/>
+        <source>Execution Configuration</source>
+        <translation>執行配置</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="152"/>
+        <source>Notify</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="157"/>
+        <source>External Notify</source>
+        <translation>外部通知</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="vanished">一般</translation>
+    </message>
+    <message>
+        <source>Refresh Count</source>
+        <translation type="vanished">更新次數</translation>
+    </message>
+    <message>
+        <source>Min Interval (hours)</source>
+        <translation type="vanished">最小間隔（小時）</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="150"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="155"/>
+        <source>Enabled</source>
+        <translation>已啟用</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="151"/>
+        <location filename="../view/task_interface/components/option_framework/speedrun_config_widget.py" line="156"/>
+        <source>Disabled</source>
+        <translation>已停用</translation>
+    </message>
+    <message>
+        <source>Enable Speedrun</source>
+        <translation type="vanished">啟用快速執行</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="vanished">N/A</translation>
+    </message>
+    <message>
+        <source>Current Count</source>
+        <translation type="vanished">目前計數</translation>
+    </message>
+    <message>
+        <source>Last Run Time</source>
+        <translation type="vanished">上次執行時間</translation>
+    </message>
+</context>
+<context>
+    <name>StartBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/start_bar_widget.py" line="30"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+</context>
+<context>
+    <name>StartupDialogManager</name>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="303"/>
+        <source>Missing Runtime Library</source>
+        <translation>缺少執行階段程式庫</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="305"/>
+        <source>Failed to load MAA framework library.
 
 Microsoft Visual C++ Redistributable runtime library is missing.
 
 Current system: {platform}
 
 Please download and install Visual C++ Redistributable, then restart the program.</source>
-            <translation>載入 MAA 框架程式庫失敗。
+        <translation>載入 MAA 框架程式庫失敗。
 
 缺少 Microsoft Visual C++ Redistributable 執行階段程式庫。
 
 目前系統：{platform}
 
 請下載並安裝 Visual C++ Redistributable，然後重新啟動程式。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="312" />
-            <source>Open Download Page</source>
-            <translation>開啟下載頁面</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="317" />
-            <location filename="../utils/startup_dialog.py" line="539" />
-            <source>Exit</source>
-            <translation>結束</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="336" />
-            <source>Program Already Running</source>
-            <translation>程式已在執行中</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="338" />
-            <source>The program is already running.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="312"/>
+        <source>Open Download Page</source>
+        <translation>開啟下載頁面</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="317"/>
+        <location filename="../utils/startup_dialog.py" line="539"/>
+        <source>Exit</source>
+        <translation>結束</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="336"/>
+        <source>Program Already Running</source>
+        <translation>程式已在執行中</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="338"/>
+        <source>The program is already running.
 
 Please close the existing window or terminate the process in Task Manager before starting again.</source>
-            <translation>程式已在執行中。
+        <translation>程式已在執行中。
 
 請關閉現有視窗或在工作管理員中終止程序，然後再重新啟動。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="343" />
-            <location filename="../utils/startup_dialog.py" line="373" />
-            <location filename="../utils/startup_dialog.py" line="388" />
-            <location filename="../utils/startup_dialog.py" line="581" />
-            <source>OK</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <source>关闭失败</source>
-            <translation type="vanished">關閉失敗</translation>
-        </message>
-        <message>
-            <source>无法在 30 秒内关闭正在运行的实例，请手动关闭后重试。</source>
-            <translation type="vanished">無法在 30 秒內關閉正在執行的實例，請手動關閉後重試。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="368" />
-            <source>The existing instance did not respond and could not be closed automatically.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="343"/>
+        <location filename="../utils/startup_dialog.py" line="373"/>
+        <location filename="../utils/startup_dialog.py" line="388"/>
+        <location filename="../utils/startup_dialog.py" line="581"/>
+        <source>OK</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>关闭失败</source>
+        <translation type="vanished">關閉失敗</translation>
+    </message>
+    <message>
+        <source>无法在 30 秒内关闭正在运行的实例，请手动关闭后重试。</source>
+        <translation type="vanished">無法在 30 秒內關閉正在執行的實例，請手動關閉後重試。</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="368"/>
+        <source>The existing instance did not respond and could not be closed automatically.
 
 Please end the process in Task Manager, then start the program again.</source>
-            <translation>現有實例沒有回應，無法自動關閉。
+        <translation>現有實例沒有回應，無法自動關閉。
 
 請在任務管理器中結束該程序，然後重新啟動。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="379" />
-            <source>The existing instance did not respond and could not be closed automatically.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="379"/>
+        <source>The existing instance did not respond and could not be closed automatically.
 
 Please try one of the following:
 • End the process in Task Manager
-• Right-click the program and choose "Run as administrator"
+• Right-click the program and choose &quot;Run as administrator&quot;
 
 If the existing instance was started with administrator privileges, you must also run as administrator to replace it.</source>
-            <translation>現有實例沒有回應，無法自動關閉。
+        <translation>現有實例沒有回應，無法自動關閉。
 
 請嘗試以下其中一種方法：
 • 在任務管理器中結束該程序
 • 右鍵點擊該程序並選擇「以系統管理員身分執行」
 
 如果現有實例是以系統管理員權限啟動的，您也必須以系統管理員身分執行才能取代它。</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="395" />
-            <source>Run as administrator</source>
-            <translation>以系統管理員身分執行</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="403" />
-            <source>Unable to Start Program</source>
-            <translation>無法啟動程式</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="433" />
-            <source>正在关闭</source>
-            <translation>正在關閉</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="434" />
-            <source>检测到其他任务正在运行，正在关闭中...</source>
-            <translation>偵測到其他任務正在執行，正在關閉中...</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="485" />
-            <source>Program Error</source>
-            <translation>程式錯誤</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="487" />
-            <source>The program encountered an unhandled exception.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="395"/>
+        <source>Run as administrator</source>
+        <translation>以系統管理員身分執行</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="403"/>
+        <source>Unable to Start Program</source>
+        <translation>無法啟動程式</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="433"/>
+        <source>正在关闭</source>
+        <translation>正在關閉</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="434"/>
+        <source>检测到其他任务正在运行，正在关闭中...</source>
+        <translation>偵測到其他任務正在執行，正在關閉中...</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="485"/>
+        <source>Program Error</source>
+        <translation>程式錯誤</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="487"/>
+        <source>The program encountered an unhandled exception.
 
 Error type: {exc_type}
 Error message: {exc_value}
 
 Below is the detailed stack trace. You can copy it and report to the developer:</source>
-            <translation>程式遇到未處理的例外狀況。
+        <translation>程式遇到未處理的例外狀況。
 
 錯誤類型：{exc_type}
 錯誤訊息：{exc_value}
 
 以下是詳細的堆疊追蹤。您可以複製並回報給開發者：</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="495" />
-            <location filename="../utils/startup_dialog.py" line="534" />
-            <source>Copy Error Info</source>
-            <translation>複製錯誤資訊</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="500" />
-            <source>Continue</source>
-            <translation>繼續</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="524" />
-            <source>Program Failed to Start</source>
-            <translation>程式啟動失敗</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="526" />
-            <source>The program failed during startup and could not continue.
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="495"/>
+        <location filename="../utils/startup_dialog.py" line="534"/>
+        <source>Copy Error Info</source>
+        <translation>複製錯誤資訊</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="500"/>
+        <source>Continue</source>
+        <translation>繼續</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="524"/>
+        <source>Program Failed to Start</source>
+        <translation>程式啟動失敗</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="526"/>
+        <source>The program failed during startup and could not continue.
 
 Error type: {exc_type}
 Error message: {exc_value}
 
 You can copy the detailed stack trace below and report it to the developer.</source>
-            <translation>程式在啟動過程中失敗，無法繼續。
+        <translation>程式在啟動過程中失敗，無法繼續。
 
 錯誤類型：{exc_type}
 錯誤訊息：{exc_value}
 
 您可以複製下方的詳細堆疊追蹤並回報給開發者。</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskDragListWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_widget.py" line="724" />
-            <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
-            <translation>基礎任務（資源、後置任務）無法刪除（ID：{id}）</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskFlowRunner</name>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="346" />
-            <source>Resource or controller not initialized</source>
-            <translation>資源或控制器未初始化</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="348" />
-            <source>Agent connection failed</source>
-            <translation>代理連線失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="355" />
-            <source>Agent connection timed out ({}s)</source>
-            <translation>MAA Agent 服務連線逾時（{} 秒）</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="357" />
-            <source>Agent configuration is missing</source>
-            <translation>缺少 Agent 設定</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="359" />
-            <source>Agent configuration list is empty</source>
-            <translation>Agent 設定清單為空</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="361" />
-            <source>Agent configuration is invalid</source>
-            <translation>Agent 設定無效</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="363" />
-            <source>Agent child_exec is missing</source>
-            <translation>Agent 缺少 child_exec 設定</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="365" />
-            <source>Failed to start agent process</source>
-            <translation>Agent 程序啟動失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="367" />
-            <source>Tasker not initialized</source>
-            <translation>任務器未初始化</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="369" />
-            <location filename="../core/runner/task_flow.py" line="374" />
-            <source>Unknown MaaFW error code: {}</source>
-            <translation>未知的 MaaFW 錯誤代碼：{}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="422" />
-            <source>Task Flow Started</source>
-            <translation>任務流程已開始</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="423" />
-            <source>Task flow has been started.</source>
-            <translation>任務流程已開始。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="517" />
-            <source>Controller or resource in current config does not exist in interface. They have been reset to default. Please check and run again.</source>
-            <translation>目前設定中的控制器或資源在介面中不存在。它們已重設為預設值。請檢查並重新執行。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="526" />
-            <source>Starting to load resources...</source>
-            <translation>開始載入資源...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="577" />
-            <source>Embedded Agent prepare failed: </source>
-            <translation>嵌入式代理準備失敗：</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="578" />
-            <source>Unknown reason</source>
-            <translation>未知原因</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="597" />
-            <source>Agent Service Start</source>
-            <translation>代理服務啟動</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="606" />
-            <source>Starting to load custom components...</source>
-            <translation>開始載入自訂元件...</translation>
-        </message>
-        <message>
-            <source>Custom components loading failed, the flow is terminated: </source>
-            <translation type="vanished">自訂元件載入失敗，流程已終止：</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="657" />
-            <location filename="../core/runner/task_flow.py" line="1505" />
-            <location filename="../core/runner/task_flow.py" line="1536" />
-            <source>please try to reset resource in setting</source>
-            <translation>請嘗試在設定中重設資源</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="667" />
-            <source>Embedded aspect ratio checker failed to load, the flow is terminated.</source>
-            <translation>內嵌長寬比檢查器載入失敗，流程已終止。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="698" />
-            <source>Starting to connect device...</source>
-            <translation>開始連接裝置...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="713" />
-            <source>Device Connection Failed</source>
-            <translation>裝置連接失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="715" />
-            <source>Failed to connect to the device.</source>
-            <translation>無法連接到裝置。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="718" />
-            <location filename="../core/runner/task_flow.py" line="2953" />
-            <location filename="../core/runner/task_flow.py" line="2965" />
-            <source>Device connected successfully</source>
-            <translation>裝置已成功連接</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="723" />
-            <source>Device Connected Successfully</source>
-            <translation>裝置連接成功</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="724" />
-            <source>Device has been connected successfully.</source>
-            <translation>裝置已成功連接。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="775" />
-            <location filename="../core/runner/task_flow.py" line="798" />
-            <location filename="../core/runner/task_flow.py" line="827" />
-            <location filename="../core/runner/task_flow.py" line="1638" />
-            <source>Task Failed</source>
-            <translation>任務失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="777" />
-            <source>Task '{}' failed and the flow was terminated.</source>
-            <translation>任務「{}」失敗，流程已終止。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="799" />
-            <source>Task '{}' was aborted.</source>
-            <translation>任務「{}」已中止。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="811" />
-            <source>Task Completed</source>
-            <translation>任務完成</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="813" />
-            <source>Task '{}' has been completed successfully.</source>
-            <translation>任務「{}」已成功完成。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="828" />
-            <source>Task '{}' failed with error: {}</source>
-            <translation>任務「{}」失敗，錯誤：{}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="844" />
-            <source>All tasks have been completed</source>
-            <translation>所有任務已完成</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="849" />
-            <source>Task flow error: </source>
-            <translation>任務流程錯誤：</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="901" />
-            <source>Task Flow Completed</source>
-            <translation>任務流程完成</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1015" />
-            <source>INFO</source>
-            <translation>資訊</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1016" />
-            <source>WARNING</source>
-            <translation>警告</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1017" />
-            <source>ERROR</source>
-            <translation>錯誤</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1018" />
-            <source>CRITICAL</source>
-            <translation>嚴重</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1039" />
-            <source>Base controller/resource task is missing.</source>
-            <translation>基礎控制器/資源任務遺失。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1060" />
-            <source>Current controller does not exist in interface: {}</source>
-            <translation>目前控制器不存在於介面：{}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1061" />
-            <location filename="../core/runner/task_flow.py" line="1066" />
-            <location filename="../core/runner/task_flow.py" line="1077" />
-            <location filename="../core/runner/task_flow.py" line="1078" />
-            <source>(empty)</source>
-            <translation>(空白)</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1065" />
-            <source>Current resource does not exist in interface: {}</source>
-            <translation>目前資源不存在於介面中：{}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1075" />
-            <source>Current resource is not enabled for current controller: {} -&gt; {}</source>
-            <translation>目前資源未對當前控制器啟用：{} -&gt; {}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1274" />
-            <source>Controller name is empty, please configure controller in settings</source>
-            <translation>控制器名稱為空，請在設定中配置控制器</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1293" />
-            <location filename="../core/runner/task_flow.py" line="1466" />
-            <source>Controller '{}' not found, please reset controller in settings</source>
-            <translation>控制器「{}」未找到，請在設定中重置控制器</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1373" />
-            <source>this Controller requires admin permission to run</source>
-            <translation>此控制器需要管理員權限才能執行</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1388" />
-            <source>Controller configuration is invalid, please reset controller in settings</source>
-            <translation>控制器配置無效，請在設定中重置控制器</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1456" />
-            <source>Controller config not found, please configure controller first</source>
-            <translation>控制器配置未找到，請先配置控制器</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1482" />
-            <source>Resource target is empty, please configure resource in settings</source>
-            <translation>資源目標為空，請在設定中配置資源</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1500" />
-            <source>Resource '{}' not found, please reset resource in settings</source>
-            <translation>資源「{}」未找到，請在設定中重置資源</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1530" />
-            <source>Resource </source>
-            <translation>資源</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1532" />
-            <source> not found in bundle: </source>
-            <translation>在套件中未找到：</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1599" />
-            <source>Task </source>
-            <translation>任務</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1601" />
-            <source> follows speedrun limit, skipping this run: </source>
-            <translation>遵循速通限制，跳過此執行：</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1639" />
-            <source>Task '{}' execution failed.</source>
-            <translation>任務「{}」執行失敗。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1665" />
-            <source>Builtin task failed: </source>
-            <translation>內建任務失敗：</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1752" />
-            <source>Stopping task...</source>
-            <translation>正在停止任務...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1779" />
-            <location filename="../core/runner/task_flow.py" line="1862" />
-            <source>Unknown Task Entry</source>
-            <translation>未知任務項目</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1868" />
-            <source>{} hours {} minutes</source>
-            <translation>{}小時{}分鐘</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1870" />
-            <source>{} minutes</source>
-            <translation>{}分鐘</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1873" />
-            <source>Task entry '{}' has been running for {}. This may indicate a problem. Please check the task status.</source>
-            <translation>任務項目「{}」已執行{}。這可能表示有問題。請檢查任務狀態。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1887" />
-            <source>Task running time too long</source>
-            <translation>任務執行時間過長</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1941" />
-            <source>Auto searching ADB devices...</source>
-            <translation>正在自動搜尋ADB裝置...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2395" />
-            <source>WlRoots controller is only supported on Linux</source>
-            <translation>WlRoots 控制器僅支援 Linux</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2426" />
-            <source>WlRoots Wayland socket path is empty, please configure it in settings</source>
-            <translation>WlRoots Wayland 通訊端路徑為空，請在設定中配置</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2443" />
-            <source>Connecting to WlRoots: {socket}</source>
-            <translation>正在連接到 WlRoots：{socket}</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2448" />
-            <source>WlRoots connected successfully</source>
-            <translation>WlRoots 連接成功</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2452" />
-            <source>Failed to connect to WlRoots</source>
-            <translation>連接 WlRoots 失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2458" />
-            <source>MacOS controller is only supported on macOS</source>
-            <translation>MacOS 控制器僅支援 macOS</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2521" />
-            <source>Auto searching MacOS windows...</source>
-            <translation>正在自動搜尋 MacOS 視窗...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2532" />
-            <source>Window ID is empty, please configure window connection in settings</source>
-            <translation>視窗 ID 為空，請在設定中配置視窗連接</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2687" />
-            <source>ADB path is empty, please configure ADB path in settings</source>
-            <translation>ADB路徑為空，請在設定中配置ADB路徑</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2706" />
-            <source>ADB connection address is empty, please configure device connection in settings</source>
-            <translation>ADB連線位址為空，請在設定中配置裝置連線</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1957" />
-            <source>try to start emulator</source>
-            <translation>嘗試啟動模擬器</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="653" />
-            <source>Custom components loading failed, the flow is terminated.</source>
-            <translation>自訂元件載入失敗，流程已終止。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1967" />
-            <source>waiting for emulator start...</source>
-            <translation>等待模擬器啟動中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="1997" />
-            <location filename="../core/runner/task_flow.py" line="2111" />
-            <location filename="../core/runner/task_flow.py" line="2118" />
-            <location filename="../core/runner/task_flow.py" line="2166" />
-            <location filename="../core/runner/task_flow.py" line="2254" />
-            <location filename="../core/runner/task_flow.py" line="2261" />
-            <location filename="../core/runner/task_flow.py" line="2304" />
-            <location filename="../core/runner/task_flow.py" line="2546" />
-            <location filename="../core/runner/task_flow.py" line="2552" />
-            <location filename="../core/runner/task_flow.py" line="2597" />
-            <source>Device connection failed</source>
-            <translation>裝置連線失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2004" />
-            <source>Win32 controller is only supported on Windows</source>
-            <translation>Win32 控制器僅支援在 Windows 上使用</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2080" />
-            <source>Auto searching Win32 windows...</source>
-            <translation>自動搜尋 Win32 視窗中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2093" />
-            <location filename="../core/runner/task_flow.py" line="2240" />
-            <source>Window handle (hwnd) is empty, please configure window connection in settings</source>
-            <translation>視窗控制代碼 (hwnd) 為空，請在設定中配置視窗連線</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2126" />
-            <location filename="../core/runner/task_flow.py" line="2268" />
-            <location filename="../core/runner/task_flow.py" line="2559" />
-            <source>try to start program</source>
-            <translation>嘗試啟動程式</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2154" />
-            <location filename="../core/runner/task_flow.py" line="2292" />
-            <location filename="../core/runner/task_flow.py" line="2585" />
-            <source>waiting for program start...</source>
-            <translation>等待程式啟動中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2173" />
-            <source>Gamepad controller is only supported on Windows</source>
-            <translation>遊戲手把控制器僅支援在 Windows 上使用</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2230" />
-            <source>Auto searching desktop windows...</source>
-            <translation>自動搜尋桌面視窗中...</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2311" />
-            <source>PlayCover controller is only supported on macOS</source>
-            <translation>PlayCover 控制器僅支援在 macOS 上使用</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2349" />
-            <source>PlayCover UUID is empty, please configure UUID in settings</source>
-            <translation>PlayCover UUID 為空，請在設定中配置 UUID</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2361" />
-            <source>PlayCover connection address is empty, please configure address in settings</source>
-            <translation>PlayCover 連線位址為空，請在設定中配置位址</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2374" />
-            <source>Connecting to PlayCover: {address} (UUID: {uuid})</source>
-            <translation>正在連線至 PlayCover: {address} (UUID: {uuid})</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2383" />
-            <source>PlayCover connected successfully</source>
-            <translation>PlayCover 連線成功</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2387" />
-            <source>Failed to connect to PlayCover</source>
-            <translation>連線至 PlayCover 失敗</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2715" />
-            <source>ADB connection port is empty; use host:port (for example 127.0.0.1:5555) or pick a device after starting the emulator.</source>
-            <translation>ADB 連接埠為空；請使用 host:port 格式（例如 127.0.0.1:5555），或啟動模擬器後選擇裝置。</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="2942" />
-            <location filename="../core/runner/task_flow.py" line="2989" />
-            <source> seconds</source>
-            <translation> 秒</translation>
-        </message>
-        <message>
-            <location filename="../core/runner/task_flow.py" line="3386" />
-            <source>Notifications are being sent, please wait up to {} seconds</source>
-            <translation>通知正在發送中，請等待最多 {} 秒</translation>
-        </message>
-        <message>
-            <source>This period's remaining execution count is 0</source>
-            <translation type="vanished">本週期剩餘執行次數為 0</translation>
-        </message>
-        <message>
-            <source>Not enough time passed since last run. Minimum interval is </source>
-            <translation type="vanished">距離上次執行時間不足。最小間隔為 </translation>
-        </message>
-        <message>
-            <source> hours.</source>
-            <translation type="vanished"> 小時。</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskInterface</name>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="28" />
-            <source>Task Information</source>
-            <translation>任務資訊</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="29" />
-            <source>Configuration Selection</source>
-            <translation>配置選擇</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="112" />
-            <location filename="../view/task_interface/task_interface_logic.py" line="147" />
-            <source>Start</source>
-            <translation>開始</translation>
-        </message>
-        <message>
-            <source>Please select a special task to run.</source>
-            <translation type="vanished">請選擇要執行的特殊任務。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/task_interface_logic.py" line="142" />
-            <source>Stop</source>
-            <translation>停止</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskListItem</name>
-        <message>
-            <source>Launch Program</source>
-            <translation type="vanished">啟動程式</translation>
-        </message>
-        <message>
-            <source>Wait</source>
-            <translation type="vanished">等待</translation>
-        </message>
-        <message>
-            <source>Wait Until</source>
-            <translation type="vanished">定時等待</translation>
-        </message>
-        <message>
-            <source>System Notification</source>
-            <translation type="vanished">系統通知</translation>
-        </message>
-        <message>
-            <source>External Notification</source>
-            <translation type="vanished">外部通知</translation>
-        </message>
-        <message>
-            <source>Yes</source>
-            <translation type="vanished">是</translation>
-        </message>
-        <message>
-            <source>No</source>
-            <translation type="vanished">否</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="409" />
-            <source>Resource</source>
-            <translation>資源</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="411" />
-            <source>Controller</source>
-            <translation>控制器</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="413" />
-            <source>Post-Action</source>
-            <translation>後續動作</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="677" />
-            <source>Run this task</source>
-            <translation>執行此任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="685" />
-            <source>Run from here</source>
-            <translation>從此處開始執行</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="693" />
-            <source>Insert task</source>
-            <translation>插入任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="734" />
-            <source>No available tasks to add.</source>
-            <translation>無可用任務可新增。</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="871" />
-            <source>Delete task</source>
-            <translation>刪除任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="888" />
-            <source>Delete Task</source>
-            <translation>刪除任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_item.py" line="889" />
-            <source>Are you sure you want to delete task '{}'?</source>
-            <translation>確定要刪除任務「{}」嗎？</translation>
-        </message>
-    </context>
-    <context>
-        <name>TaskListToolBarWidget</name>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="303" />
-            <source>Tasks</source>
-            <translation>任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="335" />
-            <source>No available tasks to add.</source>
-            <translation>無可用任務可新增。</translation>
-        </message>
-        <message>
-            <source>Switch to Normal Tasks</source>
-            <translation type="vanished">切換至一般任務</translation>
-        </message>
-        <message>
-            <source>Special Tasks</source>
-            <translation type="vanished">特殊任務</translation>
-        </message>
-        <message>
-            <source>Switch to Special Tasks</source>
-            <translation type="vanished">切換至特殊任務</translation>
-        </message>
-        <message>
-            <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="455" />
-            <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
-            <translation>基礎任務（資源、後續任務）無法刪除（ID：{id}）</translation>
-        </message>
-    </context>
-    <context>
-        <name>Update</name>
-        <message>
-            <location filename="../utils/update.py" line="1415" />
-            <location filename="../utils/update.py" line="1508" />
-            <source>Checking for updates...</source>
-            <translation>正在檢查更新...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1233" />
-            <source>Already up to date</source>
-            <translation>已是最新版本</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1238" />
-            <location filename="../utils/update.py" line="1446" />
-            <location filename="../utils/update.py" line="1467" />
-            <location filename="../utils/update.py" line="1581" />
-            <location filename="../utils/update.py" line="1604" />
-            <source>Download failed</source>
-            <translation>下載失敗</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1440" />
-            <location filename="../utils/update.py" line="1575" />
-            <source>Preparing to download update...</source>
-            <translation>準備下載更新...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1475" />
-            <location filename="../utils/update.py" line="1612" />
-            <source>Download complete</source>
-            <translation>下載完成</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1634" />
-            <source>Applying hotfix...</source>
-            <translation>正在套用熱修復...</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1689" />
-            <source>Update applied successfully</source>
-            <translation>更新已成功套用</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1740" />
-            <source>Failed to update</source>
-            <translation>更新失敗</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1832" />
-            <location filename="../utils/update.py" line="1855" />
-            <location filename="../utils/update.py" line="1941" />
-            <location filename="../utils/update.py" line="1974" />
-            <location filename="../utils/update.py" line="2335" />
-            <location filename="../utils/update.py" line="2358" />
-            <location filename="../utils/update.py" line="2435" />
-            <location filename="../utils/update.py" line="2472" />
-            <source>Found update: </source>
-            <translation>發現更新：</translation>
-        </message>
-        <message>
-            <location filename="../utils/update.py" line="1885" />
-            <location filename="../utils/update.py" line="1896" />
-            <location filename="../utils/update.py" line="1908" />
-            <location filename="../utils/update.py" line="1919" />
-            <location filename="../utils/update.py" line="1956" />
-            <location filename="../utils/update.py" line="1963" />
-            <location filename="../utils/update.py" line="2381" />
-            <location filename="../utils/update.py" line="2390" />
-            <location filename="../utils/update.py" line="2402" />
-            <location filename="../utils/update.py" line="2413" />
-            <location filename="../utils/update.py" line="2454" />
-            <location filename="../utils/update.py" line="2461" />
-            <source>GitHub update check failed</source>
-            <translation>GitHub 更新檢查失敗</translation>
-        </message>
-    </context>
-    <context>
-        <name>WxPusherNoticeType</name>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="385" />
-            <source>WxPusher Spt:</source>
-            <translation>WxPusher Spt:</translation>
-        </message>
-        <message>
-            <location filename="../view/setting_interface/widget/notice_type.py" line="386" />
-            <source>WxPusher Status:</source>
-            <translation>WxPusher 狀態：</translation>
-        </message>
-    </context>
-    <context>
-        <name>context</name>
-        <message>
-            <source>Builtin launch program path is empty, skipped.</source>
-            <translation type="vanished">內建任務啟動程式缺少路徑，已略過。</translation>
-        </message>
-        <message>
-            <source>Builtin task waits {seconds} second(s).</source>
-            <translation type="vanished">內建任務等待 {seconds} 秒。</translation>
-        </message>
-        <message>
-            <source>Builtin wait-until target time is empty, skipped.</source>
-            <translation type="vanished">內建定時等待缺少目標時間，已略過。</translation>
-        </message>
-        <message>
-            <source>Failed to parse builtin wait-until target time: {time}</source>
-            <translation type="vanished">無法解析定時等待目標時間：{time}</translation>
-        </message>
-        <message>
-            <source>Builtin task waits until {time}.</source>
-            <translation type="vanished">內建任務等待至 {time}。</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="46" />
-            <source>$builtin_log_launch_program_path_empty</source>
-            <translation>$builtin_log_launch_program_path_empty</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="62" />
-            <source>$builtin_log_wait_duration</source>
-            <translation>$builtin_log_wait_duration</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="70" />
-            <source>$builtin_log_wait_until_empty</source>
-            <translation>$builtin_log_wait_until_empty</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="77" />
-            <source>$builtin_log_wait_until_invalid</source>
-            <translation>$builtin_log_wait_until_invalid</translation>
-        </message>
-        <message>
-            <location filename="../builtin_tasks/basic_tasks.py" line="84" />
-            <source>$builtin_log_wait_until_target</source>
-            <translation>$builtin_log_wait_until_target</translation>
-        </message>
-    </context>
-    <context>
-        <name>manager</name>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="704" />
-            <source>启动参数已弃用</source>
-            <translation>啟動參數已棄用</translation>
-        </message>
-        <message>
-            <location filename="../utils/startup_dialog.py" line="706" />
-            <source>检测到旧版命令行参数。程序已按新规则继续启动，但请尽快改用下列写法：</source>
-            <translation>偵測到舊版命令列參數。程式已依新規則繼續啟動，但請盡快改用下列寫法：</translation>
-        </message>
-    </context>
+    </message>
+</context>
+<context>
+    <name>TaskDragListWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_widget.py" line="724"/>
+        <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
+        <translation>基礎任務（資源、後置任務）無法刪除（ID：{id}）</translation>
+    </message>
+</context>
+<context>
+    <name>TaskFlowRunner</name>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="379"/>
+        <source>Resource or controller not initialized</source>
+        <translation>資源或控制器未初始化</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="381"/>
+        <source>Agent connection failed</source>
+        <translation>代理連線失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="388"/>
+        <source>Agent connection timed out ({}s)</source>
+        <translation>MAA Agent 服務連線逾時（{} 秒）</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="390"/>
+        <source>Agent configuration is missing</source>
+        <translation>缺少 Agent 設定</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="392"/>
+        <source>Agent configuration list is empty</source>
+        <translation>Agent 設定清單為空</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="394"/>
+        <source>Agent configuration is invalid</source>
+        <translation>Agent 設定無效</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="396"/>
+        <source>Agent child_exec is missing</source>
+        <translation>Agent 缺少 child_exec 設定</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="398"/>
+        <source>Failed to start agent process</source>
+        <translation>Agent 程序啟動失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="400"/>
+        <source>Tasker not initialized</source>
+        <translation>任務器未初始化</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="402"/>
+        <location filename="../core/runner/task_flow.py" line="407"/>
+        <source>Unknown MaaFW error code: {}</source>
+        <translation>未知的 MaaFW 錯誤代碼：{}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="455"/>
+        <source>Task Flow Started</source>
+        <translation>任務流程已開始</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="456"/>
+        <source>Task flow has been started.</source>
+        <translation>任務流程已開始。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="550"/>
+        <source>Controller or resource in current config does not exist in interface. They have been reset to default. Please check and run again.</source>
+        <translation>目前設定中的控制器或資源在介面中不存在。它們已重設為預設值。請檢查並重新執行。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="559"/>
+        <source>Starting to load resources...</source>
+        <translation>開始載入資源...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="610"/>
+        <source>Embedded Agent prepare failed: </source>
+        <translation>嵌入式代理準備失敗：</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="611"/>
+        <source>Unknown reason</source>
+        <translation>未知原因</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="630"/>
+        <source>Agent Service Start</source>
+        <translation>代理服務啟動</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="639"/>
+        <source>Starting to load custom components...</source>
+        <translation>開始載入自訂元件...</translation>
+    </message>
+    <message>
+        <source>Custom components loading failed, the flow is terminated: </source>
+        <translation type="vanished">自訂元件載入失敗，流程已終止：</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="697"/>
+        <location filename="../core/runner/task_flow.py" line="1522"/>
+        <location filename="../core/runner/task_flow.py" line="1553"/>
+        <source>please try to reset resource in setting</source>
+        <translation>請嘗試在設定中重設資源</translation>
+    </message>
+    <message>
+        <source>Embedded aspect ratio checker failed to load, the flow is terminated.</source>
+        <translation type="vanished">內嵌長寬比檢查器載入失敗，流程已終止。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="715"/>
+        <source>Starting to connect device...</source>
+        <translation>開始連接裝置...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="730"/>
+        <source>Device Connection Failed</source>
+        <translation>裝置連接失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="732"/>
+        <source>Failed to connect to the device.</source>
+        <translation>無法連接到裝置。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="735"/>
+        <location filename="../core/runner/task_flow.py" line="2970"/>
+        <location filename="../core/runner/task_flow.py" line="2982"/>
+        <source>Device connected successfully</source>
+        <translation>裝置已成功連接</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="740"/>
+        <source>Device Connected Successfully</source>
+        <translation>裝置連接成功</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="741"/>
+        <source>Device has been connected successfully.</source>
+        <translation>裝置已成功連接。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="792"/>
+        <location filename="../core/runner/task_flow.py" line="815"/>
+        <location filename="../core/runner/task_flow.py" line="844"/>
+        <location filename="../core/runner/task_flow.py" line="1655"/>
+        <source>Task Failed</source>
+        <translation>任務失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="794"/>
+        <source>Task &apos;{}&apos; failed and the flow was terminated.</source>
+        <translation>任務「{}」失敗，流程已終止。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="816"/>
+        <source>Task &apos;{}&apos; was aborted.</source>
+        <translation>任務「{}」已中止。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="828"/>
+        <source>Task Completed</source>
+        <translation>任務完成</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="830"/>
+        <source>Task &apos;{}&apos; has been completed successfully.</source>
+        <translation>任務「{}」已成功完成。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="845"/>
+        <source>Task &apos;{}&apos; failed with error: {}</source>
+        <translation>任務「{}」失敗，錯誤：{}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="861"/>
+        <source>All tasks have been completed</source>
+        <translation>所有任務已完成</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="866"/>
+        <source>Task flow error: </source>
+        <translation>任務流程錯誤：</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="918"/>
+        <source>Task Flow Completed</source>
+        <translation>任務流程完成</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1032"/>
+        <source>INFO</source>
+        <translation>資訊</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1033"/>
+        <source>WARNING</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1034"/>
+        <source>ERROR</source>
+        <translation>錯誤</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1035"/>
+        <source>CRITICAL</source>
+        <translation>嚴重</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1056"/>
+        <source>Base controller/resource task is missing.</source>
+        <translation>基礎控制器/資源任務遺失。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1077"/>
+        <source>Current controller does not exist in interface: {}</source>
+        <translation>目前控制器不存在於介面：{}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1078"/>
+        <location filename="../core/runner/task_flow.py" line="1083"/>
+        <location filename="../core/runner/task_flow.py" line="1094"/>
+        <location filename="../core/runner/task_flow.py" line="1095"/>
+        <source>(empty)</source>
+        <translation>(空白)</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1082"/>
+        <source>Current resource does not exist in interface: {}</source>
+        <translation>目前資源不存在於介面中：{}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1092"/>
+        <source>Current resource is not enabled for current controller: {} -&gt; {}</source>
+        <translation>目前資源未對當前控制器啟用：{} -&gt; {}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1291"/>
+        <source>Controller name is empty, please configure controller in settings</source>
+        <translation>控制器名稱為空，請在設定中配置控制器</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1310"/>
+        <location filename="../core/runner/task_flow.py" line="1483"/>
+        <source>Controller &apos;{}&apos; not found, please reset controller in settings</source>
+        <translation>控制器「{}」未找到，請在設定中重置控制器</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1390"/>
+        <source>this Controller requires admin permission to run</source>
+        <translation>此控制器需要管理員權限才能執行</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1405"/>
+        <source>Controller configuration is invalid, please reset controller in settings</source>
+        <translation>控制器配置無效，請在設定中重置控制器</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1473"/>
+        <source>Controller config not found, please configure controller first</source>
+        <translation>控制器配置未找到，請先配置控制器</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1499"/>
+        <source>Resource target is empty, please configure resource in settings</source>
+        <translation>資源目標為空，請在設定中配置資源</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1517"/>
+        <source>Resource &apos;{}&apos; not found, please reset resource in settings</source>
+        <translation>資源「{}」未找到，請在設定中重置資源</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1547"/>
+        <source>Resource </source>
+        <translation>資源</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1549"/>
+        <source> not found in bundle: </source>
+        <translation>在套件中未找到：</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1616"/>
+        <source>Task </source>
+        <translation>任務</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1618"/>
+        <source> follows speedrun limit, skipping this run: </source>
+        <translation>遵循速通限制，跳過此執行：</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1656"/>
+        <source>Task &apos;{}&apos; execution failed.</source>
+        <translation>任務「{}」執行失敗。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1682"/>
+        <source>Builtin task failed: </source>
+        <translation>內建任務失敗：</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1769"/>
+        <source>Stopping task...</source>
+        <translation>正在停止任務...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1796"/>
+        <location filename="../core/runner/task_flow.py" line="1879"/>
+        <source>Unknown Task Entry</source>
+        <translation>未知任務項目</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1885"/>
+        <source>{} hours {} minutes</source>
+        <translation>{}小時{}分鐘</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1887"/>
+        <source>{} minutes</source>
+        <translation>{}分鐘</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1890"/>
+        <source>Task entry &apos;{}&apos; has been running for {}. This may indicate a problem. Please check the task status.</source>
+        <translation>任務項目「{}」已執行{}。這可能表示有問題。請檢查任務狀態。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1904"/>
+        <source>Task running time too long</source>
+        <translation>任務執行時間過長</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1958"/>
+        <source>Auto searching ADB devices...</source>
+        <translation>正在自動搜尋ADB裝置...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2412"/>
+        <source>WlRoots controller is only supported on Linux</source>
+        <translation>WlRoots 控制器僅支援 Linux</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2443"/>
+        <source>WlRoots Wayland socket path is empty, please configure it in settings</source>
+        <translation>WlRoots Wayland 通訊端路徑為空，請在設定中配置</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2460"/>
+        <source>Connecting to WlRoots: {socket}</source>
+        <translation>正在連接到 WlRoots：{socket}</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2465"/>
+        <source>WlRoots connected successfully</source>
+        <translation>WlRoots 連接成功</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2469"/>
+        <source>Failed to connect to WlRoots</source>
+        <translation>連接 WlRoots 失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2475"/>
+        <source>MacOS controller is only supported on macOS</source>
+        <translation>MacOS 控制器僅支援 macOS</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2538"/>
+        <source>Auto searching MacOS windows...</source>
+        <translation>正在自動搜尋 MacOS 視窗...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2549"/>
+        <source>Window ID is empty, please configure window connection in settings</source>
+        <translation>視窗 ID 為空，請在設定中配置視窗連接</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2704"/>
+        <source>ADB path is empty, please configure ADB path in settings</source>
+        <translation>ADB路徑為空，請在設定中配置ADB路徑</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2723"/>
+        <source>ADB connection address is empty, please configure device connection in settings</source>
+        <translation>ADB連線位址為空，請在設定中配置裝置連線</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1974"/>
+        <source>try to start emulator</source>
+        <translation>嘗試啟動模擬器</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="693"/>
+        <source>Custom components loading failed, the flow is terminated.</source>
+        <translation>自訂元件載入失敗，流程已終止。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="1984"/>
+        <source>waiting for emulator start...</source>
+        <translation>等待模擬器啟動中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2014"/>
+        <location filename="../core/runner/task_flow.py" line="2128"/>
+        <location filename="../core/runner/task_flow.py" line="2135"/>
+        <location filename="../core/runner/task_flow.py" line="2183"/>
+        <location filename="../core/runner/task_flow.py" line="2271"/>
+        <location filename="../core/runner/task_flow.py" line="2278"/>
+        <location filename="../core/runner/task_flow.py" line="2321"/>
+        <location filename="../core/runner/task_flow.py" line="2563"/>
+        <location filename="../core/runner/task_flow.py" line="2569"/>
+        <location filename="../core/runner/task_flow.py" line="2614"/>
+        <source>Device connection failed</source>
+        <translation>裝置連線失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2021"/>
+        <source>Win32 controller is only supported on Windows</source>
+        <translation>Win32 控制器僅支援在 Windows 上使用</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2097"/>
+        <source>Auto searching Win32 windows...</source>
+        <translation>自動搜尋 Win32 視窗中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2110"/>
+        <location filename="../core/runner/task_flow.py" line="2257"/>
+        <source>Window handle (hwnd) is empty, please configure window connection in settings</source>
+        <translation>視窗控制代碼 (hwnd) 為空，請在設定中配置視窗連線</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2143"/>
+        <location filename="../core/runner/task_flow.py" line="2285"/>
+        <location filename="../core/runner/task_flow.py" line="2576"/>
+        <source>try to start program</source>
+        <translation>嘗試啟動程式</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2171"/>
+        <location filename="../core/runner/task_flow.py" line="2309"/>
+        <location filename="../core/runner/task_flow.py" line="2602"/>
+        <source>waiting for program start...</source>
+        <translation>等待程式啟動中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2190"/>
+        <source>Gamepad controller is only supported on Windows</source>
+        <translation>遊戲手把控制器僅支援在 Windows 上使用</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2247"/>
+        <source>Auto searching desktop windows...</source>
+        <translation>自動搜尋桌面視窗中...</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2328"/>
+        <source>PlayCover controller is only supported on macOS</source>
+        <translation>PlayCover 控制器僅支援在 macOS 上使用</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2366"/>
+        <source>PlayCover UUID is empty, please configure UUID in settings</source>
+        <translation>PlayCover UUID 為空，請在設定中配置 UUID</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2378"/>
+        <source>PlayCover connection address is empty, please configure address in settings</source>
+        <translation>PlayCover 連線位址為空，請在設定中配置位址</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2391"/>
+        <source>Connecting to PlayCover: {address} (UUID: {uuid})</source>
+        <translation>正在連線至 PlayCover: {address} (UUID: {uuid})</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2400"/>
+        <source>PlayCover connected successfully</source>
+        <translation>PlayCover 連線成功</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2404"/>
+        <source>Failed to connect to PlayCover</source>
+        <translation>連線至 PlayCover 失敗</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2732"/>
+        <source>ADB connection port is empty; use host:port (for example 127.0.0.1:5555) or pick a device after starting the emulator.</source>
+        <translation>ADB 連接埠為空；請使用 host:port 格式（例如 127.0.0.1:5555），或啟動模擬器後選擇裝置。</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="2959"/>
+        <location filename="../core/runner/task_flow.py" line="3006"/>
+        <source> seconds</source>
+        <translation> 秒</translation>
+    </message>
+    <message>
+        <location filename="../core/runner/task_flow.py" line="3411"/>
+        <source>Notifications are being sent, please wait up to {} seconds</source>
+        <translation>通知正在發送中，請等待最多 {} 秒</translation>
+    </message>
+    <message>
+        <source>This period&apos;s remaining execution count is 0</source>
+        <translation type="vanished">本週期剩餘執行次數為 0</translation>
+    </message>
+    <message>
+        <source>Not enough time passed since last run. Minimum interval is </source>
+        <translation type="vanished">距離上次執行時間不足。最小間隔為 </translation>
+    </message>
+    <message>
+        <source> hours.</source>
+        <translation type="vanished"> 小時。</translation>
+    </message>
+</context>
+<context>
+    <name>TaskInterface</name>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="28"/>
+        <source>Task Information</source>
+        <translation>任務資訊</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="29"/>
+        <source>Configuration Selection</source>
+        <translation>配置選擇</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="112"/>
+        <location filename="../view/task_interface/task_interface_logic.py" line="147"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <source>Please select a special task to run.</source>
+        <translation type="vanished">請選擇要執行的特殊任務。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/task_interface_logic.py" line="142"/>
+        <source>Stop</source>
+        <translation>停止</translation>
+    </message>
+</context>
+<context>
+    <name>TaskListItem</name>
+    <message>
+        <source>Launch Program</source>
+        <translation type="vanished">啟動程式</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation type="vanished">等待</translation>
+    </message>
+    <message>
+        <source>Wait Until</source>
+        <translation type="vanished">定時等待</translation>
+    </message>
+    <message>
+        <source>System Notification</source>
+        <translation type="vanished">系統通知</translation>
+    </message>
+    <message>
+        <source>External Notification</source>
+        <translation type="vanished">外部通知</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="vanished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="vanished">否</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="409"/>
+        <source>Resource</source>
+        <translation>資源</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="411"/>
+        <source>Controller</source>
+        <translation>控制器</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="413"/>
+        <source>Post-Action</source>
+        <translation>後續動作</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="677"/>
+        <source>Run this task</source>
+        <translation>執行此任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="685"/>
+        <source>Run from here</source>
+        <translation>從此處開始執行</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="693"/>
+        <source>Insert task</source>
+        <translation>插入任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="734"/>
+        <source>No available tasks to add.</source>
+        <translation>無可用任務可新增。</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="871"/>
+        <source>Delete task</source>
+        <translation>刪除任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="888"/>
+        <source>Delete Task</source>
+        <translation>刪除任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_item.py" line="889"/>
+        <source>Are you sure you want to delete task &apos;{}&apos;?</source>
+        <translation>確定要刪除任務「{}」嗎？</translation>
+    </message>
+</context>
+<context>
+    <name>TaskListToolBarWidget</name>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="322"/>
+        <source>Tasks</source>
+        <translation>任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="354"/>
+        <source>No available tasks to add.</source>
+        <translation>無可用任務可新增。</translation>
+    </message>
+    <message>
+        <source>Switch to Normal Tasks</source>
+        <translation type="vanished">切換至一般任務</translation>
+    </message>
+    <message>
+        <source>Special Tasks</source>
+        <translation type="vanished">特殊任務</translation>
+    </message>
+    <message>
+        <source>Switch to Special Tasks</source>
+        <translation type="vanished">切換至特殊任務</translation>
+    </message>
+    <message>
+        <location filename="../view/task_interface/components/list_tool_bar_widget.py" line="474"/>
+        <source>Base tasks (Resource, Post-Task) cannot be deleted (ID: {id})</source>
+        <translation>基礎任務（資源、後續任務）無法刪除（ID：{id}）</translation>
+    </message>
+</context>
+<context>
+    <name>Update</name>
+    <message>
+        <location filename="../utils/update.py" line="1415"/>
+        <location filename="../utils/update.py" line="1508"/>
+        <source>Checking for updates...</source>
+        <translation>正在檢查更新...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1233"/>
+        <source>Already up to date</source>
+        <translation>已是最新版本</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1238"/>
+        <location filename="../utils/update.py" line="1446"/>
+        <location filename="../utils/update.py" line="1467"/>
+        <location filename="../utils/update.py" line="1581"/>
+        <location filename="../utils/update.py" line="1604"/>
+        <source>Download failed</source>
+        <translation>下載失敗</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1440"/>
+        <location filename="../utils/update.py" line="1575"/>
+        <source>Preparing to download update...</source>
+        <translation>準備下載更新...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1475"/>
+        <location filename="../utils/update.py" line="1612"/>
+        <source>Download complete</source>
+        <translation>下載完成</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1634"/>
+        <source>Applying hotfix...</source>
+        <translation>正在套用熱修復...</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1689"/>
+        <source>Update applied successfully</source>
+        <translation>更新已成功套用</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1740"/>
+        <source>Failed to update</source>
+        <translation>更新失敗</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1832"/>
+        <location filename="../utils/update.py" line="1855"/>
+        <location filename="../utils/update.py" line="1941"/>
+        <location filename="../utils/update.py" line="1974"/>
+        <location filename="../utils/update.py" line="2335"/>
+        <location filename="../utils/update.py" line="2358"/>
+        <location filename="../utils/update.py" line="2435"/>
+        <location filename="../utils/update.py" line="2472"/>
+        <source>Found update: </source>
+        <translation>發現更新：</translation>
+    </message>
+    <message>
+        <location filename="../utils/update.py" line="1885"/>
+        <location filename="../utils/update.py" line="1896"/>
+        <location filename="../utils/update.py" line="1908"/>
+        <location filename="../utils/update.py" line="1919"/>
+        <location filename="../utils/update.py" line="1956"/>
+        <location filename="../utils/update.py" line="1963"/>
+        <location filename="../utils/update.py" line="2381"/>
+        <location filename="../utils/update.py" line="2390"/>
+        <location filename="../utils/update.py" line="2402"/>
+        <location filename="../utils/update.py" line="2413"/>
+        <location filename="../utils/update.py" line="2454"/>
+        <location filename="../utils/update.py" line="2461"/>
+        <source>GitHub update check failed</source>
+        <translation>GitHub 更新檢查失敗</translation>
+    </message>
+</context>
+<context>
+    <name>WxPusherNoticeType</name>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="385"/>
+        <source>WxPusher Spt:</source>
+        <translation>WxPusher Spt:</translation>
+    </message>
+    <message>
+        <location filename="../view/setting_interface/widget/notice_type.py" line="386"/>
+        <source>WxPusher Status:</source>
+        <translation>WxPusher 狀態：</translation>
+    </message>
+</context>
+<context>
+    <name>context</name>
+    <message>
+        <source>Builtin launch program path is empty, skipped.</source>
+        <translation type="vanished">內建任務啟動程式缺少路徑，已略過。</translation>
+    </message>
+    <message>
+        <source>Builtin task waits {seconds} second(s).</source>
+        <translation type="vanished">內建任務等待 {seconds} 秒。</translation>
+    </message>
+    <message>
+        <source>Builtin wait-until target time is empty, skipped.</source>
+        <translation type="vanished">內建定時等待缺少目標時間，已略過。</translation>
+    </message>
+    <message>
+        <source>Failed to parse builtin wait-until target time: {time}</source>
+        <translation type="vanished">無法解析定時等待目標時間：{time}</translation>
+    </message>
+    <message>
+        <source>Builtin task waits until {time}.</source>
+        <translation type="vanished">內建任務等待至 {time}。</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="46"/>
+        <source>$builtin_log_launch_program_path_empty</source>
+        <translation>$builtin_log_launch_program_path_empty</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="62"/>
+        <source>$builtin_log_wait_duration</source>
+        <translation>$builtin_log_wait_duration</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="70"/>
+        <source>$builtin_log_wait_until_empty</source>
+        <translation>$builtin_log_wait_until_empty</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="77"/>
+        <source>$builtin_log_wait_until_invalid</source>
+        <translation>$builtin_log_wait_until_invalid</translation>
+    </message>
+    <message>
+        <location filename="../builtin_tasks/basic_tasks.py" line="84"/>
+        <source>$builtin_log_wait_until_target</source>
+        <translation>$builtin_log_wait_until_target</translation>
+    </message>
+</context>
+<context>
+    <name>manager</name>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="704"/>
+        <source>启动参数已弃用</source>
+        <translation>啟動參數已棄用</translation>
+    </message>
+    <message>
+        <location filename="../utils/startup_dialog.py" line="706"/>
+        <source>检测到旧版命令行参数。程序已按新规则继续启动，但请尽快改用下列写法：</source>
+        <translation>偵測到舊版命令列參數。程式已依新規則繼續啟動，但請盡快改用下列寫法：</translation>
+    </message>
+</context>
 </TS>

--- a/app/view/main_window/main_window.py
+++ b/app/view/main_window/main_window.py
@@ -828,7 +828,7 @@ class MainWindow(MSFluentWindow):
         self._switch_to_interface(getattr(self, "MonitorInterface", None))
 
     def _start_tasks_from_dashboard(self) -> None:
-        if self.service_coordinator.run_manager.is_running:
+        if self.service_coordinator.is_current_config_running():
             signalBus.info_bar_requested.emit(
                 "warning", self.tr("Task flow is already running")
             )
@@ -2943,15 +2943,23 @@ class MainWindow(MSFluentWindow):
         QApplication.restoreOverrideCursor()
 
     def _is_task_shutdown_pending(self) -> bool:
-        task_runner = getattr(self.service_coordinator, "task_runner", None)
-        if task_runner is None:
-            return False
+        coord = self.service_coordinator
+        task_runner = getattr(coord, "task_runner", None)
         try:
-            return bool(
+            if task_runner is not None and (
                 task_runner.is_running or task_runner.maafw.has_active_runtime()
-            )
+            ):
+                return True
         except Exception:
-            return False
+            pass
+        # 多实例：存在任意运行中的独立运行体也视为待关闭
+        try:
+            manager = getattr(coord, "runtime_manager", None)
+            if manager is not None and manager.any_running():
+                return True
+        except Exception:
+            pass
+        return False
 
     def _continue_close_after_task_shutdown(self) -> None:
         if self._shutdown_cleanup_started:
@@ -3038,6 +3046,13 @@ class MainWindow(MSFluentWindow):
             self.service_coordinator.task_runner.shutdown_runtime_sync()
         except Exception as e:
             logger.exception("清理 maafw 失败", exc_info=e)
+        # 多实例：清理所有独立运行体
+        try:
+            manager = getattr(self.service_coordinator, "runtime_manager", None)
+            if manager is not None:
+                manager.shutdown_sync()
+        except Exception as e:
+            logger.exception("清理多实例运行体失败", exc_info=e)
 
     def _stop_notice_thread(self, send_thread):
         """关闭通知线程，确保队列循环退出。"""

--- a/app/view/monitor/config_monitor_pool.py
+++ b/app/view/monitor/config_monitor_pool.py
@@ -32,6 +32,7 @@ class ConfigMonitorSlot:
     last_pil_image: Optional[Image.Image] = None
     starting: bool = False
     stopping: bool = False
+    uses_shared_maafw: bool = False
     ensure_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -153,6 +154,52 @@ class ConfigMonitorPool:
         self._slots[config_id] = slot
         return slot
 
+    def _bind_runner_maafw(self, config_id: str) -> bool:
+        """多实例：监控复用任务运行体的 MaaFW，避免与 Runner 争抢控制器连接。"""
+        if not self._coordinator.is_multi_instance_enabled():
+            return False
+        inst = self._coordinator.runtime_manager.get_instance(config_id)
+        slot = self._slots.get(config_id)
+        if inst is None or slot is None:
+            return False
+        slot.monitor_task.maafw = inst.runner.maafw
+        slot.uses_shared_maafw = True
+        return True
+
+    def _release_shared_maafw(self, slot: ConfigMonitorSlot) -> None:
+        """恢复监控槽独立 MaaFW（任务停止后或共享连接失败回退）。"""
+        if not slot.uses_shared_maafw:
+            return
+        slot.uses_shared_maafw = False
+        from app.core.runner.maafw import MaaFW
+
+        slot.monitor_task.maafw = MaaFW()
+
+    async def ensure_monitoring_when_ready(
+        self,
+        config_id: str,
+        *,
+        auto: bool = True,
+        timeout_s: float = 90.0,
+    ) -> bool:
+        """等待任务流完成控制器连接后，再启动监控（共享同一 MaaFW）。"""
+        import time
+
+        self._ensure_slot(config_id)
+        deadline = time.monotonic() + max(5.0, timeout_s)
+        while time.monotonic() < deadline:
+            if not self._coordinator.is_config_running(config_id):
+                return False
+            if self._bind_runner_maafw(config_id):
+                slot = self._slots.get(config_id)
+                if slot is not None and slot.session.is_controller_connected():
+                    return await self.ensure_monitoring(config_id, auto=auto)
+            await asyncio.sleep(0.2)
+        slot = self._slots.get(config_id)
+        if slot is not None:
+            self._release_shared_maafw(slot)
+        return await self.ensure_monitoring(config_id, auto=auto)
+
     async def ensure_monitoring(self, config_id: str, *, auto: bool = True) -> bool:
         """为指定配置启动监控（若已在运行则跳过）。"""
         if not config_id:
@@ -169,6 +216,8 @@ class ConfigMonitorPool:
             slot.starting = True
             log_prefix = f"Monitor[{config_id[:8]}]"
             try:
+                if self._coordinator.is_config_running(config_id):
+                    self._bind_runner_maafw(config_id)
                 logger.info(
                     "[%s] 后台启动监控（%s）", log_prefix, "自动" if auto else "手动"
                 )
@@ -177,6 +226,8 @@ class ConfigMonitorPool:
                 )
                 if not started:
                     logger.warning("[%s] 监控启动失败", log_prefix)
+                    if slot.uses_shared_maafw:
+                        self._release_shared_maafw(slot)
                 return bool(started)
             except Exception as exc:
                 logger.error(
@@ -197,7 +248,10 @@ class ConfigMonitorPool:
         slot.starting = False
         try:
             async with slot.ensure_lock:
-                await slot.session.stop(teardown=True)
+                await slot.session.stop(
+                    teardown=not slot.uses_shared_maafw,
+                )
+                self._release_shared_maafw(slot)
             if clear_cache:
                 slot.last_pil_image = None
                 slot.roi_store.clear()

--- a/app/view/monitor/config_monitor_pool.py
+++ b/app/view/monitor/config_monitor_pool.py
@@ -1,0 +1,214 @@
+"""多实例模式下按 config_id 维护独立监控会话，切换配置时仅切换显示。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Dict, Optional
+
+from PIL import Image
+
+from app.core.runner.monitor_task import MonitorTask
+from app.utils.logger import logger
+from app.view.monitor.monitor_session import MonitorSession
+from app.view.monitor.recognition_roi_store import RecognitionRoiStore
+
+if TYPE_CHECKING:
+    from app.core.core import ServiceCoordinator
+
+
+FrameCallback = Callable[[str, Image.Image], None]
+ClearCallback = Callable[[str], None]
+
+
+@dataclass
+class ConfigMonitorSlot:
+    """单个配置的监控槽：独立连接 + 帧缓存。"""
+
+    config_id: str
+    monitor_task: MonitorTask
+    session: MonitorSession
+    roi_store: RecognitionRoiStore = field(default_factory=RecognitionRoiStore)
+    last_pil_image: Optional[Image.Image] = None
+    starting: bool = False
+    stopping: bool = False
+
+
+class ConfigMonitorPool:
+    """按 config_id 池化 MonitorSession；切换显示配置不断开后台连接。"""
+
+    def __init__(
+        self,
+        coordinator: "ServiceCoordinator",
+        *,
+        on_frame: FrameCallback,
+        on_capture_failure_clear: ClearCallback,
+        on_controller_disconnected: Callable[[str], None],
+    ) -> None:
+        self._coordinator = coordinator
+        self._on_frame = on_frame
+        self._on_capture_failure_clear = on_capture_failure_clear
+        self._on_controller_disconnected = on_controller_disconnected
+        self._slots: Dict[str, ConfigMonitorSlot] = {}
+        self._display_config_id: str = ""
+
+    @property
+    def display_config_id(self) -> str:
+        return self._display_config_id
+
+    def get_slot(self, config_id: str) -> Optional[ConfigMonitorSlot]:
+        if not config_id:
+            return None
+        return self._slots.get(config_id)
+
+    def get_display_session(self) -> Optional[MonitorSession]:
+        slot = self._slots.get(self._display_config_id)
+        return slot.session if slot else None
+
+    def get_display_monitor_task(self) -> Optional[MonitorTask]:
+        slot = self._slots.get(self._display_config_id)
+        return slot.monitor_task if slot else None
+
+    def get_display_roi_store(self) -> RecognitionRoiStore:
+        slot = self._slots.get(self._display_config_id)
+        if slot is not None:
+            return slot.roi_store
+        return RecognitionRoiStore()
+
+    def is_display_monitoring(self) -> bool:
+        slot = self._slots.get(self._display_config_id)
+        return bool(slot and slot.session.monitoring_active)
+
+    def is_display_starting(self) -> bool:
+        slot = self._slots.get(self._display_config_id)
+        return bool(slot and slot.starting)
+
+    def is_display_stopping(self) -> bool:
+        slot = self._slots.get(self._display_config_id)
+        return bool(slot and slot.stopping)
+
+    def is_config_monitoring(self, config_id: str) -> bool:
+        slot = self._slots.get(config_id)
+        return bool(slot and slot.session.monitoring_active)
+
+    def is_config_starting(self, config_id: str) -> bool:
+        slot = self._slots.get(config_id)
+        return bool(slot and slot.starting)
+
+    def list_slot_ids(self) -> list[str]:
+        return list(self._slots.keys())
+
+    def set_display_config(self, config_id: str) -> Optional[Image.Image]:
+        """切换显示目标，返回缓存帧供 UI 秒切。"""
+        self._display_config_id = config_id or ""
+        slot = self._slots.get(self._display_config_id)
+        return slot.last_pil_image if slot else None
+
+    def _resolve_services(self, config_id: str):
+        """解析指定配置的控制器/资源服务栈。"""
+        coord = self._coordinator
+        if coord.is_multi_instance_enabled():
+            inst = coord.runtime_manager.get_instance(config_id)
+            if inst is not None:
+                return inst.task_service, inst.config_service
+        return coord.task_service, coord.config_service
+
+    def _ensure_slot(self, config_id: str) -> ConfigMonitorSlot:
+        existing = self._slots.get(config_id)
+        if existing is not None:
+            return existing
+
+        task_service, config_service = self._resolve_services(config_id)
+        monitor_task = MonitorTask(task_service, config_service)
+        session = MonitorSession(
+            monitor_task, log_prefix=f"Monitor[{config_id[:8]}]"
+        )
+
+        slot = ConfigMonitorSlot(
+            config_id=config_id,
+            monitor_task=monitor_task,
+            session=session,
+        )
+
+        def _on_frame(pil_image: Image.Image, cid: str = config_id) -> None:
+            try:
+                slot.last_pil_image = pil_image.copy()
+            except Exception:
+                slot.last_pil_image = pil_image
+            self._on_frame(cid, pil_image)
+
+        def _on_clear(cid: str = config_id) -> None:
+            slot.last_pil_image = None
+            self._on_capture_failure_clear(cid)
+
+        async def _on_disconnect(cid: str = config_id) -> None:
+            self._on_controller_disconnected(cid)
+
+        session.set_callbacks(
+            on_frame=_on_frame,
+            on_capture_failure_clear=_on_clear,
+            on_controller_disconnected=_on_disconnect,
+        )
+        self._slots[config_id] = slot
+        return slot
+
+    async def ensure_monitoring(self, config_id: str, *, auto: bool = True) -> bool:
+        """为指定配置启动监控（若已在运行则跳过）。"""
+        if not config_id:
+            return False
+        slot = self._ensure_slot(config_id)
+        if slot.session.monitoring_active or slot.starting:
+            return True
+
+        slot.starting = True
+        log_prefix = f"Monitor[{config_id[:8]}]"
+        try:
+            logger.info("[%s] 后台启动监控（%s）", log_prefix, "自动" if auto else "手动")
+            started = await slot.session.run_startup_sequence(
+                should_abort=lambda: not slot.starting,
+            )
+            if not started:
+                logger.warning("[%s] 监控启动失败", log_prefix)
+            return bool(started)
+        except Exception as exc:
+            logger.error("[%s] 监控启动异常: %s", log_prefix, exc, exc_info=True)
+            return False
+        finally:
+            slot.starting = False
+
+    async def stop_monitoring(self, config_id: str, *, clear_cache: bool = False) -> None:
+        """停止指定配置的监控会话（不影响其他配置）。"""
+        slot = self._slots.get(config_id)
+        if slot is None:
+            return
+        if slot.stopping:
+            return
+        slot.stopping = True
+        slot.starting = False
+        try:
+            await slot.session.stop()
+            if clear_cache:
+                slot.last_pil_image = None
+                slot.roi_store.clear()
+        except Exception as exc:
+            logger.warning(
+                "停止配置 %s 监控失败: %s", config_id, exc, exc_info=True
+            )
+        finally:
+            slot.stopping = False
+
+    async def stop_all(self) -> None:
+        for config_id in list(self._slots.keys()):
+            await self.stop_monitoring(config_id, clear_cache=True)
+
+    def shutdown_sync(self) -> None:
+        """应用退出时同步停止所有循环。"""
+        for slot in self._slots.values():
+            try:
+                slot.session.stop_loop()
+            except Exception:
+                pass
+            slot.starting = False
+            slot.stopping = False
+
+    def remove_slot(self, config_id: str) -> None:
+        self._slots.pop(config_id, None)

--- a/app/view/monitor/config_monitor_pool.py
+++ b/app/view/monitor/config_monitor_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Dict, Optional
 
@@ -31,6 +32,7 @@ class ConfigMonitorSlot:
     last_pil_image: Optional[Image.Image] = None
     starting: bool = False
     stopping: bool = False
+    ensure_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class ConfigMonitorPool:
@@ -76,7 +78,7 @@ class ConfigMonitorPool:
 
     def is_display_monitoring(self) -> bool:
         slot = self._slots.get(self._display_config_id)
-        return bool(slot and slot.session.monitoring_active)
+        return bool(slot and slot.session.is_loop_running())
 
     def is_display_starting(self) -> bool:
         slot = self._slots.get(self._display_config_id)
@@ -88,7 +90,7 @@ class ConfigMonitorPool:
 
     def is_config_monitoring(self, config_id: str) -> bool:
         slot = self._slots.get(config_id)
-        return bool(slot and slot.session.monitoring_active)
+        return bool(slot and slot.session.is_loop_running())
 
     def is_config_starting(self, config_id: str) -> bool:
         slot = self._slots.get(config_id)
@@ -156,24 +158,33 @@ class ConfigMonitorPool:
         if not config_id:
             return False
         slot = self._ensure_slot(config_id)
-        if slot.session.monitoring_active or slot.starting:
-            return True
+        async with slot.ensure_lock:
+            if slot.session.is_loop_running():
+                return True
+            if slot.starting:
+                return True
+            if slot.session.monitoring_active or slot.session.is_loop_running():
+                await slot.session.stop_loop_async()
 
-        slot.starting = True
-        log_prefix = f"Monitor[{config_id[:8]}]"
-        try:
-            logger.info("[%s] 后台启动监控（%s）", log_prefix, "自动" if auto else "手动")
-            started = await slot.session.run_startup_sequence(
-                should_abort=lambda: not slot.starting,
-            )
-            if not started:
-                logger.warning("[%s] 监控启动失败", log_prefix)
-            return bool(started)
-        except Exception as exc:
-            logger.error("[%s] 监控启动异常: %s", log_prefix, exc, exc_info=True)
-            return False
-        finally:
-            slot.starting = False
+            slot.starting = True
+            log_prefix = f"Monitor[{config_id[:8]}]"
+            try:
+                logger.info(
+                    "[%s] 后台启动监控（%s）", log_prefix, "自动" if auto else "手动"
+                )
+                started = await slot.session.run_startup_sequence(
+                    should_abort=lambda: not slot.starting,
+                )
+                if not started:
+                    logger.warning("[%s] 监控启动失败", log_prefix)
+                return bool(started)
+            except Exception as exc:
+                logger.error(
+                    "[%s] 监控启动异常: %s", log_prefix, exc, exc_info=True
+                )
+                return False
+            finally:
+                slot.starting = False
 
     async def stop_monitoring(self, config_id: str, *, clear_cache: bool = False) -> None:
         """停止指定配置的监控会话（不影响其他配置）。"""
@@ -185,7 +196,8 @@ class ConfigMonitorPool:
         slot.stopping = True
         slot.starting = False
         try:
-            await slot.session.stop()
+            async with slot.ensure_lock:
+                await slot.session.stop(teardown=True)
             if clear_cache:
                 slot.last_pil_image = None
                 slot.roi_store.clear()

--- a/app/view/monitor/monitor_session.py
+++ b/app/view/monitor/monitor_session.py
@@ -102,7 +102,7 @@ class MonitorSession:
         return bool(await self.monitor_task._connect())
 
     def capture_frame(self) -> Image.Image:
-        """在工作线程中调用：从监控专用控制器截取一帧。"""
+        """在工作线程中调用：通过监控会话控制器主动截图（不读取 task 侧 cached_image）。"""
         controller = getattr(self.monitor_task.maafw, "controller", None)
         if controller is None:
             raise RuntimeError("控制器尚未初始化，无法抓取画面")

--- a/app/view/monitor/monitor_session.py
+++ b/app/view/monitor/monitor_session.py
@@ -18,6 +18,24 @@ from app.utils.logger import (
     suppress_qasync_logging,
 )
 
+_active_monitor_loop_count = 0
+
+
+def _acquire_monitor_loop_logging() -> None:
+    global _active_monitor_loop_count
+    _active_monitor_loop_count += 1
+    if _active_monitor_loop_count == 1:
+        suppress_asyncify_logging()
+        suppress_qasync_logging()
+
+
+def _release_monitor_loop_logging() -> None:
+    global _active_monitor_loop_count
+    _active_monitor_loop_count = max(0, _active_monitor_loop_count - 1)
+    if _active_monitor_loop_count == 0:
+        restore_asyncify_logging()
+        restore_qasync_logging()
+
 
 class MonitorSession:
     """监控截图会话，由 MonitorInterface 独占使用。"""
@@ -47,6 +65,18 @@ class MonitorSession:
     @property
     def monitoring_active(self) -> bool:
         return self._monitoring_active
+
+    def is_loop_running(self) -> bool:
+        """截图循环与帧处理循环均存活时才算监控在运行。"""
+        monitor = self._monitor_loop_task
+        processing = self._image_processing_task
+        return bool(
+            self._monitoring_active
+            and monitor is not None
+            and not monitor.done()
+            and processing is not None
+            and not processing.done()
+        )
 
     def set_callbacks(
         self,
@@ -90,8 +120,24 @@ class MonitorSession:
 
     def start_loop(self) -> None:
         if self._monitor_loop_task and not self._monitor_loop_task.done():
-            logger.debug(f"[{self._log_prefix}] 监控循环任务已存在，跳过启动")
+            if (
+                self._image_processing_task is None
+                or self._image_processing_task.done()
+            ):
+                logger.info(
+                    f"[{self._log_prefix}] 帧处理循环已退出，正在恢复..."
+                )
+                self._image_queue = asyncio.Queue(maxsize=self._max_queue_size)
+                self._image_processing_task = asyncio.create_task(
+                    self._image_processing_loop()
+                )
+            else:
+                logger.debug(f"[{self._log_prefix}] 监控循环任务已存在，跳过启动")
             return
+        if self._monitoring_active and (
+            self._monitor_loop_task is None or self._monitor_loop_task.done()
+        ):
+            self._monitoring_active = False
         if self._monitoring_active:
             logger.debug(f"[{self._log_prefix}] 监控已激活，跳过启动")
             return
@@ -102,8 +148,7 @@ class MonitorSession:
         logger.info(
             f"[{self._log_prefix}] 开始启动监控循环，截图速率: {target_fps} FPS"
         )
-        suppress_asyncify_logging()
-        suppress_qasync_logging()
+        _acquire_monitor_loop_logging()
         self._monitoring_active = True
         try:
             self._image_queue = asyncio.Queue(maxsize=self._max_queue_size)
@@ -113,38 +158,44 @@ class MonitorSession:
             self._monitor_loop_task = asyncio.create_task(self._monitor_loop())
         except Exception:
             self._monitoring_active = False
-            restore_asyncify_logging()
-            restore_qasync_logging()
+            _release_monitor_loop_logging()
             raise
 
     def stop_loop(self) -> None:
         self._monitoring_active = False
-        task = self._monitor_loop_task
+        monitor_task = self._monitor_loop_task
+        processing_task = self._image_processing_task
         self._monitor_loop_task = None
-        if task and not task.done():
-            task.cancel()
-        restore_asyncify_logging()
-        restore_qasync_logging()
+        self._image_processing_task = None
+        if monitor_task and not monitor_task.done():
+            monitor_task.cancel()
+        if processing_task and not processing_task.done():
+            processing_task.cancel()
+
+    async def stop_loop_async(self) -> None:
+        """停止截图/帧处理双循环并等待任务退出。"""
+        self._monitoring_active = False
+        monitor_task = self._monitor_loop_task
+        processing_task = self._image_processing_task
+        self._monitor_loop_task = None
+        self._image_processing_task = None
+        self._image_queue = None
+        for task in (monitor_task, processing_task):
+            if task is not None and not task.done():
+                task.cancel()
+        for task in (monitor_task, processing_task):
+            if task is None:
+                continue
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
 
     def deactivate(self) -> None:
         """仅标记为非活跃，不取消循环任务。"""
         self._monitoring_active = False
-
-    async def wait_for_image_processing_complete(self, timeout: float = 1.0) -> None:
-        if self._image_processing_task and not self._image_processing_task.done():
-            try:
-                await asyncio.wait_for(self._image_processing_task, timeout=timeout)
-            except asyncio.TimeoutError:
-                if not self._image_processing_task.done():
-                    self._image_processing_task.cancel()
-                    try:
-                        await self._image_processing_task
-                    except asyncio.CancelledError:
-                        pass
-            except Exception:
-                pass
-        self._image_queue = None
-        self._image_processing_task = None
 
     async def teardown_controller(self) -> None:
         try:
@@ -157,10 +208,10 @@ class MonitorSession:
         except Exception as exc:
             logger.warning(f"[{self._log_prefix}] 清除控制器引用时出错: {exc}")
 
-    async def stop(self) -> None:
-        self.stop_loop()
-        await self.wait_for_image_processing_complete(timeout=1.0)
-        await self.teardown_controller()
+    async def stop(self, *, teardown: bool = True) -> None:
+        await self.stop_loop_async()
+        if teardown:
+            await self.teardown_controller()
 
     async def run_startup_sequence(
         self,
@@ -175,6 +226,9 @@ class MonitorSession:
             if not await self.connect_controller():
                 logger.warning(f"[{self._log_prefix}] 监控控制器连接失败")
                 return False
+
+        if self.is_loop_running():
+            return True
 
         self.start_loop()
         await asyncio.sleep(0.1)
@@ -239,8 +293,7 @@ class MonitorSession:
                 f"[{self._log_prefix}] 监控循环结束，共捕获 {frame_count} 帧"
             )
             self._monitor_loop_task = None
-            restore_asyncify_logging()
-            restore_qasync_logging()
+            _release_monitor_loop_logging()
 
     async def _image_processing_loop(self) -> None:
         try:

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -429,6 +429,33 @@ class MonitorInterface(QWidget):
                 self._on_task_status_changed
             )
         signalBus.task_flow_finished.connect(self._on_task_flow_finished)
+        # 多实例：切换当前配置后，监控画面应跟随新的当前配置
+        signalBus.config_changed.connect(self._on_active_config_changed)
+
+    def _on_active_config_changed(self, _config_id: str) -> None:
+        """当前激活配置变化：停止旧配置监控；若新配置在运行则自动接管画面。
+
+        监控会话基于共享的 task/config 服务（已指向新当前配置），重启后即对应新配置。
+        """
+        was_active = self._session.monitoring_active or self._starting_monitoring
+        if was_active:
+            self._request_stop_monitoring(reason="config_changed")
+            self._emit_preview_cleared()
+
+        def _maybe_restart() -> None:
+            try:
+                should_run = bool(
+                    self.service_coordinator.is_current_config_running()
+                )
+            except Exception:
+                should_run = False
+            if should_run and not (
+                self._session.monitoring_active or self._starting_monitoring
+            ):
+                self._start_monitoring(auto=True)
+
+        # 等待停止流程与防抖完成后再决定是否为新配置启动监控
+        QTimer.singleShot(2 * self._control_debounce_ms + 50, _maybe_restart)
 
     def _set_loading(self, loading: bool) -> None:
         if self._starting_monitoring == loading:

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -141,9 +141,47 @@ class MonitorInterface(QWidget):
         # 已为运行中的配置补建后台监控连接
         try:
             for cid in self.service_coordinator.running_config_ids():
-                asyncio.create_task(self._pool.ensure_monitoring(cid, auto=True))
+                self._schedule_pool_monitoring(cid, auto=True)
         except Exception as exc:
             logger.debug("初始化多配置监控池时同步运行中配置失败: %s", exc)
+
+    def _schedule_pool_monitoring(self, config_id: str, *, auto: bool = True) -> None:
+        """异步启动池化监控，并在失败时清除加载态。"""
+        if self._pool is None or not config_id:
+            return
+
+        async def _run() -> None:
+            started = await self._pool.ensure_monitoring_when_ready(
+                config_id, auto=auto
+            )
+            if (
+                not started
+                and self.service_coordinator.is_config_running(config_id)
+            ):
+                await asyncio.sleep(2.0)
+                if self.service_coordinator.is_config_running(config_id):
+                    started = await self._pool.ensure_monitoring_when_ready(
+                        config_id, auto=auto, timeout_s=30.0
+                    )
+            if self._multi_grid is not None:
+                if started:
+                    slot = self._pool.get_slot(config_id)
+                    if slot and slot.last_pil_image is not None:
+                        self._multi_grid.update_frame(
+                            config_id,
+                            slot.last_pil_image,
+                            roi_store=slot.roi_store,
+                        )
+                elif self.service_coordinator.is_config_running(config_id):
+                    self._multi_grid.clear_monitor_loading(config_id)
+            if config_id == self._bound_config_id:
+                self._set_loading(False)
+                self._set_monitor_control_running(
+                    self._pool.is_display_monitoring()
+                )
+                self._update_monitor_status()
+
+        asyncio.create_task(_run())
 
     def _on_pooled_frame(self, config_id: str, pil_image: Image.Image) -> None:
         slot = self._pool.get_slot(config_id) if self._pool else None
@@ -538,7 +576,7 @@ class MonitorInterface(QWidget):
         if self._pool is not None:
             try:
                 for cid in self.service_coordinator.running_config_ids():
-                    asyncio.create_task(self._pool.ensure_monitoring(cid, auto=True))
+                    self._schedule_pool_monitoring(cid, auto=True)
             except Exception:
                 pass
 
@@ -682,9 +720,7 @@ class MonitorInterface(QWidget):
         if self._multi_grid is not None:
             self._multi_grid.set_running(config_id, running)
         if running:
-            asyncio.create_task(self._pool.ensure_monitoring(config_id, auto=True))
-            if config_id == self._bound_config_id:
-                self._set_monitor_control_running(True)
+            self._schedule_pool_monitoring(config_id, auto=True)
             self._update_monitor_status()
             return
 
@@ -1211,9 +1247,14 @@ class MonitorInterface(QWidget):
 
             async def _start_sequence() -> None:
                 try:
-                    started = await self._pool.ensure_monitoring(
-                        target_id, auto=auto
-                    )
+                    if self.service_coordinator.is_config_running(target_id):
+                        started = await self._pool.ensure_monitoring_when_ready(
+                            target_id, auto=auto
+                        )
+                    else:
+                        started = await self._pool.ensure_monitoring(
+                            target_id, auto=auto
+                        )
                     if not started:
                         if not auto:
                             signalBus.info_bar_requested.emit(

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -78,6 +78,7 @@ class MonitorInterface(QWidget):
         self._roi_store = RecognitionRoiStore()
         self._bound_config_id: Optional[str] = None
         self._last_config_switch_id: Optional[str] = None
+        self._config_switch_seq: int = 0
         self._pool: Optional[ConfigMonitorPool] = None
         self._multi_grid: Optional[MultiConfigMonitorGrid] = None
 
@@ -191,7 +192,7 @@ class MonitorInterface(QWidget):
                 config_id, pil_image, roi_store=roi_store
             )
         if config_id == self._bound_config_id:
-            self._apply_preview_from_pil(pil_image)
+            self._apply_preview_from_pil(pil_image, config_id=config_id)
 
     def _on_pooled_capture_cleared(self, config_id: str) -> None:
         if self._multi_grid is not None:
@@ -771,25 +772,55 @@ class MonitorInterface(QWidget):
             return
         self._on_task_flow_finished(payload)
 
+    def _force_clear_monitor_area(self, *, clear_roi: bool = True) -> None:
+        """切换配置时强制清空监控区域，避免上一配置最后一帧残留。"""
+        self._config_switch_seq += 1
+        self._last_frame_timestamp = None
+        self._emit_preview_cleared(clear_roi=clear_roi)
+        if hasattr(self, "preview_label"):
+            self.preview_label.clear()
+        if hasattr(self, "preview_container"):
+            self.preview_container.update()
+        self._reposition_preview_overlays()
+
     def _on_active_config_changed(self, config_id: str) -> None:
-        """当前激活配置变化：多实例秒切缓存画面；单实例仍重连。"""
+        """当前激活配置变化：多实例先强制清空再按需恢复；单实例仍重连。"""
         target_id = config_id or self._current_config_id()
 
         if self._pool is not None:
             if target_id == self._last_config_switch_id:
                 return
             self._last_config_switch_id = target_id
+            self._force_clear_monitor_area(clear_roi=False)
+
             self._bound_config_id = target_id
-            cached = self._pool.set_display_config(target_id)
+            self._pool.set_display_config(target_id)
             self._roi_store = self._pool.get_display_roi_store()
             if self._multi_grid is not None:
                 self._multi_grid.set_active_config(target_id)
-            self._emit_preview_cleared(clear_roi=False)
-            if cached is not None:
-                self._apply_preview_from_pil(cached)
+
+            switch_seq = self._config_switch_seq
+
+            def _maybe_restore_target_preview() -> None:
+                if switch_seq != self._config_switch_seq:
+                    return
+                if self._bound_config_id != target_id:
+                    return
+                if not self._pool.is_display_monitoring():
+                    return
+                slot = self._pool.get_slot(target_id)
+                if slot is None or slot.last_pil_image is None:
+                    return
+                self._apply_preview_from_pil(
+                    slot.last_pil_image, config_id=target_id
+                )
+
+            QTimer.singleShot(0, _maybe_restore_target_preview)
             self._set_monitor_control_running(self._pool.is_display_monitoring())
             self._update_monitor_status()
             return
+
+        self._force_clear_monitor_area()
 
         if target_id == self._bound_config_id and not (
             self._legacy_session.monitoring_active or self._starting_monitoring
@@ -799,7 +830,6 @@ class MonitorInterface(QWidget):
         was_active = self._legacy_session.monitoring_active or self._starting_monitoring
         if was_active or self._bound_config_id:
             self._request_stop_monitoring(reason="config_changed")
-            self._emit_preview_cleared()
         self._bound_config_id = None
         self._clear_recognition_roi()
 
@@ -933,7 +963,11 @@ class MonitorInterface(QWidget):
             QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
         )
 
-    def _apply_preview_from_pil(self, pil_image: Image.Image) -> None:
+    def _apply_preview_from_pil(
+        self, pil_image: Image.Image, *, config_id: str | None = None
+    ) -> None:
+        if config_id is not None and config_id != self._bound_config_id:
+            return
         image_width, image_height = pil_image.size
         self._update_preview_size_policy(image_width, image_height)
 

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -1151,6 +1151,8 @@ class MonitorInterface(QWidget):
                 self._image_width, self._image_height, force_update=True
             )
         self._refresh_preview_image()
+        if self._multi_grid is not None and self._multi_panel.isVisible():
+            self._multi_grid.refresh_all_previews()
         self._reposition_preview_overlays()
 
     def showEvent(self, event) -> None:

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -33,12 +33,14 @@ from app.common.config import cfg
 from app.core.core import ServiceCoordinator
 from app.core.runner.monitor_task import MonitorTask
 from app.view.monitor import MonitorSession
+from app.view.monitor.config_monitor_pool import ConfigMonitorPool
 from app.view.monitor.recognition_roi_store import RecognitionRoiStore
 from app.view.monitor.roi_overlay import draw_roi_on_pixmap
 from app.view.task_interface.components.panel_splitter import (
     PANEL_SECTION_SPACING,
     panel_outer_margins,
 )
+from app.view.monitor_interface.multi_config_monitor_grid import MultiConfigMonitorGrid
 from app.utils.logger import logger
 from app.common.signal_bus import signalBus
 
@@ -74,9 +76,13 @@ class MonitorInterface(QWidget):
         self._image_height: Optional[int] = None
         self._is_landscape: Optional[bool] = None
         self._roi_store = RecognitionRoiStore()
+        self._bound_config_id: Optional[str] = None
+        self._pool: Optional[ConfigMonitorPool] = None
+        self._multi_grid: Optional[MultiConfigMonitorGrid] = None
 
         self._starting_monitoring = False
         self._stopping_monitoring = False
+        self._pending_stop_config_id: Optional[str] = None
         self._control_debounce_ms = 150
         self._stop_debounce_timer = QTimer(self)
         self._stop_debounce_timer.setSingleShot(True)
@@ -87,27 +93,127 @@ class MonitorInterface(QWidget):
 
         self._setup_ui()
 
-        self.monitor_task = MonitorTask(
+        self._legacy_monitor_task = MonitorTask(
             task_service=self.service_coordinator.task_service,
             config_service=self.service_coordinator.config_service,
         )
-        self._session = MonitorSession(self.monitor_task, log_prefix="Monitor")
-        self._session.set_callbacks(
+        self._legacy_session = MonitorSession(
+            self._legacy_monitor_task, log_prefix="Monitor"
+        )
+        self._legacy_session.set_callbacks(
             on_frame=self._apply_preview_from_pil,
             on_capture_failure_clear=self._emit_preview_cleared,
             on_controller_disconnected=self._on_session_controller_disconnected,
         )
+        self._init_monitor_pool()
         self._bind_auto_task_monitoring()
         self._bind_roi_signals()
+        self._apply_layout_mode()
         self._update_monitor_status()
         self._update_empty_state()
         self._reposition_preview_overlays()
 
+    def _use_pooled_monitors(self) -> bool:
+        """多实例模式下为每个配置维持独立监控连接，切换时仅换显示。"""
+        try:
+            return bool(cfg.get(cfg.multi_instance_mode))
+        except Exception:
+            return False
+
+    def _init_monitor_pool(self) -> None:
+        if not self._use_pooled_monitors():
+            self._pool = None
+            return
+        if self._pool is not None:
+            return
+        self._pool = ConfigMonitorPool(
+            self.service_coordinator,
+            on_frame=self._on_pooled_frame,
+            on_capture_failure_clear=self._on_pooled_capture_cleared,
+            on_controller_disconnected=self._on_pooled_controller_disconnected,
+        )
+        initial_id = self._current_config_id()
+        if initial_id:
+            self._pool.set_display_config(initial_id)
+            self._bound_config_id = initial_id
+            self._roi_store = self._pool.get_display_roi_store()
+        # 已为运行中的配置补建后台监控连接
+        try:
+            for cid in self.service_coordinator.running_config_ids():
+                asyncio.create_task(self._pool.ensure_monitoring(cid, auto=True))
+        except Exception as exc:
+            logger.debug("初始化多配置监控池时同步运行中配置失败: %s", exc)
+
+    def _on_pooled_frame(self, config_id: str, pil_image: Image.Image) -> None:
+        slot = self._pool.get_slot(config_id) if self._pool else None
+        roi_store = slot.roi_store if slot else None
+        if self._multi_grid is not None:
+            self._multi_grid.update_frame(
+                config_id, pil_image, roi_store=roi_store
+            )
+        if config_id == self._bound_config_id:
+            self._apply_preview_from_pil(pil_image)
+
+    def _on_pooled_capture_cleared(self, config_id: str) -> None:
+        if self._multi_grid is not None:
+            self._multi_grid.clear_frame(config_id)
+        if config_id == self._bound_config_id:
+            self._emit_preview_cleared()
+
+    def _on_pooled_controller_disconnected(self, config_id: str) -> None:
+        if config_id != self._bound_config_id:
+            return
+        if not (self._active_session().monitoring_active or self._starting_monitoring):
+            return
+        logger.warning("[Monitor] 配置 %s 控制器断开，请求停止监控", config_id)
+        self._request_stop_monitoring(reason="controller_disconnected", config_id=config_id)
+
+    @property
+    def _session(self) -> MonitorSession:
+        if self._pool is not None:
+            session = self._pool.get_display_session()
+            if session is not None:
+                return session
+        return self._legacy_session
+
+    @property
+    def monitor_task(self) -> MonitorTask:
+        if self._pool is not None:
+            task = self._pool.get_display_monitor_task()
+            if task is not None:
+                return task
+        return self._legacy_monitor_task
+
+    def _active_session(self) -> MonitorSession:
+        return self._session
+
     def _bind_roi_signals(self) -> None:
         signalBus.monitor_recognition_roi.connect(self._on_recognition_roi)
+        signalBus.monitor_recognition_roi_at.connect(self._on_recognition_roi_at)
         cfg.monitor_recognition_roi_enabled.valueChanged.connect(
             self._on_recognition_roi_setting_changed
         )
+
+    def _on_recognition_roi_at(self, config_id: str, payload: dict) -> None:
+        """多实例：按配置缓存 ROI，当前显示配置即时重绘。"""
+        if not self._is_recognition_roi_enabled():
+            return
+        if self._pool is not None:
+            slot = self._pool.get_slot(config_id)
+            if slot is not None:
+                slot.roi_store.update(payload)
+            if self._multi_grid is not None and slot and slot.last_pil_image:
+                self._multi_grid.update_frame(
+                    config_id, slot.last_pil_image, roi_store=slot.roi_store
+                )
+            if config_id == self._bound_config_id:
+                if slot is not None:
+                    self._roi_store = slot.roi_store
+                self._on_recognition_roi(payload)
+            return
+        if config_id != self._bound_config_id:
+            return
+        self._on_recognition_roi(payload)
 
     def _is_recognition_roi_enabled(self) -> bool:
         return bool(cfg.get(cfg.monitor_recognition_roi_enabled))
@@ -134,11 +240,15 @@ class MonitorInterface(QWidget):
 
     @property
     def is_starting(self) -> bool:
+        if self._pool is not None:
+            return self._pool.is_display_starting() or self._starting_monitoring
         return self._starting_monitoring
 
     @property
     def is_monitoring(self) -> bool:
-        return self._session.monitoring_active
+        if self._pool is not None:
+            return self._pool.is_display_monitoring()
+        return self._legacy_session.monitoring_active
 
     def _setup_ui(self) -> None:
         self.main_layout = QVBoxLayout(self)
@@ -159,13 +269,7 @@ class MonitorInterface(QWidget):
         header_layout.addWidget(self._status_badge, 0, Qt.AlignmentFlag.AlignVCenter)
         self.main_layout.addLayout(header_layout)
 
-        self._subtitle_label = CaptionLabel(
-            self.tr(
-                "Live device preview via an independent controller connection. "
-                "Click the preview to sync taps to the device."
-            ),
-            self,
-        )
+        self._subtitle_label = CaptionLabel("", self)
         self.main_layout.addWidget(self._subtitle_label)
 
         self.preview_card = SimpleCardWidget(self)
@@ -208,6 +312,34 @@ class MonitorInterface(QWidget):
         )
         preview_card_layout.addWidget(self.preview_container, 1)
         self.main_layout.addWidget(self.preview_card, 1)
+
+        self._multi_panel = QWidget(self)
+        self._multi_panel.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._multi_panel.setAutoFillBackground(False)
+        self._multi_panel.setStyleSheet("background: transparent;")
+        multi_panel_layout = QVBoxLayout(self._multi_panel)
+        multi_panel_layout.setContentsMargins(0, 0, 0, 0)
+        multi_panel_layout.setSpacing(0)
+        self._multi_grid = MultiConfigMonitorGrid(
+            is_config_running=lambda cid: self.service_coordinator.is_config_running(
+                cid
+            ),
+            parent=self._multi_panel,
+        )
+        self._multi_grid.tile_clicked.connect(self._on_grid_tile_clicked)
+        multi_panel_layout.addWidget(self._multi_grid)
+        self._multi_panel.hide()
+        self.main_layout.addWidget(self._multi_panel, 1)
+
+        self._single_subtitle_text = self.tr(
+            "Live device preview via an independent controller connection. "
+            "Click the preview to sync taps to the device."
+        )
+        self._multi_subtitle_text = self.tr(
+            "Multi-instance mode: all configurations are shown below. "
+            "Stopped configurations display a power-off indicator. "
+            "Click a card to switch the active configuration."
+        )
 
         self._empty_hint = CaptionLabel(
             self.tr("Preview will appear when monitoring starts"),
@@ -292,8 +424,9 @@ class MonitorInterface(QWidget):
         self.main_layout.setStretch(0, 0)
         self.main_layout.setStretch(1, 0)
         self.main_layout.setStretch(2, 1)
-        self.main_layout.setStretch(3, 0)
+        self.main_layout.setStretch(3, 1)
         self.main_layout.setStretch(4, 0)
+        self.main_layout.setStretch(5, 0)
 
         self._last_frame_timestamp: Optional[float] = None
         self._last_fps_overlay_update: Optional[float] = None
@@ -342,7 +475,79 @@ class MonitorInterface(QWidget):
         self._loading_overlay.setStyleSheet(
             "background-color: rgba(0, 0, 0, 0.35); border-radius: 8px;"
         )
+        if self._multi_grid is not None:
+            self._multi_grid.apply_theme()
         self._update_monitor_status()
+
+    def _collect_config_entries(self) -> list[tuple[str, str]]:
+        entries: list[tuple[str, str]] = []
+        try:
+            summaries = self.service_coordinator.config.list_configs()
+        except Exception:
+            summaries = []
+        for summary in summaries:
+            if isinstance(summary, dict):
+                config_id = summary.get("item_id")
+            else:
+                config_id = getattr(summary, "item_id", None)
+            if not config_id:
+                continue
+            item = self.service_coordinator.config.get_config(config_id)
+            name = item.name if item else str(config_id)
+            entries.append((str(config_id), name))
+        return entries
+
+    def _rebuild_multi_grid(self) -> None:
+        if self._multi_grid is None or self._pool is None:
+            return
+        self._multi_grid.rebuild(self._collect_config_entries())
+        self._multi_grid.set_active_config(self._current_config_id())
+        for config_id, _ in self._collect_config_entries():
+            slot = self._pool.get_slot(config_id)
+            if slot and slot.last_pil_image is not None:
+                self._multi_grid.update_frame(
+                    config_id, slot.last_pil_image, roi_store=slot.roi_store
+                )
+
+    def _apply_layout_mode(self) -> None:
+        """单画面 / 多配置网格布局切换。"""
+        self._init_monitor_pool()
+        multi = self._use_pooled_monitors() and self._pool is not None
+        self.preview_card.setVisible(not multi)
+        self._multi_panel.setVisible(multi)
+        self._resolution_label.setVisible(not multi)
+        self.control_card.setVisible(not multi)
+        self._subtitle_label.setText(
+            self._multi_subtitle_text if multi else self._single_subtitle_text
+        )
+        if multi:
+            self._rebuild_multi_grid()
+        self._update_monitor_status()
+
+    def _on_grid_tile_clicked(self, config_id: str) -> None:
+        if not config_id:
+            return
+        try:
+            self.service_coordinator.select_config(config_id)
+        except Exception as exc:
+            logger.warning("切换配置失败: %s", exc)
+
+    def _on_multi_instance_mode_changed(self, _enabled: bool) -> None:
+        self._apply_layout_mode()
+        if self._pool is not None:
+            try:
+                for cid in self.service_coordinator.running_config_ids():
+                    asyncio.create_task(self._pool.ensure_monitoring(cid, auto=True))
+            except Exception:
+                pass
+
+    def _on_mica_setting_changed(self, _enabled: bool) -> None:
+        if self._multi_grid is not None:
+            self._multi_grid.apply_theme()
+
+    def _on_config_list_changed(self, *_args) -> None:
+        if self._multi_panel.isVisible():
+            self._rebuild_multi_grid()
 
     def _apply_status_badge_style(self, state: str) -> None:
         styles = {
@@ -357,9 +562,30 @@ class MonitorInterface(QWidget):
         )
 
     def _update_monitor_status(self) -> None:
-        session = getattr(self, "_session", None)
-        monitoring_active = session is not None and session.monitoring_active
-        if self._starting_monitoring:
+        if self._multi_panel.isVisible():
+            try:
+                running = len(self.service_coordinator.running_config_ids())
+                total = len(self._collect_config_entries())
+            except Exception:
+                running, total = 0, 0
+            if running > 0:
+                self._status_badge.setText(
+                    self.tr("{0} / {1} running").format(running, total)
+                )
+                self._apply_status_badge_style("running")
+            else:
+                self._status_badge.setText(self.tr("Idle"))
+                self._apply_status_badge_style("idle")
+            return
+
+        if self._pool is not None:
+            monitoring_active = self._pool.is_display_monitoring()
+        else:
+            session = getattr(self, "_legacy_session", None)
+            monitoring_active = session is not None and session.monitoring_active
+        if self._starting_monitoring or (
+            self._pool is not None and self._pool.is_display_starting()
+        ):
             self._status_badge.setText(self.tr("Connecting"))
             self._apply_status_badge_style("connecting")
         elif monitoring_active:
@@ -424,25 +650,125 @@ class MonitorInterface(QWidget):
             self._fps_overlay.move(x, y)
 
     def _bind_auto_task_monitoring(self) -> None:
-        if hasattr(self.service_coordinator, "fs_signals"):
-            self.service_coordinator.fs_signals.fs_start_button_status.connect(
-                self._on_task_status_changed
-            )
+        self.service_coordinator.fs_signal_bus.fs_start_button_status.connect(
+            self._on_task_status_changed
+        )
+        self.service_coordinator.fs_signal_bus.fs_start_button_status_at.connect(
+            self._on_task_status_changed_at
+        )
         signalBus.task_flow_finished.connect(self._on_task_flow_finished)
-        # 多实例：切换当前配置后，监控画面应跟随新的当前配置
+        signalBus.task_flow_finished_at.connect(self._on_task_flow_finished_at)
+        # 配置切换：优先订阅 Core 信号总线（select_config 必经路径）
+        self.service_coordinator.signal_bus.config_changed.connect(
+            self._on_active_config_changed
+        )
         signalBus.config_changed.connect(self._on_active_config_changed)
+        signalBus.config_run_state_changed.connect(self._on_config_run_state_changed)
+        signalBus.multi_instance_mode_changed.connect(
+            self._on_multi_instance_mode_changed
+        )
+        signalBus.micaEnableChanged.connect(self._on_mica_setting_changed)
+        self.service_coordinator.fs_signal_bus.fs_config_added.connect(
+            self._on_config_list_changed
+        )
+        self.service_coordinator.fs_signal_bus.fs_config_removed.connect(
+            self._on_config_list_changed
+        )
 
-    def _on_active_config_changed(self, _config_id: str) -> None:
-        """当前激活配置变化：停止旧配置监控；若新配置在运行则自动接管画面。
+    def _on_config_run_state_changed(self, config_id: str, running: bool) -> None:
+        """多实例：各配置任务启停时维护对应后台监控连接。"""
+        if self._pool is None:
+            return
+        if self._multi_grid is not None:
+            self._multi_grid.set_running(config_id, running)
+        if running:
+            asyncio.create_task(self._pool.ensure_monitoring(config_id, auto=True))
+            if config_id == self._bound_config_id:
+                self._set_monitor_control_running(True)
+            self._update_monitor_status()
+            return
 
-        监控会话基于共享的 task/config 服务（已指向新当前配置），重启后即对应新配置。
-        """
-        was_active = self._session.monitoring_active or self._starting_monitoring
-        if was_active:
+        async def _stop_config_monitor() -> None:
+            await self._pool.stop_monitoring(config_id, clear_cache=True)
+            if self._multi_grid is not None:
+                self._multi_grid.clear_frame(config_id)
+            if config_id == self._bound_config_id:
+                self._emit_preview_cleared()
+                self._set_monitor_control_running(False)
+            self._update_monitor_status()
+
+        asyncio.create_task(_stop_config_monitor())
+
+    def _current_config_id(self) -> str:
+        try:
+            return str(self.service_coordinator.config_service.current_config_id or "")
+        except Exception:
+            return ""
+
+    def _on_task_status_changed_at(self, config_id: str, status: dict) -> None:
+        """多实例：后台配置由 config_run_state_changed 维护；此处仅同步当前配置 UI。"""
+        if self._pool is not None:
+            if config_id != self._current_config_id():
+                return
+            is_running = status.get("text") == "STOP"
+            self._set_monitor_control_running(
+                self._pool.is_display_monitoring() if is_running else False
+            )
+            return
+        if config_id != self._current_config_id():
+            return
+        self._on_task_status_changed(status)
+
+    def _on_task_flow_finished_at(self, config_id: str, payload: dict) -> None:
+        """多实例：停止对应配置的监控；单实例走旧逻辑。"""
+        if self._pool is not None:
+            if config_id == self._bound_config_id:
+                self._clear_recognition_roi()
+            asyncio.create_task(
+                self._pool.stop_monitoring(config_id, clear_cache=True)
+            )
+            if config_id == self._bound_config_id:
+                self._emit_preview_cleared()
+                self._set_monitor_control_running(False)
+            return
+        if config_id != self._bound_config_id:
+            return
+        self._on_task_flow_finished(payload)
+
+    def _on_active_config_changed(self, config_id: str) -> None:
+        """当前激活配置变化：多实例秒切缓存画面；单实例仍重连。"""
+        target_id = config_id or self._current_config_id()
+
+        if self._pool is not None:
+            self._bound_config_id = target_id
+            self._pool.set_display_config(target_id)
+            self._roi_store = self._pool.get_display_roi_store()
+            if self._multi_grid is not None:
+                self._multi_grid.set_active_config(target_id)
+            self._emit_preview_cleared()
+            self._set_monitor_control_running(self._pool.is_display_monitoring())
+            self._update_monitor_status()
+            if self.service_coordinator.is_config_running(target_id):
+                asyncio.create_task(
+                    self._pool.ensure_monitoring(target_id, auto=True)
+                )
+            return
+
+        if target_id == self._bound_config_id and not (
+            self._legacy_session.monitoring_active or self._starting_monitoring
+        ):
+            return
+
+        was_active = self._legacy_session.monitoring_active or self._starting_monitoring
+        if was_active or self._bound_config_id:
             self._request_stop_monitoring(reason="config_changed")
             self._emit_preview_cleared()
+        self._bound_config_id = None
+        self._clear_recognition_roi()
 
         def _maybe_restart() -> None:
+            if target_id != self._current_config_id():
+                return
             try:
                 should_run = bool(
                     self.service_coordinator.is_current_config_running()
@@ -450,11 +776,10 @@ class MonitorInterface(QWidget):
             except Exception:
                 should_run = False
             if should_run and not (
-                self._session.monitoring_active or self._starting_monitoring
+                self._legacy_session.monitoring_active or self._starting_monitoring
             ):
                 self._start_monitoring(auto=True)
 
-        # 等待停止流程与防抖完成后再决定是否为新配置启动监控
         QTimer.singleShot(2 * self._control_debounce_ms + 50, _maybe_restart)
 
     def _set_loading(self, loading: bool) -> None:
@@ -662,24 +987,64 @@ class MonitorInterface(QWidget):
             loop.create_task(self._on_session_controller_disconnected())
 
     def _on_task_flow_finished(self, payload: dict) -> None:
+        if self._pool is not None:
+            return
         self._clear_recognition_roi()
-        if self._session.monitoring_active or self._starting_monitoring:
+        if self._legacy_session.monitoring_active or self._starting_monitoring:
             logger.debug(f"[Monitor] 收到 task_flow_finished: {payload}，请求停止监控")
             self._request_stop_monitoring(reason="task_flow_finished")
 
     def _on_task_status_changed(self, status: dict) -> None:
+        if self._pool is not None:
+            return
         is_running = status.get("text") == "STOP"
-        if (
-            is_running
-            and not self._session.monitoring_active
-            and not self._starting_monitoring
-        ):
-            self._start_monitoring(auto=True)
-        elif not is_running and self._session.monitoring_active:
-            self._request_stop_monitoring(reason="task_stopped")
+        current_id = self._current_config_id()
+        if is_running:
+            if (
+                self._legacy_session.monitoring_active
+                and self._bound_config_id != current_id
+            ):
+                self._request_stop_monitoring(reason="config_switch_while_running")
+                self._emit_preview_cleared()
+                self._bound_config_id = None
+                QTimer.singleShot(
+                    2 * self._control_debounce_ms + 50,
+                    lambda: self._start_monitoring(auto=True),
+                )
+                return
+            if (
+                not self._legacy_session.monitoring_active
+                and not self._starting_monitoring
+            ):
+                self._start_monitoring(auto=True)
+        elif not is_running and self._legacy_session.monitoring_active:
+            if self._bound_config_id in (None, "", current_id):
+                self._request_stop_monitoring(reason="task_stopped")
 
-    def _request_stop_monitoring(self, *, reason: str = "") -> None:
-        if not (self._session.monitoring_active or self._starting_monitoring):
+    def _request_stop_monitoring(
+        self, *, reason: str = "", config_id: str | None = None
+    ) -> None:
+        target_id = config_id or self._bound_config_id or self._current_config_id()
+        if self._pool is not None:
+            slot = self._pool.get_slot(target_id)
+            if slot is None or not (
+                slot.session.monitoring_active or slot.starting
+            ):
+                return
+            if self._stopping_monitoring:
+                logger.debug("[Monitor] stop 已在进行中，忽略: %s", reason)
+                return
+            if self._stop_debounce_timer.isActive():
+                self._stop_debounce_timer.stop()
+            self._set_loading(False)
+            slot.session.stop_loop()
+            self._pending_stop_config_id = target_id
+            self._stop_debounce_timer.start(self._control_debounce_ms)
+            return
+
+        if not (
+            self._legacy_session.monitoring_active or self._starting_monitoring
+        ):
             return
         if self._stopping_monitoring:
             logger.debug(f"[Monitor] stop 已在进行中，忽略: {reason}")
@@ -687,13 +1052,18 @@ class MonitorInterface(QWidget):
         if self._stop_debounce_timer.isActive():
             self._stop_debounce_timer.stop()
         self._set_loading(False)
-        self._session.stop_loop()
+        self._legacy_session.stop_loop()
+        self._pending_stop_config_id = None
         self._stop_debounce_timer.start(self._control_debounce_ms)
 
     def _is_control_busy(self) -> bool:
+        pool_busy = False
+        if self._pool is not None:
+            pool_busy = self._pool.is_display_starting() or self._pool.is_display_stopping()
         return (
             self._starting_monitoring
             or self._stopping_monitoring
+            or pool_busy
             or self._stop_debounce_timer.isActive()
             or self._start_debounce_timer.isActive()
         )
@@ -789,7 +1159,7 @@ class MonitorInterface(QWidget):
     def _on_monitor_control_clicked(self) -> None:
         if self._is_control_busy():
             return
-        if self._session.monitoring_active:
+        if self.is_monitoring:
             self._set_control_button_enabled(False)
             self._request_stop_monitoring(reason="manual_or_ui")
         else:
@@ -799,7 +1169,7 @@ class MonitorInterface(QWidget):
     def _request_start_monitoring(self, *, manual: bool = False) -> None:
         if manual:
             if (
-                self._session.monitoring_active
+                self.is_monitoring
                 or self._starting_monitoring
                 or self._stopping_monitoring
             ):
@@ -819,17 +1189,72 @@ class MonitorInterface(QWidget):
         self._start_monitoring_impl(auto=auto)
 
     def _start_monitoring_impl(self, *, auto: bool = False) -> None:
-        if self._session.monitoring_active or self._starting_monitoring:
+        target_id = self._current_config_id()
+        self._bound_config_id = target_id
+
+        if self._pool is not None:
+            if self._pool.is_display_monitoring():
+                if not auto:
+                    self._set_control_button_enabled(True)
+                return
+            self._pool.set_display_config(target_id)
+            self._roi_store = self._pool.get_display_roi_store()
+            logger.info(
+                "[Monitor] 开始启动监控（%s），配置=%s",
+                "自动" if auto else "手动",
+                target_id or "?",
+            )
+            self._starting_monitoring = True
+            self._set_loading(True)
+
+            async def _start_sequence() -> None:
+                try:
+                    started = await self._pool.ensure_monitoring(
+                        target_id, auto=auto
+                    )
+                    if not started:
+                        if not auto:
+                            signalBus.info_bar_requested.emit(
+                                "error",
+                                self.tr(
+                                    "Device connection failed, cannot start monitoring"
+                                ),
+                            )
+                        return
+                    self._set_monitor_control_running(True)
+                    if not auto:
+                        signalBus.info_bar_requested.emit(
+                            "success", self.tr("Monitoring started")
+                        )
+                except Exception as exc:
+                    logger.error("[Monitor] 启动监控失败: %s", exc, exc_info=True)
+                    if not auto:
+                        signalBus.info_bar_requested.emit(
+                            "error",
+                            self.tr("Failed to start monitoring: ") + str(exc),
+                        )
+                finally:
+                    self._starting_monitoring = False
+                    self._set_loading(False)
+                    self._set_control_button_enabled(True)
+
+            QTimer.singleShot(0, lambda: asyncio.create_task(_start_sequence()))
+            return
+
+        if self._legacy_session.monitoring_active or self._starting_monitoring:
             if not auto:
                 self._set_control_button_enabled(True)
             return
 
-        logger.info(f"[Monitor] 开始启动监控（{'自动' if auto else '手动'}）")
+        logger.info(
+            f"[Monitor] 开始启动监控（{'自动' if auto else '手动'}）"
+            f"，配置={target_id or '?'}"
+        )
         self._set_loading(True)
 
         async def _start_sequence() -> None:
             try:
-                started = await self._session.run_startup_sequence(
+                started = await self._legacy_session.run_startup_sequence(
                     should_abort=lambda: not self._starting_monitoring,
                 )
                 if not started:
@@ -853,8 +1278,8 @@ class MonitorInterface(QWidget):
                     signalBus.info_bar_requested.emit(
                         "error", self.tr("Failed to start monitoring: ") + str(exc)
                     )
-                if self._session.monitoring_active:
-                    self._session.stop_loop()
+                if self._legacy_session.monitoring_active:
+                    self._legacy_session.stop_loop()
             finally:
                 self._set_loading(False)
                 self._set_control_button_enabled(True)
@@ -871,24 +1296,39 @@ class MonitorInterface(QWidget):
 
         self._stopping_monitoring = True
         self._set_loading(False)
+        stop_id = (
+            self._pending_stop_config_id
+            or self._bound_config_id
+            or self._current_config_id()
+        )
 
         async def _stop_sequence() -> None:
             try:
-                await self._session.stop()
-                self._emit_preview_cleared()
-                self._set_monitor_control_running(False)
+                if self._pool is not None:
+                    await self._pool.stop_monitoring(stop_id, clear_cache=False)
+                    if stop_id == self._bound_config_id:
+                        self._emit_preview_cleared()
+                        self._set_monitor_control_running(False)
+                else:
+                    await self._legacy_session.stop()
+                    self._emit_preview_cleared()
+                    self._bound_config_id = None
+                    self._set_monitor_control_running(False)
                 logger.info("[Monitor] 监控已停止")
             except Exception as exc:
                 logger.error(f"[Monitor] 停止监控失败: {exc}", exc_info=True)
             finally:
                 self._stopping_monitoring = False
+                self._pending_stop_config_id = None
                 self._set_control_button_enabled(True)
 
         QTimer.singleShot(0, lambda: asyncio.create_task(_stop_sequence()))
 
     def lock_monitor_page(self, stop_loop: bool = True) -> None:
-        if stop_loop:
-            self._session.stop_loop()
+        if self._pool is not None:
+            self._pool.shutdown_sync()
+        elif stop_loop:
+            self._legacy_session.stop_loop()
         else:
-            self._session.deactivate()
+            self._legacy_session.deactivate()
         self._set_monitor_control_running(False)

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -103,7 +103,7 @@ class MonitorInterface(QWidget):
             self._legacy_monitor_task, log_prefix="Monitor"
         )
         self._legacy_session.set_callbacks(
-            on_frame=self._apply_preview_from_pil,
+            on_frame=self._enqueue_preview_frame,
             on_capture_failure_clear=self._emit_preview_cleared,
             on_controller_disconnected=self._on_session_controller_disconnected,
         )
@@ -175,24 +175,47 @@ class MonitorInterface(QWidget):
                         )
                 elif self.service_coordinator.is_config_running(config_id):
                     self._multi_grid.clear_monitor_loading(config_id)
-            if config_id == self._bound_config_id:
+            if config_id == self._current_config_id():
+                if started:
+                    self.sync_task_preview()
                 self._set_loading(False)
                 self._set_monitor_control_running(
                     self._pool.is_display_monitoring()
                 )
-                self._update_monitor_status()
+            self._update_monitor_status()
 
         asyncio.create_task(_run())
 
+    def _enqueue_preview_frame(
+        self, pil_image: Image.Image, *, config_id: str | None = None
+    ) -> None:
+        """将帧投递到 Qt 主线程，避免异步循环直接改 UI。"""
+        try:
+            frame = pil_image.copy()
+        except Exception:
+            frame = pil_image
+        cid = config_id or self._bound_config_id or self._current_config_id() or ""
+        QTimer.singleShot(
+            0, lambda c=cid, f=frame: self._deliver_preview_frame(c, f)
+        )
+
+    def _deliver_preview_frame(self, config_id: str, pil_image: Image.Image) -> None:
+        if self._pool is not None:
+            slot = self._pool.get_slot(config_id) if config_id else None
+            roi_store = slot.roi_store if slot else None
+            if self._multi_grid is not None and config_id:
+                self._multi_grid.update_frame(
+                    config_id, pil_image, roi_store=roi_store
+                )
+            current_id = self._current_config_id()
+            if config_id and config_id == current_id:
+                self._bound_config_id = current_id
+                self._apply_preview_from_pil(pil_image, config_id=config_id)
+            return
+        self._apply_preview_from_pil(pil_image, config_id=config_id or None)
+
     def _on_pooled_frame(self, config_id: str, pil_image: Image.Image) -> None:
-        slot = self._pool.get_slot(config_id) if self._pool else None
-        roi_store = slot.roi_store if slot else None
-        if self._multi_grid is not None:
-            self._multi_grid.update_frame(
-                config_id, pil_image, roi_store=roi_store
-            )
-        if config_id == self._bound_config_id:
-            self._apply_preview_from_pil(pil_image, config_id=config_id)
+        self._enqueue_preview_frame(pil_image, config_id=config_id)
 
     def _on_pooled_capture_cleared(self, config_id: str) -> None:
         if self._multi_grid is not None:
@@ -273,6 +296,20 @@ class MonitorInterface(QWidget):
         if not self._is_recognition_roi_enabled():
             return
         self._roi_store.update(payload)
+
+    def sync_task_preview(self) -> None:
+        """任务页监控预览：仅使用监控池自身采集到的最后一帧。"""
+        current_id = self._current_config_id()
+        if not current_id:
+            return
+        self._bound_config_id = current_id
+        if self._pool is None:
+            return
+        slot = self._pool.get_slot(current_id)
+        if slot is not None and slot.last_pil_image is not None:
+            self._apply_preview_from_pil(
+                slot.last_pil_image, config_id=current_id
+            )
 
     @property
     def source_preview_pixmap(self) -> Optional[QPixmap]:
@@ -721,6 +758,10 @@ class MonitorInterface(QWidget):
         if self._multi_grid is not None:
             self._multi_grid.set_running(config_id, running)
         if running:
+            current_id = self._current_config_id()
+            if config_id == current_id:
+                self._bound_config_id = current_id
+                self._emit_preview_cleared(clear_roi=False)
             self._schedule_pool_monitoring(config_id, auto=True)
             self._update_monitor_status()
             return
@@ -806,14 +847,7 @@ class MonitorInterface(QWidget):
                     return
                 if self._bound_config_id != target_id:
                     return
-                if not self._pool.is_display_monitoring():
-                    return
-                slot = self._pool.get_slot(target_id)
-                if slot is None or slot.last_pil_image is None:
-                    return
-                self._apply_preview_from_pil(
-                    slot.last_pil_image, config_id=target_id
-                )
+                self.sync_task_preview()
 
             QTimer.singleShot(0, _maybe_restore_target_preview)
             self._set_monitor_control_running(self._pool.is_display_monitoring())

--- a/app/view/monitor_interface/monitor_interface.py
+++ b/app/view/monitor_interface/monitor_interface.py
@@ -77,6 +77,7 @@ class MonitorInterface(QWidget):
         self._is_landscape: Optional[bool] = None
         self._roi_store = RecognitionRoiStore()
         self._bound_config_id: Optional[str] = None
+        self._last_config_switch_id: Optional[str] = None
         self._pool: Optional[ConfigMonitorPool] = None
         self._multi_grid: Optional[MultiConfigMonitorGrid] = None
 
@@ -662,7 +663,6 @@ class MonitorInterface(QWidget):
         self.service_coordinator.signal_bus.config_changed.connect(
             self._on_active_config_changed
         )
-        signalBus.config_changed.connect(self._on_active_config_changed)
         signalBus.config_run_state_changed.connect(self._on_config_run_state_changed)
         signalBus.multi_instance_mode_changed.connect(
             self._on_multi_instance_mode_changed
@@ -740,18 +740,19 @@ class MonitorInterface(QWidget):
         target_id = config_id or self._current_config_id()
 
         if self._pool is not None:
+            if target_id == self._last_config_switch_id:
+                return
+            self._last_config_switch_id = target_id
             self._bound_config_id = target_id
-            self._pool.set_display_config(target_id)
+            cached = self._pool.set_display_config(target_id)
             self._roi_store = self._pool.get_display_roi_store()
             if self._multi_grid is not None:
                 self._multi_grid.set_active_config(target_id)
-            self._emit_preview_cleared()
+            self._emit_preview_cleared(clear_roi=False)
+            if cached is not None:
+                self._apply_preview_from_pil(cached)
             self._set_monitor_control_running(self._pool.is_display_monitoring())
             self._update_monitor_status()
-            if self.service_coordinator.is_config_running(target_id):
-                asyncio.create_task(
-                    self._pool.ensure_monitoring(target_id, auto=True)
-                )
             return
 
         if target_id == self._bound_config_id and not (
@@ -796,12 +797,13 @@ class MonitorInterface(QWidget):
         self._update_monitor_status()
         self._reposition_preview_overlays()
 
-    def _emit_preview_cleared(self) -> None:
+    def _emit_preview_cleared(self, *, clear_roi: bool = True) -> None:
         self._preview_pixmap = None
         self._current_pil_image = None
         self._image_width = None
         self._image_height = None
-        self._roi_store.clear()
+        if clear_roi:
+            self._roi_store.clear()
         self.preview_label.clear()
         self._update_fps_overlay(None)
         self._update_resolution_label()

--- a/app/view/monitor_interface/multi_config_monitor_grid.py
+++ b/app/view/monitor_interface/multi_config_monitor_grid.py
@@ -56,13 +56,14 @@ class ConfigMonitorTile(SimpleCardWidget):
         self._running = False
         self._active = False
         self._loading = False
+        self._last_pil_image: Optional[Image.Image] = None
         self._roi_store = RecognitionRoiStore()
 
         self.setClickEnabled(False)
         self.setBorderRadius(8)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
         )
 
         layout = QVBoxLayout(self)
@@ -84,6 +85,9 @@ class ConfigMonitorTile(SimpleCardWidget):
 
         self._preview_host = QWidget(self)
         self._preview_host.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        self._preview_host.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         host_layout = QVBoxLayout(self._preview_host)
         host_layout.setContentsMargins(0, 0, 0, 0)
 
@@ -93,7 +97,7 @@ class ConfigMonitorTile(SimpleCardWidget):
         self._preview_label.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
         )
-        host_layout.addWidget(self._preview_label)
+        host_layout.addWidget(self._preview_label, 1)
 
         self._idle_overlay = QWidget(self._preview_host)
         self._idle_overlay.setAttribute(
@@ -112,7 +116,7 @@ class ConfigMonitorTile(SimpleCardWidget):
         self._loading_ring.setFixedSize(32, 32)
         self._loading_ring.hide()
 
-        layout.addWidget(self._preview_host)
+        layout.addWidget(self._preview_host, 1)
 
         self._active_border = QFrame(self)
         self._active_border.setAttribute(
@@ -141,6 +145,7 @@ class ConfigMonitorTile(SimpleCardWidget):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._reposition_overlays()
+        self._refresh_preview()
         if hasattr(self, "_active_border"):
             self._active_border.setGeometry(self.rect())
 
@@ -206,6 +211,7 @@ class ConfigMonitorTile(SimpleCardWidget):
         else:
             self._running_ring.hide()
             self._running_ring.stop()
+            self._last_pil_image = None
             self._preview_label.clear()
             self._idle_overlay.show()
             self._set_loading(False)
@@ -225,17 +231,25 @@ class ConfigMonitorTile(SimpleCardWidget):
         self._reposition_overlays()
 
     def clear_preview(self) -> None:
+        self._last_pil_image = None
         self._preview_label.clear()
 
-    def update_preview(
-        self,
-        pil_image: Image.Image,
-        *,
-        roi_store: Optional[RecognitionRoiStore] = None,
-    ) -> None:
-        if not self._running:
+    def _preview_target_size(self) -> QSize:
+        host = self._preview_host
+        if host.width() > 0 and host.height() > 0:
+            return host.size()
+        label = self._preview_label
+        if label.width() > 0 and label.height() > 0:
+            return label.size()
+        return QSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+
+    def _refresh_preview(self) -> None:
+        if self._last_pil_image is None or not self._running:
             return
-        store = roi_store or self._roi_store
+        self._render_preview(self._last_pil_image)
+
+    def _render_preview(self, pil_image: Image.Image) -> None:
+        store = self._roi_store
         pixmap = _pil_to_pixmap(pil_image)
         if bool(cfg.get(cfg.monitor_recognition_roi_enabled)):
             active_roi = store.peek()
@@ -246,7 +260,7 @@ class ConfigMonitorTile(SimpleCardWidget):
                     label=active_roi.get("node", ""),
                     phase=active_roi.get("phase", "hit"),
                 )
-        target = self._preview_label.size()
+        target = self._preview_target_size()
         if target.width() > 0 and target.height() > 0:
             pixmap = pixmap.scaled(
                 target,
@@ -256,6 +270,19 @@ class ConfigMonitorTile(SimpleCardWidget):
         self._preview_label.setPixmap(pixmap)
         self._set_loading(False)
         self._idle_overlay.hide()
+
+    def update_preview(
+        self,
+        pil_image: Image.Image,
+        *,
+        roi_store: Optional[RecognitionRoiStore] = None,
+    ) -> None:
+        if not self._running:
+            return
+        if roi_store is not None:
+            self._roi_store = roi_store
+        self._last_pil_image = pil_image
+        self._render_preview(pil_image)
 
     def apply_theme(self) -> None:
         self._apply_mica_compat()
@@ -317,6 +344,9 @@ class MultiConfigMonitorGrid(ScrollArea):
                 tile = self._tiles.pop(cid)
                 tile.deleteLater()
 
+        cols = self._column_count(len(configs))
+        rows = max(1, (len(configs) + cols - 1) // cols)
+
         for idx, (cid, name) in enumerate(configs):
             tile = self._tiles.get(cid)
             if tile is None:
@@ -326,8 +356,13 @@ class MultiConfigMonitorGrid(ScrollArea):
             else:
                 tile.set_config_name(name)
 
-            row, col = divmod(idx, self._column_count(len(configs)))
+            row, col = divmod(idx, cols)
             self._grid.addWidget(tile, row, col)
+
+        for col_idx in range(cols):
+            self._grid.setColumnStretch(col_idx, 1)
+        for row_idx in range(rows):
+            self._grid.setRowStretch(row_idx, 1)
 
         for cid in keep_ids:
             tile = self._tiles.get(cid)
@@ -391,6 +426,17 @@ class MultiConfigMonitorGrid(ScrollArea):
         tile.clear_preview()
         if not self._is_config_running(config_id):
             tile.set_running(False)
+
+    def refresh_all_previews(self) -> None:
+        for tile in self._tiles.values():
+            tile._refresh_preview()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        viewport = self.viewport()
+        if viewport is not None:
+            self._container.setMinimumSize(viewport.size())
+        self.refresh_all_previews()
 
     def apply_theme(self) -> None:
         _apply_scroll_mica_compat(self, self._container)

--- a/app/view/monitor_interface/multi_config_monitor_grid.py
+++ b/app/view/monitor_interface/multi_config_monitor_grid.py
@@ -365,6 +365,11 @@ class MultiConfigMonitorGrid(ScrollArea):
         else:
             tile.clear_preview()
 
+    def clear_monitor_loading(self, config_id: str) -> None:
+        tile = self._tiles.get(config_id)
+        if tile is not None:
+            tile.set_loading(False)
+
     def update_frame(
         self,
         config_id: str,

--- a/app/view/monitor_interface/multi_config_monitor_grid.py
+++ b/app/view/monitor_interface/multi_config_monitor_grid.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from PIL import Image
 from PySide6.QtCore import QSize, Qt, Signal
-from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtGui import QImage, QPainter, QPixmap
 from PySide6.QtWidgets import (
     QFrame,
     QGridLayout,
@@ -39,6 +39,25 @@ def _pil_to_pixmap(pil_image: Image.Image) -> QPixmap:
     buffer = rgb.tobytes("raw", "RGB")
     qimage = QImage(buffer, w, h, w * 3, QImage.Format.Format_RGB888)
     return QPixmap.fromImage(qimage)
+
+
+def _scale_pixmap_centered(pixmap: QPixmap, target: QSize) -> QPixmap:
+    """等比缩放并居中绘制到目标尺寸画布上。"""
+    if pixmap.isNull() or target.width() <= 0 or target.height() <= 0:
+        return pixmap
+    scaled = pixmap.scaled(
+        target,
+        Qt.AspectRatioMode.KeepAspectRatio,
+        Qt.TransformationMode.SmoothTransformation,
+    )
+    canvas = QPixmap(target.width(), target.height())
+    canvas.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(canvas)
+    x = max(0, (target.width() - scaled.width()) // 2)
+    y = max(0, (target.height() - scaled.height()) // 2)
+    painter.drawPixmap(x, y, scaled)
+    painter.end()
+    return canvas
 
 
 class ConfigMonitorTile(SimpleCardWidget):
@@ -262,11 +281,7 @@ class ConfigMonitorTile(SimpleCardWidget):
                 )
         target = self._preview_target_size()
         if target.width() > 0 and target.height() > 0:
-            pixmap = pixmap.scaled(
-                target,
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
-            )
+            pixmap = _scale_pixmap_centered(pixmap, target)
         self._preview_label.setPixmap(pixmap)
         self._set_loading(False)
         self._idle_overlay.hide()

--- a/app/view/monitor_interface/multi_config_monitor_grid.py
+++ b/app/view/monitor_interface/multi_config_monitor_grid.py
@@ -1,0 +1,393 @@
+"""多实例模式：监控页同时展示所有配置的实时画面。"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional, Tuple
+
+from PIL import Image
+from PySide6.QtCore import QSize, Qt, Signal
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from qfluentwidgets import (
+    BodyLabel,
+    CaptionLabel,
+    FluentIcon as FIF,
+    IconWidget,
+    IndeterminateProgressRing,
+    PixmapLabel,
+    ScrollArea,
+    SimpleCardWidget,
+    isDarkTheme,
+)
+
+from app.common.config import cfg
+from app.view.monitor.recognition_roi_store import RecognitionRoiStore
+from app.view.monitor.roi_overlay import draw_roi_on_pixmap
+
+
+def _pil_to_pixmap(pil_image: Image.Image) -> QPixmap:
+    rgb = pil_image.convert("RGB")
+    w, h = rgb.size
+    buffer = rgb.tobytes("raw", "RGB")
+    qimage = QImage(buffer, w, h, w * 3, QImage.Format.Format_RGB888)
+    return QPixmap.fromImage(qimage)
+
+
+class ConfigMonitorTile(SimpleCardWidget):
+    """单个配置的监控卡片。"""
+
+    config_selected = Signal(str)
+
+    _PREVIEW_MIN_W = 280
+    _PREVIEW_MIN_H = 158
+
+    def __init__(self, config_id: str, config_name: str, parent=None):
+        super().__init__(parent)
+        self.config_id = config_id
+        self._config_name = config_name
+        self._running = False
+        self._active = False
+        self._loading = False
+        self._roi_store = RecognitionRoiStore()
+
+        self.setClickEnabled(False)
+        self.setBorderRadius(8)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(6)
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.setSpacing(6)
+        self._name_label = BodyLabel(config_name, self)
+        self._running_ring = IndeterminateProgressRing(self)
+        self._running_ring.setFixedSize(20, 20)
+        self._running_ring.setStrokeWidth(2)
+        self._running_ring.setToolTip(self.tr("Running"))
+        self._running_ring.hide()
+        header.addWidget(self._name_label, 1)
+        header.addWidget(self._running_ring, 0, Qt.AlignmentFlag.AlignVCenter)
+        layout.addLayout(header)
+
+        self._preview_host = QWidget(self)
+        self._preview_host.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        host_layout = QVBoxLayout(self._preview_host)
+        host_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._preview_label = PixmapLabel(self._preview_host)
+        self._preview_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._preview_label.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        self._preview_label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
+        host_layout.addWidget(self._preview_label)
+
+        self._idle_overlay = QWidget(self._preview_host)
+        self._idle_overlay.setAttribute(
+            Qt.WidgetAttribute.WA_TransparentForMouseEvents, True
+        )
+        idle_layout = QVBoxLayout(self._idle_overlay)
+        idle_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._power_icon = IconWidget(FIF.POWER_BUTTON, self._idle_overlay)
+        self._power_icon.setFixedSize(48, 48)
+        self._idle_hint = CaptionLabel(self.tr("Not running"), self._idle_overlay)
+        self._idle_hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        idle_layout.addWidget(self._power_icon, 0, Qt.AlignmentFlag.AlignCenter)
+        idle_layout.addWidget(self._idle_hint)
+
+        self._loading_ring = IndeterminateProgressRing(self._preview_host)
+        self._loading_ring.setFixedSize(32, 32)
+        self._loading_ring.hide()
+
+        layout.addWidget(self._preview_host)
+
+        self._active_border = QFrame(self)
+        self._active_border.setAttribute(
+            Qt.WidgetAttribute.WA_TransparentForMouseEvents, True
+        )
+        self._active_border.hide()
+
+        self._apply_styles()
+        self._apply_mica_compat()
+        self.set_running(False)
+
+    def _apply_mica_compat(self) -> None:
+        """与主窗口 Mica 背景兼容：保持 SimpleCardWidget 默认半透明，不覆写卡片底色。"""
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAutoFillBackground(False)
+        self._preview_host.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._preview_host.setAutoFillBackground(False)
+        self._preview_host.setStyleSheet("background: transparent;")
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.config_selected.emit(self.config_id)
+        # 跳过 SimpleCardWidget.mouseReleaseEvent，避免其无参 clicked 与 config_selected 冲突
+        QWidget.mouseReleaseEvent(self, event)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._reposition_overlays()
+        if hasattr(self, "_active_border"):
+            self._active_border.setGeometry(self.rect())
+
+    def _reposition_overlays(self) -> None:
+        host = self._preview_host
+        if host.width() <= 0 or host.height() <= 0:
+            return
+        self._idle_overlay.setGeometry(0, 0, host.width(), host.height())
+        ring = self._loading_ring
+        ring.move(
+            max(0, (host.width() - ring.width()) // 2),
+            max(0, (host.height() - ring.height()) // 2),
+        )
+
+    def _apply_styles(self) -> None:
+        muted = (
+            "rgba(160, 160, 160, 0.95)"
+            if isDarkTheme()
+            else "rgba(96, 96, 96, 0.95)"
+        )
+        self._idle_hint.setStyleSheet(f"color: {muted};")
+        preview_bg = (
+            "rgba(255, 255, 255, 0.04)"
+            if isDarkTheme()
+            else "rgba(0, 0, 0, 0.03)"
+        )
+        self._preview_label.setStyleSheet(
+            f"border-radius: 6px; background-color: {preview_bg};"
+        )
+        self._idle_overlay.setStyleSheet(
+            "background-color: rgba(0, 0, 0, 0.42); border-radius: 6px;"
+        )
+        self._update_active_border()
+
+    def _update_active_border(self) -> None:
+        if self._active:
+            self._active_border.setStyleSheet(
+                "QFrame {"
+                "  border: 2px solid #50c878;"
+                "  border-radius: 8px;"
+                "  background: transparent;"
+                "}"
+            )
+            self._active_border.show()
+            self._active_border.raise_()
+        else:
+            self._active_border.hide()
+
+    def set_config_name(self, name: str) -> None:
+        self._config_name = name
+        self._name_label.setText(name)
+
+    def set_active(self, active: bool) -> None:
+        self._active = bool(active)
+        self._update_active_border()
+
+    def set_running(self, running: bool) -> None:
+        self._running = bool(running)
+        if running:
+            self._running_ring.show()
+            self._running_ring.start()
+            self._idle_overlay.hide()
+        else:
+            self._running_ring.hide()
+            self._running_ring.stop()
+            self._preview_label.clear()
+            self._idle_overlay.show()
+            self._set_loading(False)
+        self._reposition_overlays()
+
+    def set_loading(self, loading: bool) -> None:
+        self._set_loading(loading)
+
+    def _set_loading(self, loading: bool) -> None:
+        self._loading = bool(loading)
+        if loading and self._running:
+            self._loading_ring.show()
+            self._loading_ring.start()
+        else:
+            self._loading_ring.hide()
+            self._loading_ring.stop()
+        self._reposition_overlays()
+
+    def clear_preview(self) -> None:
+        self._preview_label.clear()
+
+    def update_preview(
+        self,
+        pil_image: Image.Image,
+        *,
+        roi_store: Optional[RecognitionRoiStore] = None,
+    ) -> None:
+        if not self._running:
+            return
+        store = roi_store or self._roi_store
+        pixmap = _pil_to_pixmap(pil_image)
+        if bool(cfg.get(cfg.monitor_recognition_roi_enabled)):
+            active_roi = store.peek()
+            if active_roi and active_roi.get("box"):
+                pixmap = draw_roi_on_pixmap(
+                    pixmap,
+                    active_roi["box"],
+                    label=active_roi.get("node", ""),
+                    phase=active_roi.get("phase", "hit"),
+                )
+        target = self._preview_label.size()
+        if target.width() > 0 and target.height() > 0:
+            pixmap = pixmap.scaled(
+                target,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        self._preview_label.setPixmap(pixmap)
+        self._set_loading(False)
+        self._idle_overlay.hide()
+
+    def apply_theme(self) -> None:
+        self._apply_mica_compat()
+        self._apply_styles()
+
+
+def _apply_scroll_mica_compat(scroll: ScrollArea, content: QWidget) -> None:
+    """ScrollArea 透明化，使内部 SimpleCardWidget 能透出 Mica 背景。"""
+    scroll.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+    scroll.setAutoFillBackground(False)
+    scroll.setStyleSheet("ScrollArea { background: transparent; border: none; }")
+    viewport = scroll.viewport()
+    if viewport is not None:
+        viewport.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        viewport.setAutoFillBackground(False)
+        viewport.setStyleSheet("background: transparent; border: none;")
+    content.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+    content.setAutoFillBackground(False)
+    content.setStyleSheet("background: transparent;")
+
+
+class MultiConfigMonitorGrid(ScrollArea):
+    """滚动网格：每个配置一张监控卡片。"""
+
+    tile_clicked = Signal(str)
+
+    def __init__(
+        self,
+        *,
+        is_config_running: Callable[[str], bool],
+        parent=None,
+    ):
+        super().__init__(parent=parent)
+        self._is_config_running = is_config_running
+        self._tiles: Dict[str, ConfigMonitorTile] = {}
+        self._active_config_id: str = ""
+
+        self.setWidgetResizable(True)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        self._container = QWidget(self)
+        self._grid = QGridLayout(self._container)
+        self._grid.setContentsMargins(4, 4, 4, 4)
+        self._grid.setSpacing(12)
+        self.setWidget(self._container)
+        _apply_scroll_mica_compat(self, self._container)
+
+    def rebuild(self, configs: List[Tuple[str, str]]) -> None:
+        """configs: [(config_id, display_name), ...]"""
+        keep_ids = {cid for cid, _ in configs}
+
+        while self._grid.count():
+            item = self._grid.takeAt(0)
+            if item.widget():
+                item.widget().setParent(None)
+
+        for cid in list(self._tiles.keys()):
+            if cid not in keep_ids:
+                tile = self._tiles.pop(cid)
+                tile.deleteLater()
+
+        for idx, (cid, name) in enumerate(configs):
+            tile = self._tiles.get(cid)
+            if tile is None:
+                tile = ConfigMonitorTile(cid, name, self._container)
+                tile.config_selected.connect(self.tile_clicked.emit)
+                self._tiles[cid] = tile
+            else:
+                tile.set_config_name(name)
+
+            row, col = divmod(idx, self._column_count(len(configs)))
+            self._grid.addWidget(tile, row, col)
+
+        for cid in keep_ids:
+            tile = self._tiles.get(cid)
+            if tile is None:
+                continue
+            running = self._is_config_running(cid)
+            tile.set_running(running)
+            tile.set_active(cid == self._active_config_id)
+            if running and (
+                tile._preview_label.pixmap() is None
+                or tile._preview_label.pixmap().isNull()
+            ):
+                tile.set_loading(True)
+
+    @staticmethod
+    def _column_count(total: int) -> int:
+        if total <= 1:
+            return 1
+        if total <= 4:
+            return 2
+        return 3
+
+    def set_active_config(self, config_id: str) -> None:
+        self._active_config_id = config_id or ""
+        for cid, tile in self._tiles.items():
+            tile.set_active(cid == self._active_config_id)
+
+    def set_running(self, config_id: str, running: bool) -> None:
+        tile = self._tiles.get(config_id)
+        if tile is None:
+            return
+        tile.set_running(running)
+        if running:
+            tile.set_loading(True)
+        else:
+            tile.clear_preview()
+
+    def update_frame(
+        self,
+        config_id: str,
+        pil_image: Image.Image,
+        *,
+        roi_store: Optional[RecognitionRoiStore] = None,
+    ) -> None:
+        tile = self._tiles.get(config_id)
+        if tile is None:
+            return
+        if roi_store is not None:
+            tile._roi_store = roi_store
+        tile.update_preview(pil_image, roi_store=roi_store)
+
+    def clear_frame(self, config_id: str) -> None:
+        tile = self._tiles.get(config_id)
+        if tile is None:
+            return
+        tile.clear_preview()
+        if not self._is_config_running(config_id):
+            tile.set_running(False)
+
+    def apply_theme(self) -> None:
+        _apply_scroll_mica_compat(self, self._container)
+        for tile in self._tiles.values():
+            tile.apply_theme()

--- a/app/view/schedule_interface/schedule_interface.py
+++ b/app/view/schedule_interface/schedule_interface.py
@@ -622,3 +622,6 @@ class ScheduleInterface(QWidget):
         normalized_level = (level or "info").lower()
         signalBus.info_bar_requested.emit(normalized_level, message)
         signalBus.log_output.emit(normalized_level.upper(), message)
+        # 同步发射带 config_id 的日志（空值表示归属当前显示配置），
+        # 使日志面板（按 config_id 订阅）也能显示计划任务相关日志。
+        signalBus.log_output_at.emit("", normalized_level.upper(), message)

--- a/app/view/setting_interface/setting_interface.py
+++ b/app/view/setting_interface/setting_interface.py
@@ -1390,6 +1390,20 @@ class SettingInterface(QWidget):
 
         self.taskGroup.addSettingCard(self.gpu_acceleration_card)
 
+        self.multi_instance_mode_card = SwitchSettingCard(
+            FIF.ALBUM,
+            self.tr("Multi-instance mode"),
+            self.tr(
+                "Allow multiple configurations to run at the same time, "
+                "each with its own start/stop control, log, and monitor. "
+                "When off, switching the active configuration is blocked while a task is running."
+            ),
+            configItem=cfg.multi_instance_mode,
+            parent=self.taskGroup,
+        )
+
+        self.taskGroup.addSettingCard(self.multi_instance_mode_card)
+
         self.reset_task_layout_card = PrimaryPushSettingCard(
             text=self.tr("Reset"),
             icon=FIF.SYNC,
@@ -2546,7 +2560,18 @@ class SettingInterface(QWidget):
         self.save_screenshot_card.checkedChanged.connect(
             self._on_save_screenshot_changed
         )
+        self.multi_instance_mode_card.checkedChanged.connect(
+            self._on_multi_instance_mode_changed
+        )
         self._apply_theme_from_config()
+
+    def _on_multi_instance_mode_changed(self, checked: bool):
+        """多实例模式开关变更：持久化并广播给相关界面。"""
+        cfg.set(cfg.multi_instance_mode, bool(checked))
+        try:
+            signalBus.multi_instance_mode_changed.emit(bool(checked))
+        except Exception as exc:
+            logger.warning(f"发射 multi_instance_mode_changed 信号失败: {exc}")
 
     def _onRunAfterStartupCardChange(self):
         """根据输入更新启动前运行的程序脚本路径。"""

--- a/app/view/setting_interface/setting_interface.py
+++ b/app/view/setting_interface/setting_interface.py
@@ -1390,20 +1390,6 @@ class SettingInterface(QWidget):
 
         self.taskGroup.addSettingCard(self.gpu_acceleration_card)
 
-        self.multi_instance_mode_card = SwitchSettingCard(
-            FIF.ALBUM,
-            self.tr("Multi-instance mode"),
-            self.tr(
-                "Allow multiple configurations to run at the same time, "
-                "each with its own start/stop control, log, and monitor. "
-                "When off, switching the active configuration is blocked while a task is running."
-            ),
-            configItem=cfg.multi_instance_mode,
-            parent=self.taskGroup,
-        )
-
-        self.taskGroup.addSettingCard(self.multi_instance_mode_card)
-
         self.reset_task_layout_card = PrimaryPushSettingCard(
             text=self.tr("Reset"),
             icon=FIF.SYNC,
@@ -1517,6 +1503,17 @@ class SettingInterface(QWidget):
         self.compatibility_group = SettingCardGroup(
             self.tr("Experimental / Compatibility"), self.Setting_scroll_widget
         )
+        self.multi_instance_mode_card = SwitchSettingCard(
+            FIF.ALBUM,
+            self.tr("Multi-instance mode"),
+            self.tr(
+                "Experimental. Allow multiple configurations to run at the same time, "
+                "each with its own start/stop control, log, and monitor. "
+                "When off, switching the active configuration is blocked while a task is running."
+            ),
+            configItem=cfg.multi_instance_mode,
+            parent=self.compatibility_group,
+        )
         self.multi_resource_adaptation_card = SwitchSettingCard(
             FIF.SETTING,
             self.tr("Multi-resource adaptation"),
@@ -1572,6 +1569,7 @@ class SettingInterface(QWidget):
             on_value_changed=self._on_log_max_images_changed,
         )
 
+        self.compatibility_group.addSettingCard(self.multi_instance_mode_card)
         self.compatibility_group.addSettingCard(self.multi_resource_adaptation_card)
         self.compatibility_group.addSettingCard(self.save_screenshot_card)
         self.compatibility_group.addSettingCard(self.log_zip_include_images_card)

--- a/app/view/task_interface/components/list_item.py
+++ b/app/view/task_interface/components/list_item.py
@@ -980,11 +980,16 @@ class ConfigListItem(BaseListItem):
             self.unsetCursor()
 
     def set_running(self, running: bool):
-        """显示/隐藏该配置的运行指示点（多实例模式下各配置独立运行）。"""
+        """显示/隐藏该配置的运行指示（与任务列表 running 同款）。"""
         indicator = getattr(self, "running_indicator", None)
         if indicator is None:
             return
-        indicator.setVisible(bool(running))
+        if running:
+            indicator.show()
+            indicator.start()
+        else:
+            indicator.hide()
+            indicator.stop()
 
     def _init_ui(self):
         # 创建水平布局
@@ -1003,14 +1008,13 @@ class ConfigListItem(BaseListItem):
         self.name_label = self._create_name_label()
         layout.addWidget(self.name_label)
 
-        # 运行指示点（默认隐藏，多实例模式下表示该配置正在运行）
+        # 运行指示（与任务列表 running 状态同款 IndeterminateProgressRing）
         layout.addStretch(1)
-        from qfluentwidgets import CaptionLabel as _CaptionLabel
-
-        self.running_indicator = _CaptionLabel("●", self)
-        self.running_indicator.setStyleSheet("color: #50c878;")
+        self.running_indicator = IndeterminateProgressRing(self)
+        self.running_indicator.setFixedSize(20, 20)
+        self.running_indicator.setStrokeWidth(2)
         self.running_indicator.setToolTip(self.tr("Running"))
-        self.running_indicator.setVisible(False)
+        self.running_indicator.hide()
         layout.addWidget(self.running_indicator, 0, Qt.AlignmentFlag.AlignVCenter)
 
         # 创建设置按钮但不添加到布局（隐藏）

--- a/app/view/task_interface/components/list_item.py
+++ b/app/view/task_interface/components/list_item.py
@@ -706,7 +706,7 @@ class TaskListItem(BaseListItem):
         if not self.service_coordinator or self.task.is_base_task():
             return
         asyncio.create_task(
-            self.service_coordinator.run_manager.run_tasks_flow(
+            self.service_coordinator.run_tasks_flow(
                 start_task_id=self.task.item_id
             )
         )
@@ -979,6 +979,13 @@ class ConfigListItem(BaseListItem):
         else:
             self.unsetCursor()
 
+    def set_running(self, running: bool):
+        """显示/隐藏该配置的运行指示点（多实例模式下各配置独立运行）。"""
+        indicator = getattr(self, "running_indicator", None)
+        if indicator is None:
+            return
+        indicator.setVisible(bool(running))
+
     def _init_ui(self):
         # 创建水平布局
         layout = QHBoxLayout(self)
@@ -995,6 +1002,16 @@ class ConfigListItem(BaseListItem):
         # 添加标签
         self.name_label = self._create_name_label()
         layout.addWidget(self.name_label)
+
+        # 运行指示点（默认隐藏，多实例模式下表示该配置正在运行）
+        layout.addStretch(1)
+        from qfluentwidgets import CaptionLabel as _CaptionLabel
+
+        self.running_indicator = _CaptionLabel("●", self)
+        self.running_indicator.setStyleSheet("color: #50c878;")
+        self.running_indicator.setToolTip(self.tr("Running"))
+        self.running_indicator.setVisible(False)
+        layout.addWidget(self.running_indicator, 0, Qt.AlignmentFlag.AlignVCenter)
 
         # 创建设置按钮但不添加到布局（隐藏）
         self.setting_button = self._create_setting_button()

--- a/app/view/task_interface/components/list_tool_bar_widget.py
+++ b/app/view/task_interface/components/list_tool_bar_widget.py
@@ -145,11 +145,30 @@ class ConfigListToolBarWidget(BaseListToolBarWidget):
             )
         except Exception:
             pass
+        # 多实例模式切换时，重新评估是否需要锁定
+        try:
+            signalBus.multi_instance_mode_changed.connect(
+                self._on_multi_instance_mode_changed
+            )
+        except Exception:
+            pass
 
     def _on_start_button_status_changed(self, status: dict):
-        """根据任务流状态锁定/解锁配置列表。"""
+        """根据任务流状态锁定/解锁配置列表。
+
+        多实例模式下允许运行时切换/管理配置，因此不锁定列表；
+        单实例模式下保持运行中锁定的旧行为。
+        """
+        if self.service_coordinator.is_multi_instance_enabled():
+            self.set_locked(False)
+            return
         is_running = status.get("text") == "STOP"
         self.set_locked(is_running)
+
+    def _on_multi_instance_mode_changed(self, enabled: bool):
+        """多实例模式开启后立即解锁配置列表。"""
+        if enabled:
+            self.set_locked(False)
 
     def set_locked(self, locked: bool):
         """锁定后禁止新增/删除配置，并通知列表组件拦截点击切换。"""

--- a/app/view/task_interface/components/list_widget.py
+++ b/app/view/task_interface/components/list_widget.py
@@ -1008,7 +1008,33 @@ class ConfigListWidget(BaseListWidget):
         self.service_coordinator.signal_bus.config_changed.connect(
             self._on_config_changed
         )
+        # 多实例：各配置运行状态变化时更新运行指示点
+        signalBus.config_run_state_changed.connect(
+            self._on_config_run_state_changed
+        )
         self.update_list()
+
+    def _on_config_run_state_changed(self, config_id: str, running: bool):
+        """更新指定配置项的运行指示点。"""
+        for i in range(self.count()):
+            item = self.item(i)
+            widget = self.itemWidget(item)
+            if (
+                isinstance(widget, ConfigListItem)
+                and widget.item.item_id == config_id
+                and hasattr(widget, "set_running")
+            ):
+                widget.set_running(running)
+                break
+
+    def _sync_config_running_indicator(self, widget: "ConfigListItem") -> None:
+        """根据当前运行状态初始化某配置项的运行指示点。"""
+        try:
+            running = self.service_coordinator.is_config_running(widget.item.item_id)
+        except Exception:
+            running = False
+        if hasattr(widget, "set_running"):
+            widget.set_running(running)
 
     def set_locked(self, locked: bool):
         """锁定后禁止用户通过点击/键盘切换配置，同时禁用配置项右键编辑入口。"""
@@ -1107,6 +1133,7 @@ class ConfigListWidget(BaseListWidget):
         config_widget = ConfigListItem(config, self.service_coordinator)
         self.addItem(list_item)
         self.setItemWidget(list_item, config_widget)
+        self._sync_config_running_indicator(config_widget)
 
     def _select_config_by_id(self, config_id: str, emit_signal: bool = True):
         """根据配置ID选中对应的列表项"""

--- a/app/view/task_interface/components/logoutput_widget.py
+++ b/app/view/task_interface/components/logoutput_widget.py
@@ -379,6 +379,12 @@ class LogoutputWidget(QWidget):
         records = self._config_log_records.get(cid, [])
         for level, text, _timestamp in records:
             self._add_log_row(_timestamp, text, level, capture_image=False)
+        if hasattr(self, "monitor_widget"):
+            self.monitor_widget._sync_from_monitor()
+            monitor = getattr(self.monitor_widget, "_monitor", None)
+            if monitor is not None and hasattr(monitor, "sync_task_preview"):
+                monitor.sync_task_preview()
+                self.monitor_widget._sync_from_monitor()
 
     def _record_log(self, config_id: str, level: str, text: str, timestamp: str):
         """将一条日志写入对应配置的缓冲（带上限淘汰）。"""

--- a/app/view/task_interface/components/logoutput_widget.py
+++ b/app/view/task_interface/components/logoutput_widget.py
@@ -90,6 +90,17 @@ class LogoutputWidget(QWidget):
         self._error_flash_previous_phase = 0.0
         self._error_flash_cycle_seconds = 1.8
         self._user_event_filter_installed = False
+        # 多实例：按 config_id 维护日志文本缓冲，切换配置时重建显示。
+        # 记录为 (level, text, timestamp)；图片仅在当前配置实时渲染时附带。
+        self._config_log_records: dict[str, list[tuple[str, str, str]]] = {}
+        self._current_log_config_id: str = ""
+        if service_coordinator is not None:
+            try:
+                self._current_log_config_id = (
+                    service_coordinator.config_service.current_config_id or ""
+                )
+            except Exception:
+                self._current_log_config_id = ""
         self._init_log_output()
         self._add_tail_spacer()
         self._apply_theme_colors()
@@ -156,10 +167,13 @@ class LogoutputWidget(QWidget):
             self.main_layout.setStretch(0, 0)
             self.main_layout.setStretch(1, 1)
 
-        # 连接日志输出信号
-        signalBus.log_output.connect(self._on_log_output)
-
+        # 连接日志输出信号（带 config_id，多实例隔离）
+        signalBus.log_output_at.connect(self._on_log_output_at)
+        signalBus.log_clear_requested_at.connect(self._on_clear_requested_at)
+        # 未携带 config_id 的清空请求（如调度服务）作用于当前显示的配置
         signalBus.log_clear_requested.connect(self.clear_log)
+        # 切换当前配置时重建日志显示，避免不同配置日志串流
+        signalBus.config_changed.connect(self._on_config_changed)
         signalBus.log_zip_started.connect(
             lambda: self.generate_log_zip_button.setEnabled(False)
         )
@@ -328,8 +342,8 @@ class LogoutputWidget(QWidget):
         # 交互信号：由组件发射，外部处理
         self.generate_log_zip_button.clicked.connect(signalBus.request_log_zip)
 
-    def clear_log(self):
-        """清空日志内容，清除缓存图像并重置序号"""
+    def _clear_display_only(self):
+        """仅清除当前显示的日志控件（不动缓冲）。"""
         self._remove_tail_spacer()
         while self.log_list_layout.count():
             item = self.log_list_layout.takeAt(0)
@@ -337,20 +351,63 @@ class LogoutputWidget(QWidget):
             if w:
                 w.deleteLater()
         self._log_items.clear()
-        
-        # 清除缓存图像，避免跨 session 复用旧图
         self._last_image_bytes = None
         self._last_image_small_gray = None
-        logger.info("[日志清除] 已清除所有日志条目和缓存图像，序号已重置")
-        
         self._add_tail_spacer()
 
-    def _on_log_output(self, level: str, text: str):
-        """处理日志输出信号"""
+    def clear_log(self):
+        """清空当前显示配置的日志内容、缓冲，清除缓存图像并重置序号"""
+        self._clear_display_only()
+        self._config_log_records.pop(self._current_log_config_id, None)
+        logger.info("[日志清除] 已清除当前配置日志条目和缓存图像，序号已重置")
+
+    def _on_clear_requested_at(self, config_id: str):
+        """按 config_id 清空日志缓冲；若为当前显示配置则一并清空显示。"""
+        cid = config_id or self._current_log_config_id
+        self._config_log_records.pop(cid, None)
+        if cid == self._current_log_config_id:
+            self._clear_display_only()
+
+    def _on_config_changed(self, config_id: str):
+        """切换当前配置：保存当前显示、重建为目标配置的日志缓冲。"""
+        cid = config_id or ""
+        if cid == self._current_log_config_id:
+            return
+        self._current_log_config_id = cid
+        self._clear_display_only()
+        # 从缓冲重建目标配置的历史日志（仅文本，不含历史图片）
+        records = self._config_log_records.get(cid, [])
+        for level, text, _timestamp in records:
+            self._add_log_row(_timestamp, text, level, capture_image=False)
+
+    def _record_log(self, config_id: str, level: str, text: str, timestamp: str):
+        """将一条日志写入对应配置的缓冲（带上限淘汰）。"""
+        records = self._config_log_records.setdefault(config_id, [])
+        records.append((level, text, timestamp))
+        try:
+            max_records = cfg.get(cfg.log_max_images)
+        except Exception:
+            max_records = self._max_log_entries
+        if not isinstance(max_records, int) or max_records <= 0:
+            max_records = self._max_log_entries
+        if len(records) > max_records:
+            del records[: len(records) - max_records]
+
+    def _on_log_output_at(self, config_id: str, level: str, text: str):
+        """处理带 config_id 的日志输出信号。"""
+        cid = config_id or self._current_log_config_id
         normalized_level = self._normalize_level_by_text(level, text)
-        if normalized_level in {"ERROR", "CRITICAL"}:
-            self._start_log_zip_attention_effect()
-        self.add_structured_log(normalized_level, text)
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        self._record_log(cid, normalized_level, text, timestamp)
+        # 仅当前显示配置实时渲染（含图片闪烁提示）
+        if cid == self._current_log_config_id:
+            if normalized_level in {"ERROR", "CRITICAL"}:
+                self._start_log_zip_attention_effect()
+            self.add_structured_log(normalized_level, text)
+
+    def _on_log_output(self, level: str, text: str):
+        """处理日志输出信号（兼容旧无 config_id 路径，归属当前配置）。"""
+        self._on_log_output_at(self._current_log_config_id, level, text)
 
     def _normalize_level_by_text(self, level: str, text: str) -> str:
         """根据日志级别与关键词将消息归一化到最终显示级别。"""
@@ -496,8 +553,12 @@ class LogoutputWidget(QWidget):
         # 2. 正确处理换行符（在同一个日志条目内换行显示）
         self._add_log_row(timestamp, raw_text, level)
 
-    def _add_log_row(self, timestamp: str, text: str, level: str):
-        """新增一条日志（LogItemWidget）"""
+    def _add_log_row(self, timestamp: str, text: str, level: str, capture_image: bool = True):
+        """新增一条日志（LogItemWidget）
+
+        Args:
+            capture_image: 是否尝试抓取当前控制器画面作为预览。重建历史缓冲时为 False。
+        """
         formatted_text, has_rich_content = self._format_colored_text(text)
         self._remove_tail_spacer()
 
@@ -512,7 +573,7 @@ class LogoutputWidget(QWidget):
 
         # System 任务：不捕获图片，使用图标 icon，不占用 500 张配额
         # 其他任务：正常捕获图片
-        if task_name == self.tr("System"):
+        if not capture_image or task_name == self.tr("System"):
             image_bytes = None
         else:
             # 日志出现时抓取一帧作为预览（优先 cached_image；None 则不显示）
@@ -712,12 +773,13 @@ class LogoutputWidget(QWidget):
         if not self.service_coordinator:
             return None
         try:
-            if hasattr(self.service_coordinator, "run_manager"):
+            task_flow = getattr(self.service_coordinator, "current_runner", None)
+            if task_flow is None and hasattr(self.service_coordinator, "run_manager"):
                 task_flow = self.service_coordinator.run_manager
-                if task_flow and hasattr(task_flow, "maafw"):
-                    controller = getattr(task_flow.maafw, "controller", None)
-                    if controller is not None:
-                        return controller
+            if task_flow and hasattr(task_flow, "maafw"):
+                controller = getattr(task_flow.maafw, "controller", None)
+                if controller is not None:
+                    return controller
         except Exception:
             return None
         return None
@@ -885,7 +947,9 @@ class LogoutputWidget(QWidget):
         if not self.service_coordinator:
             return self.tr("System")
         try:
-            runner = getattr(self.service_coordinator, "run_manager", None)
+            runner = getattr(self.service_coordinator, "current_runner", None)
+            if runner is None:
+                runner = getattr(self.service_coordinator, "run_manager", None)
             task_id = getattr(runner, "_current_running_task_id", None)
             if not task_id:
                 return self.tr("System")

--- a/app/view/task_interface/components/option_widget.py
+++ b/app/view/task_interface/components/option_widget.py
@@ -1083,8 +1083,8 @@ class OptionWidget(QWidget, ResourceSettingMixin, PostActionSettingMixin):
 
     def _update_options_enabled(self):
         """根据运行状态更新所有选项的启用/禁用状态"""
-        # 检查是否有任务正在运行
-        is_running = self.service_coordinator.run_manager.is_running
+        # 检查当前配置是否正在运行（多实例下仅锁定当前配置的选项编辑）
+        is_running = self.service_coordinator.is_current_config_running()
         self._set_options_enabled(not is_running)
         if not is_running:
             self._reapply_contextual_disable_rules()

--- a/app/view/task_interface/task_interface_logic.py
+++ b/app/view/task_interface/task_interface_logic.py
@@ -85,7 +85,7 @@ class TaskInterface(UI_TaskInterface, QWidget):
         if not self.isVisible():
             return
         self.option_panel.reset()
-        if self.service_coordinator and self.service_coordinator.run_manager.is_running:
+        if self.service_coordinator and self.service_coordinator.is_current_config_running():
             self._set_task_list_editable(False)
         if hasattr(self, "task_info") and hasattr(self.task_info, "task_list"):
             task_list = self.task_info.task_list

--- a/app/view/test_interface/test_interface.py
+++ b/app/view/test_interface/test_interface.py
@@ -99,7 +99,7 @@ class TestInterface(QWidget):
         logger.info("测试页面：切换配置 %s -> %s", current, target_id)
 
     def _test_run_tasks(self) -> None:
-        if self.service_coordinator.run_manager.is_running:
+        if self.service_coordinator.is_current_config_running():
             signalBus.info_bar_requested.emit(
                 "warning", "任务流正在运行，无法重复启动"
             )

--- a/tests/test_config_monitor_pool.py
+++ b/tests/test_config_monitor_pool.py
@@ -1,0 +1,115 @@
+"""ConfigMonitorPool 与 MonitorSession 行为单元测试。"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from PIL import Image
+
+from app.view.monitor.config_monitor_pool import ConfigMonitorPool
+from app.view.monitor.monitor_session import MonitorSession
+
+
+class MonitorSessionLoopTests(unittest.IsolatedAsyncioTestCase):
+    def _make_session(self) -> MonitorSession:
+        monitor_task = MagicMock()
+        monitor_task.maafw = MagicMock(controller=None)
+        return MonitorSession(monitor_task, log_prefix="TestMonitor")
+
+    async def test_is_loop_running_requires_both_tasks(self) -> None:
+        session = self._make_session()
+        self.assertFalse(session.is_loop_running())
+
+        session._monitoring_active = True
+        self.assertFalse(session.is_loop_running())
+
+        session._monitor_loop_task = asyncio.create_task(asyncio.sleep(3600))
+        self.assertFalse(session.is_loop_running())
+
+        session._image_processing_task = asyncio.create_task(asyncio.sleep(3600))
+        self.assertTrue(session.is_loop_running())
+
+        await session.stop_loop_async()
+
+    async def test_stop_loop_async_cancels_both_tasks(self) -> None:
+        session = self._make_session()
+        session._monitoring_active = True
+        monitor_task = asyncio.create_task(asyncio.sleep(3600))
+        processing_task = asyncio.create_task(asyncio.sleep(3600))
+        session._monitor_loop_task = monitor_task
+        session._image_processing_task = processing_task
+
+        await session.stop_loop_async()
+
+        self.assertFalse(session._monitoring_active)
+        self.assertTrue(monitor_task.done())
+        self.assertTrue(processing_task.done())
+
+
+class ConfigMonitorPoolTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.frames: list[tuple[str, Image.Image]] = []
+        self.cleared: list[str] = []
+        self.disconnected: list[str] = []
+
+        coordinator = SimpleNamespace(
+            is_multi_instance_enabled=lambda: True,
+            runtime_manager=SimpleNamespace(get_instance=lambda _cid: None),
+            task_service=MagicMock(),
+            config_service=MagicMock(),
+        )
+        self.pool = ConfigMonitorPool(
+            coordinator,
+            on_frame=lambda cid, img: self.frames.append((cid, img)),
+            on_capture_failure_clear=lambda cid: self.cleared.append(cid),
+            on_controller_disconnected=lambda cid: self.disconnected.append(cid),
+        )
+
+    def test_set_display_config_returns_cached_frame(self) -> None:
+        img = Image.new("RGB", (4, 4), color=(1, 2, 3))
+        slot = self.pool._ensure_slot("cfg_a")
+        slot.last_pil_image = img
+
+        cached = self.pool.set_display_config("cfg_a")
+        self.assertIs(cached, img)
+        self.assertEqual(self.pool.display_config_id, "cfg_a")
+
+    async def test_ensure_monitoring_skips_when_loop_running(self) -> None:
+        slot = self.pool._ensure_slot("cfg_a")
+        slot.session._monitoring_active = True
+        slot.session._monitor_loop_task = asyncio.create_task(asyncio.sleep(3600))
+        slot.session._image_processing_task = asyncio.create_task(asyncio.sleep(3600))
+
+        with patch.object(
+            slot.session, "run_startup_sequence", new=AsyncMock(return_value=True)
+        ) as mock_start:
+            result = await self.pool.ensure_monitoring("cfg_a", auto=True)
+            self.assertTrue(result)
+            mock_start.assert_not_called()
+
+        await slot.session.stop_loop_async()
+
+    async def test_ensure_monitoring_skips_after_loop_running(self) -> None:
+        slot = self.pool._ensure_slot("cfg_c")
+
+        async def _mark_running(*_args, **_kwargs) -> bool:
+            slot.session._monitoring_active = True
+            slot.session._monitor_loop_task = asyncio.create_task(asyncio.sleep(3600))
+            slot.session._image_processing_task = asyncio.create_task(
+                asyncio.sleep(3600)
+            )
+            return True
+
+        with patch.object(
+            slot.session, "run_startup_sequence", side_effect=_mark_running
+        ) as mock_start:
+            self.assertTrue(await self.pool.ensure_monitoring("cfg_c", auto=True))
+            self.assertTrue(await self.pool.ensure_monitoring("cfg_c", auto=True))
+            mock_start.assert_called_once()
+
+        await slot.session.stop_loop_async()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_monitor_pool.py
+++ b/tests/test_config_monitor_pool.py
@@ -55,6 +55,7 @@ class ConfigMonitorPoolTests(unittest.IsolatedAsyncioTestCase):
 
         coordinator = SimpleNamespace(
             is_multi_instance_enabled=lambda: True,
+            is_config_running=lambda _cid: False,
             runtime_manager=SimpleNamespace(get_instance=lambda _cid: None),
             task_service=MagicMock(),
             config_service=MagicMock(),
@@ -109,6 +110,53 @@ class ConfigMonitorPoolTests(unittest.IsolatedAsyncioTestCase):
             mock_start.assert_called_once()
 
         await slot.session.stop_loop_async()
+
+    def test_bind_runner_maafw_shares_controller(self) -> None:
+        shared_maafw = MagicMock()
+        runner = SimpleNamespace(maafw=shared_maafw)
+        inst = SimpleNamespace(
+            runner=runner,
+            task_service=MagicMock(),
+            config_service=MagicMock(),
+        )
+        self.pool._coordinator.runtime_manager.get_instance = lambda cid: (
+            inst if cid == "cfg_run" else None
+        )
+        slot = self.pool._ensure_slot("cfg_run")
+        own_maafw = slot.monitor_task.maafw
+
+        self.assertTrue(self.pool._bind_runner_maafw("cfg_run"))
+        self.assertIs(slot.monitor_task.maafw, shared_maafw)
+        self.assertTrue(slot.uses_shared_maafw)
+
+        self.pool._release_shared_maafw(slot)
+        self.assertFalse(slot.uses_shared_maafw)
+        self.assertIsNot(slot.monitor_task.maafw, shared_maafw)
+        self.assertIsNot(slot.monitor_task.maafw, own_maafw)
+
+    async def test_ensure_monitoring_when_ready_waits_for_runner(self) -> None:
+        shared_maafw = MagicMock(controller=MagicMock(connected=True))
+        runner = SimpleNamespace(maafw=shared_maafw)
+        inst = SimpleNamespace(
+            runner=runner,
+            task_service=MagicMock(),
+            config_service=MagicMock(),
+        )
+        self.pool._coordinator.runtime_manager.get_instance = lambda cid: (
+            inst if cid == "cfg_wait" else None
+        )
+        self.pool._coordinator.is_config_running = lambda cid: cid == "cfg_wait"
+
+        slot = self.pool._ensure_slot("cfg_wait")
+        with patch.object(
+            slot.session, "run_startup_sequence", new=AsyncMock(return_value=True)
+        ) as mock_start:
+            result = await self.pool.ensure_monitoring_when_ready(
+                "cfg_wait", auto=True, timeout_s=1.0
+            )
+            self.assertTrue(result)
+            mock_start.assert_called_once()
+            self.assertTrue(slot.uses_shared_maafw)
 
 
 if __name__ == "__main__":

--- a/tests/test_embedded_agent_runtime.py
+++ b/tests/test_embedded_agent_runtime.py
@@ -301,6 +301,62 @@ class EmbeddedAgentRuntimeTests(unittest.TestCase):
             self.assertEqual("agent/main.py", translated.get("__embedded_agent_entry"))
             self.assertNotIn("__embedded_agent_error", translated)
 
+    def test_two_embedded_agents_with_colliding_action_package(self):
+        def _write_bundle(root: Path, register_name: str) -> None:
+            agent_dir = root / "agent"
+            action_dir = agent_dir / "action"
+            action_dir.mkdir(parents=True, exist_ok=True)
+            (action_dir / "__init__.py").write_text("", encoding="utf-8")
+            (action_dir / "Fishing.py").write_text(
+                '\n'.join(
+                    [
+                        "class Fishing:",
+                        "    pass",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (agent_dir / "Agent_file.py").write_text(
+                '\n'.join(
+                    [
+                        "from action.Fishing import Fishing",
+                        "from maa.custom_action import CustomAction",
+                        "from maa.resource import resource",
+                        "",
+                        f'@resource.custom_action("{register_name}")',
+                        "class AgentAction(CustomAction):",
+                        "    def run(self, context, argv):",
+                        "        return True",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+        with tempfile.TemporaryDirectory() as temp_a, tempfile.TemporaryDirectory() as temp_b:
+            root_a = Path(temp_a)
+            root_b = Path(temp_b)
+            _write_bundle(root_a, "alpha")
+            _write_bundle(root_b, "beta")
+
+            maafw_a = MaaFW()
+            maafw_b = MaaFW()
+            self.assertTrue(
+                maafw_a.load_embedded_agent_custom(
+                    agent_root=root_a / "agent",
+                    agent_entry=root_a / "agent" / "Agent_file.py",
+                )
+            )
+            self.assertTrue(
+                maafw_b.load_embedded_agent_custom(
+                    agent_root=root_b / "agent",
+                    agent_entry=root_b / "agent" / "Agent_file.py",
+                )
+            )
+            self.assertIn("alpha", maafw_a.resource.custom_action_list)
+            self.assertIn("beta", maafw_b.resource.custom_action_list)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_multi_instance_log_buffer.py
+++ b/tests/test_multi_instance_log_buffer.py
@@ -1,0 +1,103 @@
+"""多实例模式下日志面板按 config_id 隔离缓冲的单元测试。
+
+仅验证 LogoutputWidget 的数据层（缓冲/过滤/清空/切换）逻辑，
+通过 __new__ 跳过重型 UI 构建，并对触及 UI 的方法打桩。
+"""
+
+import unittest
+
+from app.view.task_interface.components.logoutput_widget import LogoutputWidget
+
+
+class _StubLog(LogoutputWidget):
+    """绕过 __init__，仅装配缓冲逻辑所需的最小状态与 UI 打桩。"""
+
+    def __init__(self):  # noqa: D401 - 故意不调用父类 __init__
+        self._config_log_records = {}
+        self._current_log_config_id = "c_a"
+        self._max_log_entries = 100
+        self.rendered: list[tuple[str, str]] = []
+        self.cleared = 0
+
+    # --- UI 打桩 ---
+    def add_structured_log(self, level, text):
+        self.rendered.append((level, text))
+
+    def _clear_display_only(self):
+        self.cleared += 1
+        self.rendered.clear()
+
+    def _add_log_row(self, timestamp, text, level, capture_image=True):
+        self.rendered.append((level, text))
+
+    def _start_log_zip_attention_effect(self):
+        pass
+
+    def _normalize_level_by_text(self, level, text):
+        return (level or "INFO").upper()
+
+
+class MultiInstanceLogBufferTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.widget = _StubLog()
+
+    def test_background_config_logs_are_buffered_not_rendered(self) -> None:
+        # 当前显示 c_a；写入 c_b 的日志不应渲染，但应缓冲
+        self.widget._on_log_output_at("c_b", "INFO", "hello-b")
+        self.assertEqual(self.widget.rendered, [])
+        self.assertEqual(
+            [r[1] for r in self.widget._config_log_records["c_b"]], ["hello-b"]
+        )
+
+    def test_current_config_logs_render_and_buffer(self) -> None:
+        self.widget._on_log_output_at("c_a", "INFO", "hello-a")
+        self.assertEqual(self.widget.rendered, [("INFO", "hello-a")])
+        self.assertIn("c_a", self.widget._config_log_records)
+
+    def test_empty_config_id_attributes_to_current(self) -> None:
+        self.widget._on_log_output_at("", "INFO", "current-log")
+        self.assertEqual(
+            [r[1] for r in self.widget._config_log_records["c_a"]], ["current-log"]
+        )
+        self.assertEqual(self.widget.rendered, [("INFO", "current-log")])
+
+    def test_switch_config_rebuilds_from_target_buffer(self) -> None:
+        self.widget._on_log_output_at("c_a", "INFO", "a1")
+        self.widget._on_log_output_at("c_b", "INFO", "b1")
+        self.widget._on_log_output_at("c_b", "INFO", "b2")
+        self.widget.rendered.clear()
+
+        self.widget._on_config_changed("c_b")
+        self.assertEqual(self.widget._current_log_config_id, "c_b")
+        self.assertEqual(
+            [r[1] for r in self.widget.rendered], ["b1", "b2"]
+        )
+
+    def test_clear_requested_only_affects_target(self) -> None:
+        self.widget._on_log_output_at("c_a", "INFO", "a1")
+        self.widget._on_log_output_at("c_b", "INFO", "b1")
+
+        self.widget._on_clear_requested_at("c_b")
+        self.assertNotIn("c_b", self.widget._config_log_records)
+        self.assertIn("c_a", self.widget._config_log_records)
+
+    def test_buffer_respects_max_entries(self) -> None:
+        from app.common.config import cfg
+
+        try:
+            cap = cfg.get(cfg.log_max_images)
+        except Exception:
+            cap = None
+        if not isinstance(cap, int) or cap <= 0:
+            cap = self.widget._max_log_entries
+
+        for i in range(cap + 25):
+            self.widget._record_log("c_x", "INFO", f"line-{i}", "00:00:00")
+        records = self.widget._config_log_records["c_x"]
+        self.assertEqual(len(records), cap)
+        # 淘汰应保留最新的若干条
+        self.assertEqual(records[-1][1], f"line-{cap + 24}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multi_instance_runtime.py
+++ b/tests/test_multi_instance_runtime.py
@@ -1,0 +1,142 @@
+"""多实例模式运行时管理与配置切换守卫的单元测试。"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from PySide6.QtWidgets import QApplication
+
+from app.common.config import cfg
+from app.core.core import ServiceCoordinator
+from app.core.runtime_manager import RuntimeInstance, RuntimeInstanceManager
+
+
+def _ensure_qapp() -> None:
+    if QApplication.instance() is None:
+        # 提供最简 QApplication，使信号 emit 安全执行
+        QApplication([])
+
+
+class _FakeRunner:
+    def __init__(self, is_running: bool = False):
+        self.is_running = is_running
+        self.run_calls = 0
+        self.stop_calls = 0
+        self.run_other_config_callback = None
+
+    async def run_tasks_flow(self, task_id=None, *, start_task_id=None):
+        self.run_calls += 1
+        return "ran"
+
+    async def stop_task(self, *, manual: bool = False):
+        self.stop_calls += 1
+        return "stopped"
+
+
+def _make_instance(config_id: str, *, running: bool = False) -> RuntimeInstance:
+    runner = _FakeRunner(is_running=running)
+    inst = RuntimeInstance(
+        config_id=config_id,
+        runner=runner,
+        runner_events=None,
+        fs_signal_bus=None,
+        log_processor=None,
+        bridge=None,
+        config_service=None,
+        task_service=None,
+    )
+    inst.running = running
+    return inst
+
+
+class RuntimeInstanceManagerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _ensure_qapp()
+
+    def setUp(self) -> None:
+        self.coordinator = SimpleNamespace(
+            config_service=SimpleNamespace(current_config_id="c_a"),
+        )
+        self.manager = RuntimeInstanceManager(self.coordinator)
+
+    def test_running_state_aggregation(self) -> None:
+        self.manager._instances["c_a"] = _make_instance("c_a", running=True)
+        self.manager._instances["c_b"] = _make_instance("c_b", running=False)
+
+        self.assertTrue(self.manager.is_running("c_a"))
+        self.assertFalse(self.manager.is_running("c_b"))
+        self.assertTrue(self.manager.any_running())
+        self.assertEqual(self.manager.running_config_ids(), ["c_a"])
+
+    def test_instance_is_running_follows_runner(self) -> None:
+        inst = _make_instance("c_a", running=False)
+        self.assertFalse(inst.is_running)
+        inst.runner.is_running = True
+        self.assertTrue(inst.is_running)
+
+    def test_run_skips_when_already_running(self) -> None:
+        inst = _make_instance("c_a", running=True)
+        self.manager._instances["c_a"] = inst
+
+        asyncio.run(self.manager.run("c_a"))
+        self.assertEqual(inst.runner.run_calls, 0)
+
+    def test_run_invokes_runner_when_idle(self) -> None:
+        inst = _make_instance("c_a", running=False)
+        self.manager._instances["c_a"] = inst
+        # 避免触发协调器的真实刷新逻辑
+        self.coordinator._refresh_runtime_instance = lambda _inst: None
+
+        result = asyncio.run(self.manager.run("c_a"))
+        self.assertEqual(result, "ran")
+        self.assertEqual(inst.runner.run_calls, 1)
+
+    def test_stop_invokes_runner(self) -> None:
+        inst = _make_instance("c_a", running=True)
+        self.manager._instances["c_a"] = inst
+
+        result = asyncio.run(self.manager.stop("c_a", manual=True))
+        self.assertEqual(result, "stopped")
+        self.assertEqual(inst.runner.stop_calls, 1)
+        self.assertFalse(inst.running)
+
+
+class SwitchConfigGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _ensure_qapp()
+
+    def setUp(self) -> None:
+        # 通过 __new__ 跳过重型初始化，仅装配守卫逻辑所需的属性
+        self.coord = ServiceCoordinator.__new__(ServiceCoordinator)
+        self.coord.task_runner = _FakeRunner(is_running=False)
+        self.coord.config_service = SimpleNamespace(current_config_id="c_a")
+        self.coord.runtime_manager = RuntimeInstanceManager(self.coord)
+        self._original_mode = cfg.get(cfg.multi_instance_mode)
+
+    def tearDown(self) -> None:
+        cfg.set(cfg.multi_instance_mode, self._original_mode)
+
+    def test_single_instance_blocks_switch_while_running(self) -> None:
+        cfg.set(cfg.multi_instance_mode, False)
+        self.assertTrue(self.coord.is_switch_config_allowed())
+
+        self.coord.task_runner.is_running = True
+        self.assertFalse(self.coord.is_switch_config_allowed())
+        self.assertTrue(self.coord.any_config_running())
+        self.assertTrue(self.coord.is_current_config_running())
+
+    def test_multi_instance_allows_switch_while_running(self) -> None:
+        cfg.set(cfg.multi_instance_mode, True)
+        # 即使某配置在运行，多实例模式也允许切换
+        self.coord.runtime_manager._instances["c_b"] = _make_instance(
+            "c_b", running=True
+        )
+        self.assertTrue(self.coord.is_switch_config_allowed())
+        self.assertTrue(self.coord.is_config_running("c_b"))
+        self.assertFalse(self.coord.is_config_running("c_a"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- 新增多实例模式配置项，允许同时运行多个配置并在运行时切换
- 引入 RuntimeInstanceManager 管理独立运行体，确保各配置的启动、停止和日志互不干扰
- 更新信号总线，支持带 config_id 的日志输出和状态变化通知
- 修改界面组件以适应多实例模式，确保用户体验一致性
- 添加单元测试验证多实例模式下的日志缓冲和运行管理逻辑