### PR TITLE
feat: 支持复用已有进程执行任务

### DIFF
--- a/app/core/service/schedule_service.py
+++ b/app/core/service/schedule_service.py
@@ -37,6 +37,7 @@ class ScheduleEntry:
     force_start: bool
     enabled: bool
     created_at: datetime
+    reuse_existing: bool = False
     run_elevated: bool = False
     last_run: Optional[datetime] = None
     next_run: Optional[datetime] = None
@@ -49,6 +50,7 @@ class ScheduleEntry:
             "schedule_type": self.schedule_type,
             "params": self.params,
             "force_start": self.force_start,
+            "reuse_existing": self.reuse_existing,
             "run_elevated": self.run_elevated,
             "enabled": self.enabled,
             "created_at": self.created_at.isoformat(),
@@ -65,6 +67,7 @@ class ScheduleEntry:
             schedule_type=payload.get("schedule_type", SCHEDULE_SINGLE),
             params=payload.get("params", {}),
             force_start=bool(payload.get("force_start", False)),
+            reuse_existing=bool(payload.get("reuse_existing", False)),
             run_elevated=bool(payload.get("run_elevated", False)),
             enabled=bool(payload.get("enabled", True)),
             created_at=_parse_iso(payload.get("created_at")) or datetime.now(),

--- a/app/core/service/system_scheduler/crontab.py
+++ b/app/core/service/system_scheduler/crontab.py
@@ -118,11 +118,13 @@ class CrontabSchedulerBackend(SystemSchedulerBackend):
 
         config_id = ""
         force_start = False
+        reuse_existing = False
         if "--config-id=" in cmd:
             match = re.search(r"--config-id=(\S+)", cmd)
             if match:
                 config_id = match.group(1)
         force_start = "--force-restart" in cmd
+        reuse_existing = "--reuse-existing" in cmd
 
         hour = int(hour_f)
         minute = int(minute_f)
@@ -192,6 +194,7 @@ class CrontabSchedulerBackend(SystemSchedulerBackend):
             schedule_type=schedule_type,
             params=params,
             force_start=force_start,
+            reuse_existing=reuse_existing,
             run_elevated=run_elevated,
             enabled=True,
             created_at=datetime.now(),

--- a/app/core/service/system_scheduler/unix_common.py
+++ b/app/core/service/system_scheduler/unix_common.py
@@ -35,10 +35,16 @@ def current_schedule_instance_id() -> str:
     return resolve_schedule_instance_id()
 
 
-def build_shell_job(config_id: str, *, force_start: bool, run_elevated: bool = False) -> str:
+def build_shell_job(
+    config_id: str,
+    *,
+    force_start: bool,
+    reuse_existing: bool = False,
+    run_elevated: bool = False,
+) -> str:
     """构建可在 shell/cron 中执行的 MFW 启动命令。"""
     executable, arguments = resolve_schedule_launch_command(
-        config_id, force_start=force_start
+        config_id, force_start=force_start, reuse_existing=reuse_existing
     )
     job = f"{shlex.quote(executable)} {arguments}"
     if run_elevated:
@@ -214,6 +220,11 @@ def list_managed_entry_ids(content: str) -> set[str]:
 def build_managed_lines(entry: "ScheduleEntry") -> list[str]:
     from app.core.service.system_scheduler.cron_expr import build_cron_schedule_lines
 
-    job = build_shell_job(entry.config_id, force_start=entry.force_start, run_elevated=entry.run_elevated)
+    job = build_shell_job(
+        entry.config_id,
+        force_start=entry.force_start,
+        reuse_existing=entry.reuse_existing,
+        run_elevated=entry.run_elevated,
+    )
     schedule_lines = build_cron_schedule_lines(entry)
     return [f"{schedule} {job}" for schedule in schedule_lines]

--- a/app/core/service/system_scheduler/windows.py
+++ b/app/core/service/system_scheduler/windows.py
@@ -100,7 +100,9 @@ def _append_text(parent: ET.Element, tag: str, text: str) -> None:
 def build_task_xml(entry: "ScheduleEntry") -> str:
     """生成 Windows 任务计划程序 XML（与 schtasks 导出的 1.2 格式对齐）。"""
     command, arguments = resolve_schedule_launch_command(
-        entry.config_id, force_start=entry.force_start
+        entry.config_id,
+        force_start=entry.force_start,
+        reuse_existing=entry.reuse_existing,
     )
 
     root = ET.Element(f"{{{_TASK_NS}}}Task")
@@ -380,11 +382,13 @@ class WindowsTaskSchedulerBackend(SystemSchedulerBackend):
         args_str = text(root.find(f".//{tag('Arguments')}"))
         config_id = ""
         force_start = False
+        reuse_existing = False
         if args_str:
             match = re.search(r"--config-id=(\S+)", args_str)
             if match:
                 config_id = match.group(1)
             force_start = "--force-restart" in args_str
+            reuse_existing = "--reuse-existing" in args_str
 
         run_elevated = False
         run_level = text(root.find(f".//{tag('RunLevel')}"))
@@ -480,6 +484,7 @@ class WindowsTaskSchedulerBackend(SystemSchedulerBackend):
             schedule_type=schedule_type,
             params=params,
             force_start=force_start,
+            reuse_existing=reuse_existing,
             run_elevated=run_elevated,
             enabled=True,
             created_at=created_at,

--- a/app/i18n/i18n.ja_JP.ts
+++ b/app/i18n/i18n.ja_JP.ts
@@ -3565,6 +3565,11 @@ interface.nameフィールドがmulti_config.jsonのバンドルキーと一致�
             <translation>強制開始</translation>
         </message>
         <message>
+            <location filename="../view/schedule_interface/schedule_interface.py" line="228" />
+            <source>Reuse existing process</source>
+            <translation>既存のプロセスを再利用</translation>
+        </message>
+        <message>
             <location filename="../view/schedule_interface/schedule_interface.py" line="234" />
             <location filename="../view/schedule_interface/schedule_interface.py" line="476" />
             <source>Enabled</source>
@@ -3741,6 +3746,11 @@ interface.nameフィールドがmulti_config.jsonのバンドルキーと一致�
             <location filename="../view/schedule_interface/schedule_interface.py" line="474" />
             <source>Force</source>
             <translation>強制実行</translation>
+        </message>
+        <message>
+            <location filename="../view/schedule_interface/schedule_interface.py" line="476" />
+            <source>Reuse</source>
+            <translation>再利用</translation>
         </message>
         <message>
             <location filename="../view/schedule_interface/schedule_interface.py" line="475" />

--- a/app/i18n/i18n.zh_CN.ts
+++ b/app/i18n/i18n.zh_CN.ts
@@ -3806,6 +3806,11 @@ interface.name 字段可能与 multi_config.json 中的包键不匹配。请检�
             <translation>强制启动</translation>
         </message>
         <message>
+            <location filename="../view/schedule_interface/schedule_interface.py" line="228" />
+            <source>Reuse existing process</source>
+            <translation>复用已有进程</translation>
+        </message>
+        <message>
             <location filename="../view/schedule_interface/schedule_interface.py" line="234" />
             <location filename="../view/schedule_interface/schedule_interface.py" line="476" />
             <source>Enabled</source>
@@ -3982,6 +3987,11 @@ interface.name 字段可能与 multi_config.json 中的包键不匹配。请检�
             <location filename="../view/schedule_interface/schedule_interface.py" line="474" />
             <source>Force</source>
             <translation>强制</translation>
+        </message>
+        <message>
+            <location filename="../view/schedule_interface/schedule_interface.py" line="476" />
+            <source>Reuse</source>
+            <translation>复用</translation>
         </message>
         <message>
             <location filename="../view/schedule_interface/schedule_interface.py" line="475" />

--- a/app/i18n/i18n.zh_TW.ts
+++ b/app/i18n/i18n.zh_TW.ts
@@ -3565,6 +3565,11 @@ interface.name 欄位可能與 multi_config.json 中的套件金鑰不符。請�
             <translation>強制開始</translation>
         </message>
         <message>
+            <location filename="../view/schedule_interface/schedule_interface.py" line="228" />
+            <source>Reuse existing process</source>
+            <translation>重用現有程序</translation>
+        </message>
+        <message>
             <location filename="../view/schedule_interface/schedule_interface.py" line="234" />
             <location filename="../view/schedule_interface/schedule_interface.py" line="476" />
             <source>Enabled</source>
@@ -3741,6 +3746,11 @@ interface.name 欄位可能與 multi_config.json 中的套件金鑰不符。請�
             <location filename="../view/schedule_interface/schedule_interface.py" line="474" />
             <source>Force</source>
             <translation>強制執行</translation>
+        </message>
+        <message>
+            <location filename="../view/schedule_interface/schedule_interface.py" line="476" />
+            <source>Reuse</source>
+            <translation>重用</translation>
         </message>
         <message>
             <location filename="../view/schedule_interface/schedule_interface.py" line="475" />

--- a/app/utils/install_paths.py
+++ b/app/utils/install_paths.py
@@ -37,13 +37,22 @@ def resolve_schedule_task_folder() -> str:
     return f"MFW-ChainFlow Assistant-{resolve_schedule_instance_id()}"
 
 
-def resolve_schedule_launch_command(config_id: str, *, force_start: bool) -> tuple[str, str]:
+def resolve_schedule_launch_command(
+    config_id: str, *, force_start: bool, reuse_existing: bool = False
+) -> tuple[str, str]:
     """构建计划任务启动命令，返回 (executable, arguments)。"""
-    from mfw_cli import FLAG_CONFIG_ID, FLAG_DIRECT_RUN, FLAG_FORCE_RESTART
+    from mfw_cli import (
+        FLAG_CONFIG_ID,
+        FLAG_DIRECT_RUN,
+        FLAG_FORCE_RESTART,
+        FLAG_REUSE_EXISTING,
+    )
 
     cli_args: list[str] = [f"{FLAG_CONFIG_ID}={config_id}", FLAG_DIRECT_RUN]
     if force_start:
         cli_args.append(FLAG_FORCE_RESTART)
+    if reuse_existing:
+        cli_args.append(FLAG_REUSE_EXISTING)
 
     anchor = resolve_install_anchor()
     if getattr(sys, "frozen", False) or anchor.suffix.lower() in {".exe", ".bin"}:

--- a/app/utils/single_instance.py
+++ b/app/utils/single_instance.py
@@ -5,6 +5,8 @@ import tempfile
 import time
 from pathlib import Path
 
+from app.utils.logger import logger
+
 CMD_ACTIVATE = b"activate"
 CMD_SHUTDOWN = b"shutdown"
 CMD_RUN_CONFIG = b"run-config:"
@@ -149,6 +151,7 @@ class _ActivationServer:
             socket = self._server.nextPendingConnection()
             if socket is None:
                 continue
+            socket.setParent(self._server)
 
             if socket.bytesAvailable() > 0:
                 self._consume_activation_request(socket)
@@ -181,10 +184,16 @@ class _ActivationServer:
                 request = json.loads(command[len(CMD_RUN_CONFIG) :].decode("utf-8"))
                 config_id = str(request.get("config_id") or "").strip()
                 force_start = bool(request.get("force_start", False))
+                logger.debug(
+                    "单实例 IPC 收到复用执行请求: config_id=%s force_start=%s",
+                    config_id,
+                    force_start,
+                )
                 if config_id and self._on_run_config is not None:
                     result = self._on_run_config(config_id, force_start)
                     response = result if isinstance(result, bytes) else RESP_FAIL
-            except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+            except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                logger.debug("单实例 IPC 拒绝无效的复用执行请求: %s", exc)
                 response = RESP_INVALID
         else:
             activated = False
@@ -198,13 +207,9 @@ class _ActivationServer:
         try:
             socket.write(response)
             socket.flush()
-            socket.waitForBytesWritten(800)
+            logger.debug("单实例 IPC 已回复: %s", response)
         except Exception:
-            pass
-
-        try:
-            socket.disconnectFromServer()
-        except Exception:
+            logger.debug("单实例 IPC 写入回复失败")
             pass
 
 
@@ -324,31 +329,54 @@ def request_existing_instance_run(
     *,
     force_start: bool,
     connect_ms: int = 800,
-    response_ms: int = 1500,
+    response_ms: int = 5000,
 ) -> bytes:
     """请求已有实例执行配置，返回 IPC 状态码。"""
     try:
         from PySide6.QtNetwork import QLocalSocket
-    except Exception:
+    except Exception as exc:
+        logger.debug("单实例 IPC 无法导入 QLocalSocket: %s", exc)
         return RESP_FAIL
 
     socket = QLocalSocket()
     socket.connectToServer(server_name)
     if not socket.waitForConnected(connect_ms):
+        logger.debug(
+            "单实例 IPC 连接失败: server=%s error=%s state=%s",
+            server_name,
+            socket.errorString(),
+            socket.state(),
+        )
         return RESP_FAIL
 
     try:
         request = json.dumps(
             {"config_id": config_id, "force_start": force_start}, separators=(",", ":")
         ).encode("utf-8")
-        socket.write(CMD_RUN_CONFIG + request)
+        payload = CMD_RUN_CONFIG + request
+        written = socket.write(payload)
+        if written != len(payload):
+            logger.debug(
+                "单实例 IPC 请求写入失败: expected=%s written=%s error=%s state=%s",
+                len(payload),
+                written,
+                socket.errorString(),
+                socket.state(),
+            )
+            return RESP_FAIL
         socket.flush()
-        if not socket.waitForBytesWritten(800):
-            return RESP_FAIL
         if not socket.waitForReadyRead(response_ms):
+            logger.debug(
+                "单实例 IPC 等待回复失败: error=%s state=%s",
+                socket.errorString(),
+                socket.state(),
+            )
             return RESP_FAIL
-        return bytes(socket.readAll()).strip().lower()
-    except Exception:
+        response = bytes(socket.readAll()).strip().lower()
+        logger.debug("单实例 IPC 收到回复: %s", response)
+        return response
+    except Exception as exc:
+        logger.debug("单实例 IPC 客户端异常: %s", exc)
         return RESP_FAIL
     finally:
         try:

--- a/app/utils/single_instance.py
+++ b/app/utils/single_instance.py
@@ -207,6 +207,7 @@ class _ActivationServer:
         try:
             socket.write(response)
             socket.flush()
+            socket.waitForBytesWritten(800)
             logger.debug("单实例 IPC 已回复: %s", response)
         except Exception:
             logger.debug("单实例 IPC 写入回复失败")
@@ -354,17 +355,14 @@ def request_existing_instance_run(
             {"config_id": config_id, "force_start": force_start}, separators=(",", ":")
         ).encode("utf-8")
         payload = CMD_RUN_CONFIG + request
-        written = socket.write(payload)
-        if written != len(payload):
-            logger.debug(
-                "单实例 IPC 请求写入失败: expected=%s written=%s error=%s state=%s",
-                len(payload),
-                written,
-                socket.errorString(),
-                socket.state(),
-            )
-            return RESP_FAIL
-        socket.flush()
+        try:
+            socket.write(payload)
+            socket.flush()
+            socket.waitForBytesWritten(800)
+            logger.debug("复用单实例 IPC 已请求: %s", payload)
+        except Exception:
+            logger.debug("复用单实例 IPC 请求失败")
+            pass
         if not socket.waitForReadyRead(response_ms):
             logger.debug(
                 "单实例 IPC 等待回复失败: error=%s state=%s",

--- a/app/utils/single_instance.py
+++ b/app/utils/single_instance.py
@@ -1,14 +1,18 @@
 import os
 import hashlib
+import json
 import tempfile
 import time
 from pathlib import Path
 
 CMD_ACTIVATE = b"activate"
 CMD_SHUTDOWN = b"shutdown"
+CMD_RUN_CONFIG = b"run-config:"
 RESP_OK = b"ok"
 RESP_ACCEPTED = b"accepted"
 RESP_FAIL = b"fail"
+RESP_BUSY = b"busy"
+RESP_INVALID = b"invalid"
 FORCE_RESTART_WAIT_TIMEOUT = 10.0
 
 
@@ -87,6 +91,7 @@ class _ActivationServer:
         self._server = None
         self._on_activate = None
         self._on_shutdown = None
+        self._on_run_config = None
 
     @staticmethod
     def make_server_name(lock_key: str) -> str:
@@ -98,6 +103,9 @@ class _ActivationServer:
 
     def set_on_shutdown(self, callback) -> None:
         self._on_shutdown = callback
+
+    def set_on_run_config(self, callback) -> None:
+        self._on_run_config = callback
 
     def start(self, parent=None) -> bool:
         from PySide6.QtNetwork import QLocalServer
@@ -154,12 +162,12 @@ class _ActivationServer:
 
     def _consume_activation_request(self, socket) -> None:
         try:
-            payload = bytes(socket.readAll()).strip().lower()
+            payload = bytes(socket.readAll()).strip()
         except Exception:
             payload = b""
 
         command = payload or CMD_ACTIVATE
-        if command == CMD_SHUTDOWN:
+        if command.lower() == CMD_SHUTDOWN:
             accepted = False
             if self._on_shutdown is not None:
                 try:
@@ -167,6 +175,17 @@ class _ActivationServer:
                 except Exception:
                     accepted = False
             response = RESP_ACCEPTED if accepted else RESP_FAIL
+        elif command.startswith(CMD_RUN_CONFIG):
+            response = RESP_INVALID
+            try:
+                request = json.loads(command[len(CMD_RUN_CONFIG) :].decode("utf-8"))
+                config_id = str(request.get("config_id") or "").strip()
+                force_start = bool(request.get("force_start", False))
+                if config_id and self._on_run_config is not None:
+                    result = self._on_run_config(config_id, force_start)
+                    response = result if isinstance(result, bytes) else RESP_FAIL
+            except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+                response = RESP_INVALID
         else:
             activated = False
             if self._on_activate is not None:
@@ -292,6 +311,45 @@ def try_activate_existing_instance(
         return response == RESP_OK
     except Exception:
         return False
+    finally:
+        try:
+            socket.disconnectFromServer()
+        except Exception:
+            pass
+
+
+def request_existing_instance_run(
+    server_name: str,
+    config_id: str,
+    *,
+    force_start: bool,
+    connect_ms: int = 800,
+    response_ms: int = 1500,
+) -> bytes:
+    """请求已有实例执行配置，返回 IPC 状态码。"""
+    try:
+        from PySide6.QtNetwork import QLocalSocket
+    except Exception:
+        return RESP_FAIL
+
+    socket = QLocalSocket()
+    socket.connectToServer(server_name)
+    if not socket.waitForConnected(connect_ms):
+        return RESP_FAIL
+
+    try:
+        request = json.dumps(
+            {"config_id": config_id, "force_start": force_start}, separators=(",", ":")
+        ).encode("utf-8")
+        socket.write(CMD_RUN_CONFIG + request)
+        socket.flush()
+        if not socket.waitForBytesWritten(800):
+            return RESP_FAIL
+        if not socket.waitForReadyRead(response_ms):
+            return RESP_FAIL
+        return bytes(socket.readAll()).strip().lower()
+    except Exception:
+        return RESP_FAIL
     finally:
         try:
             socket.disconnectFromServer()
@@ -483,9 +541,17 @@ class SingleInstanceGuard:
     def set_shutdown_callback(self, callback) -> None:
         self._activation_server.set_on_shutdown(callback)
 
+    def set_run_config_callback(self, callback) -> None:
+        self._activation_server.set_on_run_config(callback)
+
     def request_instance_shutdown(self) -> bool:
         return request_instance_shutdown(self.server_name)
 
     def notify_existing_instance(self) -> bool:
         """请求已有实例前置窗口；仅当旧实例正常响应时返回 True。"""
         return try_activate_existing_instance(self.server_name)
+
+    def request_existing_instance_run(self, config_id: str, *, force_start: bool) -> bytes:
+        return request_existing_instance_run(
+            self.server_name, config_id, force_start=force_start
+        )

--- a/app/view/schedule_interface/schedule_interface.py
+++ b/app/view/schedule_interface/schedule_interface.py
@@ -225,6 +225,7 @@ class ScheduleInterface(QWidget):
         control_layout = QHBoxLayout()
         control_layout.setSpacing(24)
         self.force_checkbox = CheckBox(self.tr("Force start"))
+        self.reuse_existing_checkbox = CheckBox(self.tr("Reuse existing process"))
         self.elevated_checkbox = CheckBox(self.tr("Run as administrator"))
         if not is_admin():
             self.elevated_checkbox.setEnabled(False)
@@ -235,6 +236,7 @@ class ScheduleInterface(QWidget):
         self.enabled_checkbox = CheckBox(self.tr("Enabled"))
         self.enabled_checkbox.setChecked(True)
         control_layout.addWidget(self.force_checkbox)
+        control_layout.addWidget(self.reuse_existing_checkbox)
         control_layout.addWidget(self.elevated_checkbox)
         control_layout.addWidget(self.enabled_checkbox)
         control_layout.addStretch()
@@ -463,7 +465,7 @@ class ScheduleInterface(QWidget):
         layout.addWidget(title)
 
         self.schedule_table = TableWidget(self)
-        self.schedule_table.setColumnCount(8)
+        self.schedule_table.setColumnCount(9)
         self.schedule_table.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
         )
@@ -473,13 +475,14 @@ class ScheduleInterface(QWidget):
             self.tr("Pattern"),
             self.tr("Next run"),
             self.tr("Force"),
+            self.tr("Reuse"),
             self.tr("Admin"),
             self.tr("Enabled"),
             self.tr("Action"),
         ]
         for col, label in enumerate(header_labels):
             header_item = QTableWidgetItem(label)
-            if col in (4, 5, 6, 7):
+            if col in (4, 5, 6, 7, 8):
                 header_item.setTextAlignment(
                     Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                 )
@@ -490,15 +493,16 @@ class ScheduleInterface(QWidget):
         header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
         header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(5, QHeaderView.ResizeMode.Fixed)
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
         header.setSectionResizeMode(6, QHeaderView.ResizeMode.Fixed)
         header.setSectionResizeMode(7, QHeaderView.ResizeMode.Fixed)
+        header.setSectionResizeMode(8, QHeaderView.ResizeMode.Fixed)
         header.setStretchLastSection(False)
-        self.schedule_table.setColumnWidth(5, 48)
-        self.schedule_table.setColumnWidth(6, 56)
+        self.schedule_table.setColumnWidth(6, 48)
         self.schedule_table.setColumnWidth(7, 56)
+        self.schedule_table.setColumnWidth(8, 56)
         if not _HAS_ENABLED_STATE:
-            self.schedule_table.setColumnHidden(6, True)
+            self.schedule_table.setColumnHidden(7, True)
         self.schedule_table.verticalHeader().setDefaultSectionSize(40)
         self.schedule_table.verticalHeader().setVisible(False)
         self.schedule_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
@@ -611,9 +615,20 @@ class ScheduleInterface(QWidget):
         self.schedule_table.setItem(
             row,
             5,
+            _item(self.tr("Yes") if entry.reuse_existing else self.tr("No")),
+        )
+        reuse_item = self.schedule_table.item(row, 5)
+        if reuse_item is not None:
+            reuse_item.setTextAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+            )
+
+        self.schedule_table.setItem(
+            row,
+            6,
             _item(self.tr("Yes") if entry.run_elevated else self.tr("No")),
         )
-        elevated_item = self.schedule_table.item(row, 5)
+        elevated_item = self.schedule_table.item(row, 6)
         if elevated_item is not None:
             elevated_item.setTextAlignment(
                 Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
@@ -625,7 +640,7 @@ class ScheduleInterface(QWidget):
             partial(self._on_enabled_toggled, entry.entry_id)
         )
         self.schedule_table.setCellWidget(
-            row, 6, self._centered_cell_widget(enabled_check)
+            row, 7, self._centered_cell_widget(enabled_check)
         )
 
         remove_button = TransparentToolButton(FIF.DELETE, self)
@@ -633,7 +648,7 @@ class ScheduleInterface(QWidget):
         apply_fluent_tooltip(remove_button, self.tr("Delete schedule"))
         remove_button.clicked.connect(partial(self._on_remove_schedule, entry.entry_id))
         self.schedule_table.setCellWidget(
-            row, 7, self._centered_cell_widget(remove_button)
+            row, 8, self._centered_cell_widget(remove_button)
         )
 
     def _centered_cell_widget(self, child: QWidget) -> QWidget:
@@ -724,6 +739,7 @@ class ScheduleInterface(QWidget):
             schedule_type=schedule_type,
             params=params,
             force_start=self.force_checkbox.isChecked(),
+            reuse_existing=self.reuse_existing_checkbox.isChecked(),
             run_elevated=self.elevated_checkbox.isChecked(),
             enabled=self.enabled_checkbox.isChecked(),
             created_at=datetime.now(),

--- a/main.py
+++ b/main.py
@@ -425,8 +425,6 @@ def _run() -> int:
         if reuse_request_in_progress["value"]:
             return RESP_BUSY
         if window is None:
-            pending_reuse_request["request"] = (config_id, force_start)
-            reuse_request_in_progress["value"] = True
             return RESP_BUSY
         if not window.service_coordinator.config.get_config(config_id):
             return RESP_INVALID

--- a/main.py
+++ b/main.py
@@ -170,7 +170,11 @@ def _run() -> int:
     if not single_instance.acquire():
         if options.reuse_existing:
             from app.utils.single_instance import RESP_ACCEPTED, RESP_BUSY
+            from PySide6.QtCore import QCoreApplication
 
+            _ = QCoreApplication.instance()
+            if ipc_app is None:
+                _ = QCoreApplication([sys.argv[0]])
             response = single_instance.request_existing_instance_run(
                 options.config_id or "", force_start=options.force_restart
             )

--- a/main.py
+++ b/main.py
@@ -169,23 +169,27 @@ def _run() -> int:
     single_instance = SingleInstanceGuard(instance_key)
     if not single_instance.acquire():
         if options.reuse_existing:
-            from app.utils.single_instance import RESP_ACCEPTED, RESP_BUSY
-            from PySide6.QtCore import QCoreApplication
+            try:
+                from app.utils.single_instance import RESP_ACCEPTED, RESP_BUSY
+                from PySide6.QtCore import QCoreApplication
 
-            _ = QCoreApplication.instance()
-            if ipc_app is None:
-                _ = QCoreApplication([sys.argv[0]])
-            response = single_instance.request_existing_instance_run(
-                options.config_id or "", force_start=options.force_restart
-            )
-            if response == RESP_ACCEPTED:
-                logger.info("已有实例已接收复用执行请求")
-                return 0
-            if response == RESP_BUSY:
-                logger.info("已有实例正在执行任务，已跳过复用执行请求")
-                return 0
-            logger.warning("向已有实例发送复用执行请求失败: %s", response)
-            return 1
+                ipc_app = QCoreApplication.instance()
+                if ipc_app is None:
+                    _ = QCoreApplication([sys.argv[0]])
+                response = single_instance.request_existing_instance_run(
+                    options.config_id or "", force_start=options.force_restart
+                )
+                if response == RESP_ACCEPTED:
+                    logger.info("已有实例已接收复用执行请求")
+                    return 0
+                if response == RESP_BUSY:
+                    logger.info("已有实例正在执行任务，跳过复用执行请求")
+                    return 2
+                logger.warning("向已有实例发送复用执行请求失败: %s", response)
+                return 1
+            except Exception:
+                logger.exception("未知错误")
+                return 3
 
         from app.utils.startup_dialog import run_duplicate_instance_flow
 
@@ -423,7 +427,7 @@ def _run() -> int:
         if window is None:
             pending_reuse_request["request"] = (config_id, force_start)
             reuse_request_in_progress["value"] = True
-            return RESP_ACCEPTED
+            return RESP_BUSY
         if not window.service_coordinator.config.get_config(config_id):
             return RESP_INVALID
         if _is_task_running(window) and not force_start:

--- a/main.py
+++ b/main.py
@@ -154,7 +154,11 @@ def _run() -> int:
             apply_theme_from_config()
         return app
 
-    if options.force_restart and is_instance_running(instance_key):
+    if (
+        options.force_restart
+        and not options.reuse_existing
+        and is_instance_running(instance_key)
+    ):
         from app.utils.startup_dialog import run_force_restart_shutdown_flow
 
         _ensure_early_startup_app(qt_argv)
@@ -164,6 +168,21 @@ def _run() -> int:
 
     single_instance = SingleInstanceGuard(instance_key)
     if not single_instance.acquire():
+        if options.reuse_existing:
+            from app.utils.single_instance import RESP_ACCEPTED, RESP_BUSY
+
+            response = single_instance.request_existing_instance_run(
+                options.config_id or "", force_start=options.force_restart
+            )
+            if response == RESP_ACCEPTED:
+                logger.info("已有实例已接收复用执行请求")
+                return 0
+            if response == RESP_BUSY:
+                logger.info("已有实例正在执行任务，已跳过复用执行请求")
+                return 0
+            logger.warning("向已有实例发送复用执行请求失败: %s", response)
+            return 1
+
         from app.utils.startup_dialog import run_duplicate_instance_flow
 
         _ensure_early_startup_app(qt_argv)
@@ -225,6 +244,8 @@ def _run() -> int:
     window_holder: dict[str, MainWindow | None] = {"window": None}
     pending_force_shutdown = {"requested": False}
     pending_activation = {"requested": False}
+    pending_reuse_request: dict[str, tuple[str, bool] | None] = {"request": None}
+    reuse_request_in_progress = {"value": False}
 
     def _activate_existing_window() -> bool:
         window = window_holder["window"]
@@ -365,6 +386,51 @@ def _run() -> int:
 
     single_instance.set_shutdown_callback(_handle_force_shutdown_request)
 
+    def _is_task_running(window: MainWindow) -> bool:
+        task_runner = window.service_coordinator.task_runner
+        return task_runner.is_running or task_runner.maafw.has_active_runtime()
+
+    def _schedule_reused_run(window: MainWindow, config_id: str, force_start: bool) -> None:
+        async def _run() -> None:
+            try:
+                if _is_task_running(window):
+                    if not force_start:
+                        logger.info("已有任务正在执行，跳过复用执行请求")
+                        return
+                    await window.service_coordinator.stop_task(manual=True)
+
+                if not window.service_coordinator.select_config(config_id):
+                    logger.warning("复用执行请求指定的配置不存在: %s", config_id)
+                    return
+                await window.service_coordinator.run_tasks_flow()
+            except Exception:
+                logger.exception("复用已有实例执行任务失败")
+            finally:
+                reuse_request_in_progress["value"] = False
+
+        asyncio.ensure_future(_run(), loop=loop)
+
+    def _handle_reuse_run_request(config_id: str, force_start: bool) -> bytes:
+        from app.utils.single_instance import RESP_ACCEPTED, RESP_BUSY, RESP_INVALID
+
+        window = window_holder["window"]
+        if reuse_request_in_progress["value"]:
+            return RESP_BUSY
+        if window is None:
+            pending_reuse_request["request"] = (config_id, force_start)
+            reuse_request_in_progress["value"] = True
+            return RESP_ACCEPTED
+        if not window.service_coordinator.config.get_config(config_id):
+            return RESP_INVALID
+        if _is_task_running(window) and not force_start:
+            return RESP_BUSY
+
+        reuse_request_in_progress["value"] = True
+        _schedule_reused_run(window, config_id, force_start)
+        return RESP_ACCEPTED
+
+    single_instance.set_run_config_callback(_handle_reuse_run_request)
+
     # 初始化 GPU 信息缓存
     try:
         from app.utils.gpu_cache import gpu_cache
@@ -383,6 +449,10 @@ def _run() -> int:
     window_holder["window"] = w
     if pending_force_shutdown["requested"]:
         _schedule_graceful_shutdown(w)
+    elif pending_reuse_request["request"] is not None:
+        config_id, force_start = pending_reuse_request["request"]
+        pending_reuse_request["request"] = None
+        _schedule_reused_run(w, config_id, force_start)
     elif pending_activation["requested"]:
         from PySide6.QtCore import QTimer
 

--- a/mfw_cli.py
+++ b/mfw_cli.py
@@ -11,12 +11,14 @@ FLAG_CONFIG_ID = "--config-id"
 FLAG_DIRECT_RUN = "--direct-run"
 FLAG_DEV = "--dev"
 FLAG_FORCE_RESTART = "--force-restart"
+FLAG_REUSE_EXISTING = "--reuse-existing"
 
 MFW_FLAGS = (
     FLAG_CONFIG_ID,
     FLAG_DIRECT_RUN,
     FLAG_DEV,
     FLAG_FORCE_RESTART,
+    FLAG_REUSE_EXISTING,
 )
 
 # 已弃用的旧写法 → 现行开关
@@ -39,6 +41,7 @@ class StartupOptions:
     direct_run: bool = False
     enable_dev: bool = False
     force_restart: bool = False
+    reuse_existing: bool = False
 
 
 def _token_option_name(token: str) -> str:
@@ -113,6 +116,8 @@ def build_startup_argv(options: StartupOptions) -> list[str]:
         argv.append(FLAG_DEV)
     if options.force_restart:
         argv.append(FLAG_FORCE_RESTART)
+    if options.reuse_existing:
+        argv.append(FLAG_REUSE_EXISTING)
     return argv
 
 
@@ -133,6 +138,7 @@ def _build_parser() -> argparse.ArgumentParser:
             f"  {FLAG_DIRECT_RUN}      启动后直接运行任务流\n"
             f"  {FLAG_DEV}             显示测试页面\n"
             f"  {FLAG_FORCE_RESTART}   请求同目录下已有实例退出后启动本进程\n"
+            f"  {FLAG_REUSE_EXISTING}  复用已有实例执行指定配置\n"
             "\n"
             "示例:\n"
             f"  %(prog)s {FLAG_CONFIG_ID} default {FLAG_DIRECT_RUN}\n"
@@ -164,6 +170,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="请求同安装目录下正在运行的 MFW 停止任务并退出后启动本进程",
     )
+    parser.add_argument(
+        FLAG_REUSE_EXISTING,
+        action="store_true",
+        help="已有实例时复用它执行指定配置",
+    )
     return parser
 
 
@@ -183,5 +194,6 @@ def parse_startup_cli(
         direct_run=bool(ns.direct_run),
         enable_dev=bool(ns.enable_dev),
         force_restart=bool(ns.force_restart),
+        reuse_existing=bool(ns.reuse_existing),
     )
     return options, qt_extra, deprecated

--- a/tests/test_reuse_existing.py
+++ b/tests/test_reuse_existing.py
@@ -1,0 +1,55 @@
+import unittest
+from datetime import datetime
+
+from app.core.service.schedule_service import ScheduleEntry
+from mfw_cli import (
+    FLAG_REUSE_EXISTING,
+    StartupOptions,
+    build_startup_argv,
+    parse_startup_cli,
+)
+
+
+class ReuseExistingTests(unittest.TestCase):
+    def test_cli_parses_reuse_existing(self) -> None:
+        options, _, _ = parse_startup_cli(
+            ["--config-id=cfg_demo", "--direct-run", FLAG_REUSE_EXISTING]
+        )
+        self.assertTrue(options.reuse_existing)
+        self.assertEqual(options.config_id, "cfg_demo")
+
+    def test_cli_serializes_reuse_existing(self) -> None:
+        argv = build_startup_argv(
+            StartupOptions(config_id="cfg_demo", reuse_existing=True)
+        )
+        self.assertIn(FLAG_REUSE_EXISTING, argv)
+
+    def test_schedule_entry_defaults_reuse_existing_to_false(self) -> None:
+        entry = ScheduleEntry.from_dict(
+            {
+                "entry_id": "sched_demo",
+                "config_id": "cfg_demo",
+                "force_start": False,
+                "enabled": True,
+                "created_at": datetime.now().isoformat(),
+            }
+        )
+        self.assertFalse(entry.reuse_existing)
+
+    def test_schedule_entry_serializes_reuse_existing(self) -> None:
+        entry = ScheduleEntry(
+            entry_id="sched_demo",
+            config_id="cfg_demo",
+            name="Demo",
+            schedule_type="daily",
+            params={},
+            force_start=False,
+            enabled=True,
+            created_at=datetime.now(),
+            reuse_existing=True,
+        )
+        self.assertTrue(entry.to_dict()["reuse_existing"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_single_instance_restart.py
+++ b/tests/test_single_instance_restart.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from app.utils.single_instance import (
     CMD_ACTIVATE,
+    CMD_RUN_CONFIG,
     CMD_SHUTDOWN,
     RESP_OK,
     process_matches_install_anchor,
@@ -28,6 +29,7 @@ class ProcessMatchesInstallAnchorTests(unittest.TestCase):
     def test_shutdown_command_constants(self) -> None:
         self.assertEqual(CMD_ACTIVATE, b"activate")
         self.assertEqual(CMD_SHUTDOWN, b"shutdown")
+        self.assertEqual(CMD_RUN_CONFIG, b"run-config:")
         self.assertEqual(RESP_OK, b"ok")
 
     @patch("app.utils.single_instance.is_running_with_admin_privileges", return_value=False)

--- a/tests/test_unix_system_scheduler.py
+++ b/tests/test_unix_system_scheduler.py
@@ -144,6 +144,12 @@ class CrontabBlockTests(unittest.TestCase):
         self.assertTrue(job.startswith("sudo "), f"expected sudo prefix, got: {job}")
         self.assertIn("--config-id=cfg_demo", job)
 
+    def test_build_shell_job_includes_reuse_existing(self) -> None:
+        job = build_shell_job(
+            "cfg_demo", force_start=False, reuse_existing=True
+        )
+        self.assertIn("--reuse-existing", job)
+
     def test_split_preserves_other_instance_blocks(self) -> None:
         original = "\n".join(
             [

--- a/tests/test_windows_system_scheduler.py
+++ b/tests/test_windows_system_scheduler.py
@@ -23,6 +23,7 @@ class BuildTaskXmlTests(unittest.TestCase):
         schedule_type: str,
         params: dict,
         force_start: bool = False,
+        reuse_existing: bool = False,
         run_elevated: bool = False,
         enabled: bool = True,
     ) -> ScheduleEntry:
@@ -33,6 +34,7 @@ class BuildTaskXmlTests(unittest.TestCase):
             schedule_type=schedule_type,
             params=params,
             force_start=force_start,
+            reuse_existing=reuse_existing,
             run_elevated=run_elevated,
             enabled=enabled,
             created_at=datetime(2025, 6, 17, 8, 0, 0),
@@ -65,7 +67,28 @@ class BuildTaskXmlTests(unittest.TestCase):
                 force_start=True,
             )
         )
-        mock_command.assert_called_once_with("cfg_demo", force_start=True)
+        mock_command.assert_called_once_with(
+            "cfg_demo", force_start=True, reuse_existing=False
+        )
+
+    @patch(
+        "app.core.service.system_scheduler.windows.resolve_schedule_launch_command",
+        return_value=(
+            r"C:\MFW\MFW.exe",
+            "--config-id=cfg_demo --direct-run --reuse-existing",
+        ),
+    )
+    def test_reuse_existing_uses_cli_arguments(self, mock_command: object) -> None:
+        build_task_xml(
+            self._entry(
+                schedule_type=SCHEDULE_SINGLE,
+                params={"run_at": "2025-06-18T09:30:00"},
+                reuse_existing=True,
+            )
+        )
+        mock_command.assert_called_once_with(
+            "cfg_demo", force_start=False, reuse_existing=True
+        )
 
     @patch(
         "app.core.service.system_scheduler.windows.resolve_schedule_launch_command",


### PR DESCRIPTION
fix #233 

已在 MAA_bbb 项目中本地测试复用有效。

## Summary by Sourcery

Add support for reusing an already-running MFW instance to execute a specified configuration, including CLI, IPC, scheduler, and UI integration.

New Features:
- Introduce an IPC command and callback mechanism that allows an existing instance to run a specified config on request, with busy/invalid responses.
- Add CLI and startup options for requesting reuse of an existing process instead of forcing restart when a config is run.
- Extend scheduling logic on Windows and Unix so scheduled tasks can opt to reuse an existing process via a new reuse_existing flag.
- Expose a new "Reuse existing process" option in the schedule configuration UI and list view with localization support.

Enhancements:
- Refine single-instance IPC logging and socket handling to better trace command requests and responses.

Tests:
- Add unit tests covering CLI parsing/serialization of the reuse-existing flag, ScheduleEntry reuse_existing defaults/serialization, and scheduler command generation on Windows and Unix.
- Extend existing single-instance and Windows scheduler tests to validate new IPC command constants and reuse-existing CLI arguments.