### PR TITLE
fix: linux 下可执行判断错误导致创建无效计划任务

### DIFF
--- a/app/core/runner/maafw.py
+++ b/app/core/runner/maafw.py
@@ -51,6 +51,7 @@ except ImportError:  # pragma: no cover
 
 from PySide6.QtCore import QObject, Signal
 
+from app.utils.install_paths import is_packed
 from app.utils.logger import logger
 from app.utils.screencap_lock import screencap_guard
 from app.core.runner.recognition_roi import (
@@ -1265,8 +1266,7 @@ class MaaFW(QObject):
         start_cmd = [child_exec, *child_args, socket_id]
         logger.debug(f"启动agent命令: {start_cmd}")
 
-        is_packed = getattr(sys, "frozen", False)
-        encoding = "utf-8" if is_packed else "gbk"
+        encoding = "utf-8" if is_packed() else "gbk"
         env = os.environ.copy()
         if self.agent_env_vars:
             env.update(self.agent_env_vars)

--- a/app/utils/install_paths.py
+++ b/app/utils/install_paths.py
@@ -6,6 +6,11 @@ import hashlib
 import sys
 from pathlib import Path
 
+def is_packed() -> bool:
+    return (
+            getattr(sys, "frozen", False) or
+            globals().get("__compiled__") is not None
+    )
 
 def resolve_install_anchor() -> Path:
     """定位 MFW 安装锚点（发行根目录旁的 exe 或 main.py）。"""
@@ -46,7 +51,7 @@ def resolve_schedule_launch_command(config_id: str, *, force_start: bool) -> tup
         cli_args.append(FLAG_FORCE_RESTART)
 
     anchor = resolve_install_anchor()
-    if getattr(sys, "frozen", False) or anchor.suffix.lower() in {".exe", ".bin"}:
+    if is_packed() or anchor.suffix.lower() in {".exe", ".bin"}:
         return str(anchor), " ".join(cli_args)
 
     main_py = anchor if anchor.suffix.lower() == ".py" else anchor.parent / "main.py"


### PR DESCRIPTION
假设应用安装到 `/opt/app`，可执行为 `/opt/app/MFW`。

### 当前行为

`getattr(sys, "frozen", False)` 得到 `False` 且后缀不是 `.exe` 或 `.bin`，创建计划任务：

```
/opt/app/python "/opt/app/main.py" --config-id=...
```

### 预期行为

计划任务应为：

```
/opt/app/MFW --config-id=...
```

### 修复计划

将 nuitka 所注入的全局对象 `__compiled__` 也加入判断。